### PR TITLE
fix: prevent second pogod from displacing the running daemon (:10000 race)

### DIFF
--- a/cmd/pogod/main.go
+++ b/cmd/pogod/main.go
@@ -444,8 +444,12 @@ func main() {
 		fmt.Printf("Warning: could not augment PATH: %v\n", err)
 	}
 
-	// Acquire lockfile
-	lock, err := lockfile.New(filepath.Join(os.TempDir(), "pogo.pid"))
+	// Acquire lockfile. The path is derived from POGO_HOME (see
+	// config.LockfilePath), NOT os.TempDir(): $TMPDIR differs between the
+	// launchd domain and a shell/agent, so a TempDir-based lock did not
+	// prevent a second pogod from starting and racing the live daemon for
+	// :10000, hanging up the agent fleet via SIGHUP (#22).
+	lock, err := lockfile.New(config.LockfilePath())
 	if err != nil {
 		fmt.Printf("Cannot create lock. reason: %v", err)
 		os.Exit(1)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,10 +10,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -105,7 +104,46 @@ func GetFullHealth() (*health.FullResponse, error) {
 // failure surfaces promptly to the user instead of a silent false-success.
 const startupHealthTimeout = 5 * time.Second
 
+// daemonProbeTimeout bounds the TCP dial used to detect whether a pogod is
+// already bound to the daemon port. It is short because the probe targets
+// loopback: a live daemon answers the SYN immediately, and a free port refuses
+// immediately, so the only thing this timeout guards against is a dropped
+// packet on a wedged host.
+const daemonProbeTimeout = 500 * time.Millisecond
+
+// daemonBound reports whether something is already listening on the pogod TCP
+// port. It probes the actual bind (a raw TCP dial to 127.0.0.1:<port>) rather
+// than /health, answering the specific question "would a second pogod fail to
+// bind :10000?".
+func daemonBound() bool {
+	return portBound(config.Load().DialAddr())
+}
+
+// portBound reports whether a TCP listener currently holds addr.
+func portBound(addr string) bool {
+	conn, err := net.DialTimeout("tcp", addr, daemonProbeTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+// StartServer ensures a pogod is running, spawning one only when the daemon
+// port is actually free.
+//
+// If the port is already bound we must NOT spawn a rival pogod: a second pogod
+// either loses the bind and exits — closing the PTY masters of any agents it
+// had started — or, during a launchd restart window, wins the bind and
+// displaces the launchd-managed daemon. Either path hangs up the agent fleet
+// via SIGHUP (#22). When the port is held we treat the daemon as up and return
+// nil so the caller connects to it instead. The primary guard against a double
+// daemon is still the shared singleton lockfile (config.LockfilePath); this is
+// a cheaper, earlier check on the client side.
 func StartServer() error {
+	if daemonBound() {
+		return nil
+	}
 	cmd := exec.Command("pogod")
 	return startServerCmd(cmd, HealthCheck, startupHealthTimeout)
 }
@@ -237,7 +275,10 @@ func StopOrchestration() error {
 }
 
 func StopServer() error {
-	pidPath := filepath.Join(os.TempDir(), "pogo.pid")
+	// Must match cmd/pogod's lock path (config.LockfilePath) so we read the
+	// same lockfile the running daemon holds — a TempDir-based path would miss
+	// the launchd-domain lock and report "not running" (#22).
+	pidPath := config.LockfilePath()
 
 	lock, err := lockfile.New(pidPath)
 	if err != nil {
@@ -269,9 +310,11 @@ func StopServer() error {
 // Run closure with health check
 func RunWithHealthCheck[T ClientResp](run func() (T, error)) (T, error) {
 	if err := HealthCheck(); err != nil {
-		// StartServer now blocks until pogod is healthy or returns a
-		// descriptive error (including captured stderr) — no separate
-		// retry loop needed here.
+		// StartServer blocks until pogod is healthy or returns a descriptive
+		// error (including captured stderr) — no separate retry loop needed
+		// here. It also refuses to spawn a rival pogod when :10000 is already
+		// bound (connecting to the existing daemon instead), so a missed
+		// /health probe can't displace the running daemon (#22).
 		if err := StartServer(); err != nil {
 			return nil, err
 		}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2,11 +2,37 @@ package client
 
 import (
 	"errors"
+	"net"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
 )
+
+// TestPortBound verifies the TCP bind probe that keeps StartServer from
+// spawning a rival pogod when :10000 is already held (#22). An ephemeral
+// listener stands in for the running daemon so the test never touches the real
+// port.
+func TestPortBound(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to open ephemeral listener: %v", err)
+	}
+	addr := ln.Addr().String()
+
+	if !portBound(addr) {
+		t.Errorf("portBound(%q) = false while a listener holds it, want true", addr)
+	}
+
+	// After closing the listener the address is free; the probe must say so,
+	// otherwise StartServer would refuse to launch a legitimately-needed pogod.
+	if err := ln.Close(); err != nil {
+		t.Fatalf("failed to close listener: %v", err)
+	}
+	if portBound(addr) {
+		t.Errorf("portBound(%q) = true after listener closed, want false", addr)
+	}
+}
 
 // alwaysFailingHealth simulates a daemon that never becomes healthy.
 func alwaysFailingHealth() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -402,6 +402,41 @@ func ConfigFilePath() string {
 	return filepath.Join(dir, "config.toml")
 }
 
+// PogoHome returns the pogo state directory: $POGO_HOME, or ~/.pogo when
+// unset. It deliberately never falls back to os.TempDir(): $TMPDIR differs
+// between the launchd domain and an interactive shell/agent, so a
+// TempDir-based path is not shared across domains. The singleton daemon
+// lockfile (see LockfilePath) must resolve to the SAME path from launchd,
+// shells, and agents, otherwise a second pogod acquires its own lock and
+// displaces the running daemon (the :10000 race in #22). This mirrors the
+// existing POGO_HOME resolution in internal/service, internal/project, and
+// internal/driver.
+func PogoHome() string {
+	if h := os.Getenv("POGO_HOME"); h != "" {
+		return h
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".pogo")
+}
+
+// LockfilePath returns the deterministic path of the pogod singleton lockfile
+// (pogo.pid) under PogoHome. Because PogoHome is domain-independent, the lock
+// is shared across the launchd-managed pogod, shells, and agents, so a second
+// pogod's TryLock fails instead of racing the live daemon for :10000 (#22).
+func LockfilePath() string {
+	return filepath.Join(PogoHome(), "pogo.pid")
+}
+
+// DialAddr returns a loopback TCP address (127.0.0.1:<port>) for probing
+// whether a pogod is already bound to the daemon port. It targets 127.0.0.1
+// explicitly rather than the raw Bind so a wildcard bind (0.0.0.0/::) is still
+// probed on a concrete loopback address, and so the probe never races
+// IPv6-vs-IPv4 resolution of "localhost". Callers use this to avoid spawning a
+// rival pogod when the port is already held (#22).
+func (c *Config) DialAddr() string {
+	return fmt.Sprintf("127.0.0.1:%d", c.Port)
+}
+
 // loadConfigFile reads port from the TOML config file.
 // Only parses the minimal subset needed: [server] section with port key.
 func loadConfigFile() (*parsedConfig, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -750,5 +751,45 @@ func TestParseStringArray(t *testing.T) {
 				t.Errorf("parseStringArray(%q)[%d] = %q, want %q", c.input, i, got[i], c.want[i])
 			}
 		}
+	}
+}
+
+// TestPogoHomeFromEnv verifies POGO_HOME takes precedence, so the singleton
+// lockfile resolves to the same directory across the launchd domain, shells,
+// and agents (#22).
+func TestPogoHomeFromEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("POGO_HOME", home)
+	if got := PogoHome(); got != home {
+		t.Errorf("PogoHome() = %q, want %q", got, home)
+	}
+	if got, want := LockfilePath(), filepath.Join(home, "pogo.pid"); got != want {
+		t.Errorf("LockfilePath() = %q, want %q", got, want)
+	}
+}
+
+// TestPogoHomeDefaultNotTempDir verifies the fallback (POGO_HOME unset) is
+// ~/.pogo and, critically, never os.TempDir — a TempDir-based path differs
+// between the launchd domain and a shell/agent and would not share the lock.
+func TestPogoHomeDefaultNotTempDir(t *testing.T) {
+	t.Setenv("POGO_HOME", "")
+	got := PogoHome()
+	if home, err := os.UserHomeDir(); err == nil {
+		if want := filepath.Join(home, ".pogo"); got != want {
+			t.Errorf("PogoHome() = %q, want %q", got, want)
+		}
+	}
+	if strings.HasPrefix(got, os.TempDir()) {
+		t.Errorf("PogoHome() = %q must not be under TempDir %q", got, os.TempDir())
+	}
+	if strings.HasPrefix(LockfilePath(), os.TempDir()) {
+		t.Errorf("LockfilePath() = %q must not be under TempDir %q", LockfilePath(), os.TempDir())
+	}
+}
+
+func TestDialAddr(t *testing.T) {
+	cfg := &Config{Port: 10000}
+	if got := cfg.DialAddr(); got != "127.0.0.1:10000" {
+		t.Errorf("DialAddr() = %q, want 127.0.0.1:10000", got)
 	}
 }


### PR DESCRIPTION
<h4>Description</h4>

This addresses a self-contained <em>secondary</em> trigger of the SIGHUP cascade in #22: the two-pogod <code>:10000</code> race. A crew agent running any <code>pogo</code>/<code>lsp</code>/<code>pose</code> command routes through <code>client.RunWithHealthCheck</code>; on a missed <code>/health</code> probe it called <code>StartServer()</code> → <code>exec.Command("pogod")</code>, spawning a <strong>second</strong> pogod. The singleton lockfile lived at <code>$TMPDIR/pogo.pid</code>, and <code>$TMPDIR</code> differs between the launchd domain and a shell/agent, so the lock never blocked the rival. The rival races the launchd-managed pogod for <code>:10000</code>; the displaced daemon exits, its controlling-terminal PTY masters close, and every agent tethered to them gets SIGHUP. See #22 for the full root-cause writeup.

<h4>Changes</h4>

<strong>1. Deterministic, domain-shared lockfile path</strong>
<ul>
<li><code>internal/config/config.go</code> — new <code>PogoHome()</code> / <code>LockfilePath()</code>. The lock path is derived from <code>POGO_HOME</code> (fallback <code>~/.pogo</code>, <strong>never</strong> <code>os.TempDir()</code>), so it resolves to the same file across the launchd domain, shells, and agents. Mirrors the existing <code>POGO_HOME</code> resolution in <code>internal/service</code>, <code>internal/project</code>, and <code>internal/driver</code>.</li>
<li><code>cmd/pogod/main.go</code> (~:448) — acquires the lock via <code>config.LockfilePath()</code> instead of <code>filepath.Join(os.TempDir(), "pogo.pid")</code>, so a second pogod's <code>TryLock</code> now fails.</li>
<li><code>internal/client/client.go</code> — <code>StopServer()</code> reads the same <code>config.LockfilePath()</code>, so it still targets the lock the running daemon holds.</li>
</ul>

<strong>2. Refuse to spawn a rival when the port is already bound</strong>
<ul>
<li><code>internal/config/config.go</code> — new <code>(*Config).DialAddr()</code> returning <code>127.0.0.1:&lt;port&gt;</code> (concrete loopback, so a wildcard bind is still probed and there's no IPv4/IPv6 <code>localhost</code> race).</li>
<li><code>internal/client/client.go</code> — new <code>daemonBound()</code> / <code>portBound()</code> do a raw TCP dial of the daemon port. <code>StartServer()</code> now returns early (treating the daemon as up) when the port is held, rather than spawning a rival that would either lose the bind and exit — closing its agents' PTY masters — or win the bind and displace the launchd-managed daemon.</li>
</ul>

<h4>Out of scope</h4>

The <strong>primary</strong> fix — pogod tethering agents to a controlling-terminal PTY and dying un-gracefully on SIGTERM (no signal handler), so any pogod exit hangs up the fleet — is an architecture decision and is intentionally left to the repo owner. This PR only removes the secondary trigger that turns a routine health-probe miss into a fleet-wide SIGHUP.

<h4>Testing</h4>

<ul>
<li><code>go build ./...</code> — passes.</li>
<li><code>go vet ./internal/config/... ./internal/client/... ./cmd/pogod/...</code> — passes.</li>
<li><code>go test ./internal/config/... ./internal/client/...</code> — passes. New tests: <code>TestPogoHomeFromEnv</code>, <code>TestPogoHomeDefaultNotTempDir</code>, <code>TestDialAddr</code> (config); <code>TestPortBound</code> (client). All new tests use an ephemeral port (<code>127.0.0.1:0</code>) and a temp <code>POGO_HOME</code> — no fixed <code>:10000</code>, no real pogod spawned — so they are safe to run alongside a live daemon.</li>
</ul>

The full <code>go test ./...</code> was deliberately <em>not</em> run: some packages start a pogod or bind a fixed port and would collide with the live daemon on this host.

<h4>Deferred follow-up</h4>

The optional non-destructive restart gate (make <code>service.Restart()</code> / <code>launchctl kickstart -k</code> refuse when live agents are registered unless <code>--force</code>) was <strong>deferred</strong>. <code>service.Restart()</code> has a single caller (<code>cmd/pogo/main.go</code> in <code>pogo init</code>'s ensure-daemon path), and it only fires when <code>HealthCheck()</code> has already failed — i.e. the daemon is already down and there is no live fleet to protect. Gating it there would add a cross-package HTTP dependency (service → agent count) and flag plumbing through a command that isn't a restart command, for near-zero value. Recommended as a separate change that instead targets the paths which actually kickstart a live daemon (e.g. <code>service.Install()</code> and the recovery agent).

Part of #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)
