### PR TITLE
test(pi): integration coverage + pi-e2e CI job (mg-3e7c) [CI validation only]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,34 @@ jobs:
       - name: Test
         run: go test ./...
 
+  pi-e2e:
+    # Live pi-provider integration tests (mg-3e7c): drive a real pi binary
+    # through agent.Registry (TUI initial + mid-session nudges) and in
+    # headless --print --mode json form, against a localhost mock OpenAI
+    # server — no API key, no external model traffic. pi is pinned to the
+    # version the nudge dialect was calibrated against
+    # (docs/investigations/pi-nudge-calibration.md); bump it deliberately and
+    # re-check the calibration if pi's TUI changed.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install pi
+        run: npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.3
+
+      - name: Run pi provider integration tests
+        env:
+          POGO_PI_E2E: "1"
+        run: go test ./internal/pi/ -v -timeout 300s
+
   emacs-test:
     runs-on: ubuntu-latest
     steps:

--- a/docs/investigations/pi-nudge-calibration.md
+++ b/docs/investigations/pi-nudge-calibration.md
@@ -183,12 +183,23 @@ step, not a pogo concern.
 ## Reproducing
 
 ```
-POGO_PI_E2E=1 go test ./internal/pi/ -run TestPiEndToEnd -v
+POGO_PI_E2E=1 go test ./internal/pi/ -run 'TestPi' -v
 ```
 
 Needs only a `pi` binary on PATH — no API key, no network beyond localhost.
-It drives a real `pi` through pogo's `agent.Registry` + `pi.Provider` and
-asserts: the sentinel-gated initial nudge submits; the persona from
-`--append-system-prompt` reaches the request's system message and the task the
-user message (byte-level, via the mock provider); the reply renders; the
-composer settles; the registry shuts the agent down cleanly.
+`TestPiEndToEnd` drives a real `pi` through pogo's `agent.Registry` +
+`pi.Provider`, wired the way `cmd/pogod` wires it (per-type provider config,
+claude as global default), and asserts: the spawn resolves pi via the
+`[agents.polecat] provider = "pi"` config tier; the sentinel-gated initial
+nudge submits; the persona from `--append-system-prompt` reaches the
+request's system message and the task the user message (byte-level, via the
+mock provider); the repo's own AGENTS.md survives untouched and still reaches
+the request (the mg-9829 collision regression); the reply renders; the
+composer settles; a mid-session `Agent.Nudge` triggers a second turn; the
+registry shuts the agent down cleanly. `TestPiHeadless` runs the same
+provider flags in `--print --mode json` form (mg-3e7c).
+
+GitHub CI runs both in the `pi-e2e` job (`.github/workflows/ci.yml`) against
+a pinned `@earendil-works/pi-coding-agent@0.80.3` — the version calibrated
+here. The ungated `internal/pi/integration_test.go` covers the config →
+provider-registry resolution path in every plain `go test ./...`.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -181,6 +181,18 @@ func (a *Agent) alive() bool {
 // distinguish a live agent from one whose process has died.
 func (a *Agent) Alive() bool { return a.alive() }
 
+// ProviderID returns the id of the harness provider resolved for this agent
+// at spawn time ("claude", "codex", "pi"), or "" for a bare-registry spawn.
+// The field is immutable after construction, so no lock is needed. Exposed so
+// integration tests can assert which provider the resolution chain actually
+// picked (per-type config vs global default vs built-in fallback).
+func (a *Agent) ProviderID() string {
+	if a.provider == nil {
+		return ""
+	}
+	return a.provider.ID
+}
+
 // eventAgent returns the agent identity string used in event log envelopes.
 // Mirrors the identity convention from docs/event-log.md: crew-<name> or cat-<name>.
 func (a *Agent) eventAgent() string {

--- a/internal/pi/e2e_test.go
+++ b/internal/pi/e2e_test.go
@@ -1,13 +1,24 @@
 package pi_test
 
-// End-to-end verification for the pi provider (mg-9829). It drives a real `pi`
-// process through pogo's actual agent.Registry and the resolved pi.Provider —
-// the exact pipeline a `provider = "pi"` polecat takes:
+// End-to-end verification for the pi provider (mg-9829, extended by mg-3e7c).
+// TestPiEndToEnd drives a real `pi` process through pogo's actual
+// agent.Registry and the resolved pi.Provider — the exact pipeline a
+// `provider = "pi"` polecat takes:
 //
-//	providers.Resolve("pi")
+//	[agents.polecat] provider = "pi"   (config tier of resolveProvider)
 //	  -> ExpandCommand(provider.CommandTemplate, ...)
 //	  -> Registry.Spawn
 //	  -> initial nudge (the task, typed into the pi composer)
+//	  -> mid-session nudge (Agent.Nudge into the settled composer)
+//
+// The registry is wired exactly as cmd/pogod wires it (all providers
+// registered, per-type config, claude as the global default), so the spawn
+// resolving pi proves the `[agents.polecat] provider = "pi"` config tier —
+// not just a hardcoded default. The worktree carries its own AGENTS.md, so
+// the run also regression-tests the mg-9829 collision wrinkle: persona via
+// --append-system-prompt must not clobber (or shadow) the repo's context
+// file. TestPiHeadless covers the same provider flags in pi's non-interactive
+// `--print --mode json` mode, without the TUI or the registry.
 //
 // Unlike the Codex e2e test, this one needs NO API key and makes NO network
 // request: pi's models.json supports custom OpenAI-compatible providers, so
@@ -18,13 +29,18 @@ package pi_test
 // arrives intact as the user message. PI_CODING_AGENT_DIR isolates pi's
 // config/auth/session state from the developer's real ~/.pi.
 //
-// It is opt-in only because it needs a `pi` binary (Node >= 22.19) on PATH:
+// The tests are opt-in only because they need a `pi` binary (Node >= 22.19)
+// on PATH:
 //
-//	POGO_PI_E2E=1 go test ./internal/pi/ -run TestPiEndToEnd -v
+//	POGO_PI_E2E=1 go test ./internal/pi/ -run 'TestPi' -v
 //
-// See docs/investigations/pi-nudge-calibration.md.
+// GitHub CI runs them in the pi-e2e job (.github/workflows/ci.yml), which
+// installs the pinned calibration version of pi. See
+// docs/investigations/pi-nudge-calibration.md.
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -87,6 +103,20 @@ func (m *mockOpenAI) last() []byte {
 	return m.reqs[len(m.reqs)-1]
 }
 
+// polecatPiConfig mirrors a config.toml with `[agents] provider = "claude"`
+// and `[agents.polecat] provider = "pi"` — the mixed-fleet shape the per-type
+// provider tier exists for (it satisfies agent.AgentCommandConfig the same
+// way config.AgentsConfig does).
+type polecatPiConfig struct{}
+
+func (polecatPiConfig) AgentCommand(string) string { return "" }
+func (polecatPiConfig) AgentProvider(agentType string) string {
+	if agentType == string(agent.TypePolecat) {
+		return "pi"
+	}
+	return "claude"
+}
+
 func TestPiEndToEnd(t *testing.T) {
 	if os.Getenv("POGO_PI_E2E") != "1" {
 		t.Skip("set POGO_PI_E2E=1 to run the live pi end-to-end test")
@@ -123,18 +153,36 @@ func TestPiEndToEnd(t *testing.T) {
 		t.Fatalf("write prompt file: %v", err)
 	}
 
-	// Resolve the provider exactly as cmd/pogod does for provider = "pi".
+	// The worktree carries its own AGENTS.md — the collision case from
+	// mg-9829. AppendFlag injection must leave it untouched (byte-identical
+	// after the run) while pi still loads it as project context.
+	const repoContextMarker = "POGO-PI-E2E-REPO-AGENTS-MD-MARKER"
+	repoAgentsMD := []byte("# repo context\n\nThis repo's own AGENTS.md (" +
+		repoContextMarker + ") — pogo must not clobber this file.\n")
+	agentsMDPath := filepath.Join(workDir, "AGENTS.md")
+	if err := os.WriteFile(agentsMDPath, repoAgentsMD, 0644); err != nil {
+		t.Fatalf("write repo AGENTS.md: %v", err)
+	}
+
 	provider, ok := providers.Resolve("pi")
 	if !ok || provider.ID != "pi" {
 		t.Fatalf("providers.Resolve(\"pi\") = (%v, %v), want the pi provider", provider, ok)
 	}
 
+	// Wire the registry exactly as cmd/pogod does at startup: every known
+	// provider registered, the per-type/global provider config installed, and
+	// claude as the global default. pi being resolved for the polecat spawn
+	// below therefore proves the `[agents.polecat] provider = "pi"` config
+	// tier, not a registry-global default.
 	reg, err := agent.NewRegistry(filepath.Join(base, "sock"))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
-	reg.RegisterProvider(provider)
-	reg.SetDefaultProvider(provider.ID)
+	for _, p := range providers.All() {
+		reg.RegisterProvider(p)
+	}
+	reg.SetCommandConfig(polecatPiConfig{})
+	reg.SetDefaultProvider("claude")
 	defer reg.StopAll(3 * time.Second)
 
 	cmd, err := agent.ExpandCommand(provider.CommandTemplate, agent.CommandTemplateVars{
@@ -168,6 +216,12 @@ func TestPiEndToEnd(t *testing.T) {
 	a := reg.Get("e2e")
 	if a == nil {
 		t.Fatal("agent not in registry after spawn")
+	}
+
+	// Acceptance (provider registry): the spawn resolved pi through the
+	// per-type config tier — not claude, the registry's global default.
+	if got := a.ProviderID(); got != "pi" {
+		t.Fatalf("resolved provider = %q, want pi via the [agents.polecat] config tier", got)
 	}
 
 	// Acceptance: the initial nudge is submitted and pi runs a turn — the mock
@@ -215,6 +269,21 @@ func TestPiEndToEnd(t *testing.T) {
 		t.Error("nudged task did not arrive intact in the user message (startup race?)")
 	}
 
+	// Acceptance (mg-9829 collision regression): AppendFlag injection must
+	// coexist with the repo's own AGENTS.md — the persona never touches the
+	// worktree, and pi still loads the repo context file. Location-agnostic
+	// on purpose: where pi folds AGENTS.md into the request is pi's business;
+	// that it arrives (and the file survives) is pogo's contract.
+	if !strings.Contains(string(mock.last()), repoContextMarker) {
+		t.Error("repo AGENTS.md content did not reach the model request — " +
+			"persona injection shadowed the repo's own context file")
+	}
+	if got, rerr := os.ReadFile(agentsMDPath); rerr != nil {
+		t.Errorf("repo AGENTS.md unreadable after spawn: %v", rerr)
+	} else if !bytes.Equal(got, repoAgentsMD) {
+		t.Errorf("repo AGENTS.md was clobbered by the spawn; contents now:\n%s", got)
+	}
+
 	// Acceptance: the calibrated PromptReadySentinel actually appears in pi's
 	// output as seen through pogo's own ANSI stripper — if this fails the
 	// initial nudge is running on the degraded wait-idle path (see
@@ -253,6 +322,44 @@ func TestPiEndToEnd(t *testing.T) {
 			after-before)
 	}
 
+	// Acceptance (nudge dialect, mid-session): Agent.Nudge into the settled
+	// composer — the calibrated body + "\r" split-write — triggers a second
+	// turn whose message arrives intact at the model. This is the path every
+	// later `pogo nudge` / mayor message to a running pi polecat takes.
+	const followUp = "Reply with exactly the word PONG once more"
+	turnsBefore := mock.count()
+	if err := a.Nudge(followUp); err != nil {
+		t.Fatalf("mid-session Nudge: %v", err)
+	}
+	deadline = time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) && mock.count() == turnsBefore {
+		time.Sleep(500 * time.Millisecond)
+	}
+	if mock.count() == turnsBefore {
+		clean = string(agent.StripANSI(a.RecentOutput(1 << 20)))
+		t.Fatalf("mid-session nudge never triggered a completion request — "+
+			"submit terminator or idle handling regressed.\noutput tail:\n%s",
+			tail(clean, 1200))
+	}
+	var followReq struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(mock.last(), &followReq); err != nil {
+		t.Fatalf("unmarshal follow-up request: %v", err)
+	}
+	lastUser := ""
+	for _, m := range followReq.Messages {
+		if m.Role == "user" {
+			lastUser = string(m.Content)
+		}
+	}
+	if !strings.Contains(lastUser, followUp) {
+		t.Errorf("follow-up nudge is not the latest user message; got %q", lastUser)
+	}
+
 	// Acceptance: the registry shuts the agent down cleanly.
 	stopped := make(chan struct{})
 	go func() {
@@ -264,6 +371,133 @@ func TestPiEndToEnd(t *testing.T) {
 		t.Log("registry stopped the pi agent cleanly")
 	case <-time.After(15 * time.Second):
 		t.Error("registry did not stop the pi agent within 15s — unclean shutdown")
+	}
+}
+
+// TestPiHeadless verifies the provider's spawn flags compose with pi's
+// non-interactive mode: the expanded CommandTemplate plus `--print --mode
+// json` and a positional task executes one turn and exits — no PTY, no
+// registry, no nudge. Same mock-provider setup as TestPiEndToEnd (no API key,
+// no network beyond localhost), same POGO_PI_E2E=1 gate. This is the shape
+// scripted/batch pi invocations take, and it pins down that --approve and
+// --append-system-prompt (file form) behave identically outside the TUI.
+func TestPiHeadless(t *testing.T) {
+	if os.Getenv("POGO_PI_E2E") != "1" {
+		t.Skip("set POGO_PI_E2E=1 to run the live pi headless test")
+	}
+	if _, err := exec.LookPath("pi"); err != nil {
+		t.Skip("pi binary not on PATH")
+	}
+
+	mock := &mockOpenAI{}
+	srv := httptest.NewServer(mock)
+	defer srv.Close()
+
+	base := t.TempDir()
+	workDir := filepath.Join(base, "worktree")
+	agentDir := filepath.Join(base, "pi-agent")
+	for _, d := range []string{workDir, agentDir} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	modelsJSON := fmt.Sprintf(`{"providers":{"mock":{"baseUrl":%q,"api":"openai-completions","apiKey":"mock","models":[{"id":"mock-1","name":"Mock 1","contextWindow":128000,"maxTokens":16000}]}}}`,
+		srv.URL+"/v1")
+	if err := os.WriteFile(filepath.Join(agentDir, "models.json"), []byte(modelsJSON), 0644); err != nil {
+		t.Fatalf("write models.json: %v", err)
+	}
+
+	const personaMarker = "POGO-PI-HEADLESS-PERSONA-MARKER"
+	promptFile := filepath.Join(base, "prompt.md")
+	persona := "# pogo persona\n\nYou are a pogo agent (" + personaMarker + ").\n"
+	if err := os.WriteFile(promptFile, []byte(persona), 0644); err != nil {
+		t.Fatalf("write prompt file: %v", err)
+	}
+
+	provider, ok := providers.Resolve("pi")
+	if !ok {
+		t.Fatal("providers.Resolve(\"pi\") returned ok=false")
+	}
+	argv, err := agent.ExpandCommand(provider.CommandTemplate, agent.CommandTemplateVars{
+		PromptFile: promptFile,
+		AgentName:  "headless",
+		AgentType:  string(agent.TypePolecat),
+		WorkDir:    workDir,
+	})
+	if err != nil {
+		t.Fatalf("ExpandCommand: %v", err)
+	}
+	const task = "Reply with exactly the word PONG"
+	argv = append(argv, "--provider", "mock", "--model", "mock-1", "--no-session",
+		"--print", "--mode", "json", task)
+	t.Logf("headless command: %v", argv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(), "PI_CODING_AGENT_DIR="+agentDir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("headless pi run failed: %v\noutput:\n%s", err, tail(string(out), 2000))
+	}
+
+	// The turn actually ran: the mock captured a completion request carrying
+	// both the appended persona and the positional task.
+	if mock.count() == 0 {
+		t.Fatalf("headless pi exited 0 but never sent a completion request.\noutput:\n%s",
+			tail(string(out), 2000))
+	}
+	var req struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(mock.last(), &req); err != nil {
+		t.Fatalf("unmarshal captured request: %v", err)
+	}
+	personaSeen, taskSeen := false, false
+	for _, m := range req.Messages {
+		switch m.Role {
+		case "system", "developer":
+			if strings.Contains(string(m.Content), personaMarker) {
+				personaSeen = true
+			}
+		case "user":
+			if strings.Contains(string(m.Content), task) {
+				taskSeen = true
+			}
+		}
+	}
+	if !personaSeen {
+		t.Error("persona from --append-system-prompt missing from headless request")
+	}
+	if !taskSeen {
+		t.Error("positional task missing from headless request's user message")
+	}
+
+	// --mode json emits machine-readable events; the mock's reply must appear
+	// in them, and at least one output line must be valid JSON.
+	if !strings.Contains(string(out), "PONG") {
+		t.Errorf("mock reply missing from headless json output.\noutput:\n%s",
+			tail(string(out), 2000))
+	}
+	jsonLine := false
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var v any
+		if json.Unmarshal([]byte(line), &v) == nil {
+			jsonLine = true
+			break
+		}
+	}
+	if !jsonLine {
+		t.Errorf("--mode json produced no parseable JSON lines.\noutput:\n%s",
+			tail(string(out), 2000))
 	}
 }
 

--- a/internal/pi/integration_test.go
+++ b/internal/pi/integration_test.go
@@ -1,0 +1,93 @@
+package pi_test
+
+// Integration coverage for the pi provider's config-resolution path (mg-3e7c).
+//
+// TestPolecatProviderConfigPath drives the exact composition cmd/pogod runs at
+// startup for a `[agents.polecat] provider = "pi"` deployment — TOML bytes on
+// disk through config.Load(), the per-type AgentProvider precedence, and
+// providers.Resolve() — and asserts the result is the real pi descriptor and
+// that its command template expands to the argv a pi polecat is spawned with.
+//
+// Unlike the live tests in e2e_test.go this needs no pi binary and no env
+// gate: it runs in every `go test ./...` (and therefore in the refinery gates
+// and GitHub CI). The registry side of the same chain — Registry.Spawn
+// resolving pi through the config tier — needs a real spawn, so it is
+// asserted in TestPiEndToEnd via Agent.ProviderID.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/drellem2/pogo/internal/agent"
+	"github.com/drellem2/pogo/internal/config"
+	"github.com/drellem2/pogo/internal/pi"
+	"github.com/drellem2/pogo/internal/providers"
+)
+
+func TestPolecatProviderConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	// Neutralize env overrides that would shadow the config file.
+	t.Setenv("POGO_AGENT_PROVIDER", "")
+	t.Setenv("POGO_AGENT_COMMAND", "")
+
+	pogoDir := filepath.Join(dir, "pogo")
+	if err := os.MkdirAll(pogoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pogoDir, "config.toml"), []byte(`
+[agents]
+provider = "claude"
+
+[agents.polecat]
+provider = "pi"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.Load()
+
+	// Per-type precedence: polecats get pi, crew inherit the global claude.
+	if got := cfg.Agents.AgentProvider("polecat"); got != "pi" {
+		t.Fatalf("AgentProvider(polecat) = %q, want pi", got)
+	}
+	if got := cfg.Agents.AgentProvider("crew"); got != "claude" {
+		t.Errorf("AgentProvider(crew) = %q, want claude (global)", got)
+	}
+
+	// The id maps to the real pi descriptor — same composition as pogod's
+	// resolveAgentProvider(cfg.Agents.AgentProvider(agentType)).
+	p, ok := providers.Resolve(cfg.Agents.AgentProvider("polecat"))
+	if !ok {
+		t.Fatal("providers.Resolve returned ok=false for the configured polecat provider")
+	}
+	if p != &pi.Provider {
+		t.Fatalf("Resolve returned %q (%p), want the pi.Provider descriptor (%p)",
+			p.ID, p, &pi.Provider)
+	}
+
+	// No explicit [agents] command is configured, so the provider's template
+	// supplies the spawn argv.
+	if got := cfg.Agents.AgentCommand("polecat"); got != "" {
+		t.Fatalf("AgentCommand(polecat) = %q, want \"\" (provider template should win)", got)
+	}
+	argv, err := agent.ExpandCommand(p.CommandTemplate, agent.CommandTemplateVars{
+		PromptFile: "/tmp/prompt.md",
+		AgentName:  "cfg-test",
+		AgentType:  string(agent.TypePolecat),
+		WorkDir:    "/tmp/work",
+	})
+	if err != nil {
+		t.Fatalf("ExpandCommand: %v", err)
+	}
+	want := []string{"pi", "--approve", "--append-system-prompt", "/tmp/prompt.md"}
+	if len(argv) != len(want) {
+		t.Fatalf("expanded argv = %v, want %v", argv, want)
+	}
+	for i := range want {
+		if argv[i] != want[i] {
+			t.Fatalf("expanded argv = %v, want %v", argv, want)
+		}
+	}
+}


### PR DESCRIPTION
Temporary PR to exercise the new pi-e2e CI job on ubuntu before the refinery merges this branch. Will be closed without merging — the pogo refinery performs the actual merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)