### PR TITLE
Usage-limit visibility + recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ is the curated, human-readable summary kept in sync at each release cut.
 ## [Unreleased]
 
 ### Added
+- **Usage-limit visibility + recovery** (mg-7ffa, gh #45). pogod's modal
+  watcher now recognizes a provider usage-limit wedge as a distinct, observable
+  condition instead of a silent stall. When the rate-limit-options modal stays
+  visible while an agent's event log goes stale past ~5m (a heuristic off the
+  existing event-staleness tracker — no quota/API probe), pogod emits a
+  `usage_limit_hit` event `{agent, work_item_id, timestamp}`, flags the agent
+  `RateLimited`, and surfaces it as `health=rate_limited` in
+  `pogo agent diagnose` and `⚠ rate-limited` in `pogo status`. Recovery is
+  detected when the event log advances again: pogod emits `usage_limit_cleared`
+  and drops the flag. To avoid an N-agent notification storm, operator mail is
+  coalesced to **one mail to `human` per fleet-wide episode** — one at hit, one
+  at clear, the latter carrying a per-agent resume checklist. Runbook in
+  [docs/operations.md](docs/operations.md#recovering-from-a-usage-limit-episode);
+  event catalog in [docs/event-log.md](docs/event-log.md). Deferred (not built):
+  auto-resume of waiting agents, a `pogo usage` command, provider quota probes.
 - **`polecat-build-pr.md` template: issue-track build variant** (mg-9675,
   gh-issue-workflow design §3/§6). Shipped polecat template for work that
   answers a GitHub issue: after commit + branch push the builder opens a PR

--- a/cmd/pogo/main.go
+++ b/cmd/pogo/main.go
@@ -333,8 +333,12 @@ Use --json for the raw structured response.`,
 			fmt.Fprintf(&b, "  %d total (%d crew, %d polecat), %d running\n",
 				len(agents), crew, polecats, running)
 			for _, a := range agents {
-				fmt.Fprintf(&b, "  %-20s  %-8s  %-10s  pid=%-6d  uptime=%s\n",
-					a.Name, a.Type, a.Status, a.PID, a.Uptime)
+				marker := ""
+				if a.RateLimited {
+					marker = "  ⚠ rate-limited"
+				}
+				fmt.Fprintf(&b, "  %-20s  %-8s  %-10s  pid=%-6d  uptime=%s%s\n",
+					a.Name, a.Type, a.Status, a.PID, a.Uptime, marker)
 			}
 		}
 		fmt.Fprintln(&b)
@@ -885,6 +889,9 @@ Use --plain to strip ANSI/VT escape sequences for human-readable or machine-pars
 						if a.RestartCount > 0 {
 							extra += fmt.Sprintf("  restarts=%d", a.RestartCount)
 						}
+						if a.RateLimited {
+							extra += "  rate-limited"
+						}
 						if a.LastActivity != "" {
 							extra += fmt.Sprintf("  last-activity=%s", a.LastActivity)
 						}
@@ -903,11 +910,12 @@ Use --plain to strip ANSI/VT escape sequences for human-readable or machine-pars
 process health, idle duration, and stall detection thresholds.
 
 Health states:
-  healthy  — produced output within the last 30s (actively working)
-  idle     — quiet for over 30s but within the stall threshold (alive, between cycles)
-  stalled  — quiet for longer than the stall threshold
-  exited   — process has exited
-  dead     — registered as running but OS process is gone
+  healthy      — produced output within the last 30s (actively working)
+  idle         — quiet for over 30s but within the stall threshold (alive, between cycles)
+  stalled      — quiet for longer than the stall threshold
+  rate_limited — alive but wedged on the provider's usage-limit modal (gh #45)
+  exited       — process has exited
+  dead         — registered as running but OS process is gone
 
 A cron-driven agent (e.g. a */30 mail-check) is idle by design between firings.
 While it is within one cron interval of its last scheduled firing it reports
@@ -934,6 +942,15 @@ While it is within one cron interval of its last scheduled firing it reports
 				}
 				fmt.Printf("Stall threshold: %s\n", diag.StallThreshold)
 				fmt.Printf("Health:         %s\n", diag.Health)
+				if diag.RateLimited {
+					fmt.Printf("\n⚠ Agent appears rate-limited (provider usage limit).")
+					if !diag.RateLimitedSince.IsZero() {
+						fmt.Printf(" Since %s.", diag.RateLimitedSince.UTC().Format(time.RFC3339))
+					}
+					fmt.Printf("\n  It is alive but wedged on the rate-limit modal; work resumes when the limit\n")
+					fmt.Printf("  resets. Do not restart it to \"fix\" the wedge. See docs/operations.md →\n")
+					fmt.Printf("  \"Recovering from a usage-limit episode\".\n")
+				}
 				if diag.CronCovered {
 					fmt.Printf("\nℹ Idle past the stall threshold, but within one cron interval of\n")
 					fmt.Printf("  the last scheduled firing — this is normal between-cron idle, not a stall.\n")

--- a/docs/event-log.md
+++ b/docs/event-log.md
@@ -304,6 +304,32 @@ pogod's stall watcher (gh drellem2/macguffin #12) crossed a work-pile-up thresho
 {"schema_version":1,"timestamp":"2026-06-10T16:20:00.000000000Z","event_type":"stall_watch_fired","agent":"pogod","details":{"category":"unclaimed_items","watched_agent":"mayor","item_count":2,"item_ids":["mg-2350","mg-9299"],"age_threshold":"10m0s","oldest_age_seconds":1830.4}}
 ```
 
+#### `usage_limit_hit`
+
+pogod's modal watcher ([modal_hook.go](../internal/claude/modal_hook.go), gh drellem2/pogo #45) declared a **suspected** provider usage-limit hit for an agent: the rate-limit-options modal has been recently visible AND the agent's event log has been stale for longer than the usage-limit staleness gate (~5m, `UsageLimitSuspectStaleness`). This is a heuristic derived entirely from the existing event-staleness tracker — there is no provider quota/API probe. The ~5m gate is deliberately long because the marker text also appears in ordinary transcripts; a shorter gate would false-positive on an agent that merely prints the phrase. Emitted once per wedge; the paired `usage_limit_cleared` fires on recovery. Additive — no `schema_version` bump.
+
+- **Required envelope:** `schema_version`, `timestamp`, `event_type`, `agent` (the wedged agent, e.g. `"cat-mg-7ffa"`), `details`
+- **Optional envelope:** `work_item_id` (present when the agent is tied to a work item)
+- **`details` fields:**
+  - `matcher` (string, required): always `"rate-limit-options"` in v1
+
+```json
+{"schema_version":1,"timestamp":"2026-07-06T18:20:00.000000000Z","event_type":"usage_limit_hit","agent":"cat-mg-7ffa","work_item_id":"mg-7ffa","details":{"matcher":"rate-limit-options"}}
+```
+
+#### `usage_limit_cleared`
+
+The agent flagged by a prior `usage_limit_hit` recovered: its event log advanced past the wedge point (the agent is producing events again). This is the recovery signal operators wait on — it means the limit reset and the agent resumed work. Emitted once per hit, paired with the preceding `usage_limit_hit`. (If the agent instead exits while still limited, no `usage_limit_cleared` is emitted — the agent's `agent_stopped`/`agent_crashed` lifecycle event records the death, and the fleet coordinator releases it from the episode.) Additive — no `schema_version` bump.
+
+- **Required envelope:** `schema_version`, `timestamp`, `event_type`, `agent`, `details`
+- **Optional envelope:** `work_item_id` (present when the agent is tied to a work item)
+- **`details` fields:**
+  - `matcher` (string, required): always `"rate-limit-options"` in v1
+
+```json
+{"schema_version":1,"timestamp":"2026-07-06T22:05:00.000000000Z","event_type":"usage_limit_cleared","agent":"cat-mg-7ffa","work_item_id":"mg-7ffa","details":{"matcher":"rate-limit-options"}}
+```
+
 ## Worked example: a polecat merge cycle
 
 The lines below show the canonical event sequence for a successful polecat run. Times are illustrative.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,6 +11,32 @@ An agent whose process has died — a crew loop that exited cleanly without re-a
 
 A **live** agent is still protected: `start` refuses a duplicate of a running process, and `stop` signals it normally. So there is no need to `systemctl restart pogo.service` / bounce launchd to recover one wedged agent — that bounces the whole fleet. Reserve the daemon restart tiers below for pogod itself misbehaving.
 
+## Recovering from a usage-limit episode
+
+When the provider's usage limit is hit, Claude Code renders a rate-limit-options modal ("Stop and wait for limit to reset") and the agent's reasoning loop wedges — it stops producing events but stays alive. pogod's modal watcher (gh #45) detects this and surfaces it so you aren't left guessing why a fleet went quiet. **Do not restart or `kill` a rate-limited agent to "fix" the wedge** — it is not broken; it is waiting for the limit to reset, and a restart just loses in-flight context. Recovery is: wait for the reset, then nudge or restart as needed.
+
+### How you find out
+
+- **One coalesced mail to `human` at the start of an episode** (subject `usage limit hit — fleet episode started`). An "episode" is one fleet-wide limit event: the first affected agent triggers the mail; additional agents that hit the same limit join the episode **silently** (no per-agent mail storm). No action is required at hit time.
+- **`pogo status`** marks affected agents with `⚠ rate-limited` in the agent rows; `pogo agent list` appends `rate-limited`.
+- **`pogo agent diagnose <name>`** reports `Health: rate_limited` — a distinct condition that outranks `stalled`/`idle`, so a limit wait is never mistaken for a genuine wedge. `--json` carries `rate_limited` and `rate_limited_since`.
+- The `usage_limit_hit` / `usage_limit_cleared` events land in `~/.pogo/events.log` (see [event-log.md](event-log.md)) with `{agent, work_item_id, timestamp}` — filter with `jq 'select(.event_type=="usage_limit_hit")'`.
+
+### When the limit resets
+
+The condition **clears automatically** when each agent resumes producing events (its event log advances past the wedge point): the `rate_limited` flag drops, a `usage_limit_cleared` event is emitted, and — once the **last** limited agent clears — pogod sends **one coalesced clear mail to `human`** (subject `usage limit cleared — N agent(s) recovered`) carrying a per-agent **resume checklist**:
+
+```
+- cat-mg-7ffa (work item mg-7ffa)
+    verify: pogo agent diagnose mg-7ffa
+    if idle: pogo nudge mg-7ffa "usage limit reset — resume your task"
+    if exited: pogo agent start mg-7ffa
+```
+
+Work through the checklist per agent: `pogo agent diagnose` to see whether it self-resumed, `pogo nudge` an idle-but-alive agent to prod it back into its loop, or `pogo agent start` one that exited during the wait. Agents that were mid-task and resumed on their own need nothing.
+
+> **Note on marker drift (pre-existing risk):** detection keys off the modal's marker text (`"Stop and wait for limit to reset"`). If a future Claude Code version changes that string, detection silently stops until the marker constant is updated — the same drift risk the modal-dismissal watcher already carries. This is diagnostic-only: a missed detection means you fall back to the pre-#45 behavior (agents read as `stalled`), it does not break anything.
+
 ## Parking a crew agent (supported dormancy)
 
 `restart_on_crash = true` is an always-on contract: pogod respawns the agent on **any** exit — including an explicit `pogo agent stop` — within seconds. To take such an agent out of rotation (e.g. a PM whose workstream is gated with zero in-flight items), **park** it instead of stopping it:

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -95,6 +95,17 @@ type Agent struct {
 	// running-agent token cost to the right item without grepping events.
 	WorkItemID string `json:"work_item_id,omitempty"`
 
+	// RateLimited is set by the modal watcher when the agent is suspected to
+	// have hit a provider usage limit — the rate-limit-options modal is visible
+	// and the agent's event log has been stale past the usage-limit threshold
+	// (~5m). It is cleared when the agent resumes producing events. Guarded by
+	// mu; mutated only through SetRateLimited. See internal/claude/modal_hook.go
+	// and docs/operations.md (usage-limit recovery runbook).
+	RateLimited bool `json:"rate_limited,omitempty"`
+	// RateLimitedSince records when RateLimited was last set true (zero when the
+	// agent is not currently rate-limited). Guarded by mu.
+	RateLimitedSince time.Time `json:"rate_limited_since,omitempty"`
+
 	// InitialNudge is the message sent after spawn to bypass the CLI interactive prompt.
 	// Stored so Respawn can re-send it.
 	InitialNudge string `json:"-"`
@@ -149,6 +160,33 @@ func (a *Agent) GetStatus() AgentStatus {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.Status
+}
+
+// SetRateLimited records (or clears) the usage-limit condition for this agent.
+// It is idempotent: setting the same value twice is a no-op, so the modal
+// watcher can call it on every gate evaluation without churning
+// RateLimitedSince. Setting true stamps RateLimitedSince with the current time;
+// clearing resets it to zero. Safe for concurrent use — the modal watcher
+// goroutine calls this while status/diagnose readers hold the same lock.
+func (a *Agent) SetRateLimited(v bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if v == a.RateLimited {
+		return
+	}
+	a.RateLimited = v
+	if v {
+		a.RateLimitedSince = time.Now()
+	} else {
+		a.RateLimitedSince = time.Time{}
+	}
+}
+
+// IsRateLimited reports whether the agent is currently flagged as rate-limited.
+func (a *Agent) IsRateLimited() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.RateLimited
 }
 
 // pidAlive reports whether a process with the given pid is currently running,

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -33,6 +33,15 @@ type AgentInfo struct {
 	Uptime         string      `json:"uptime"`
 	LastActivity   string      `json:"last_activity,omitempty"`
 	WorkItemID     string      `json:"work_item_id,omitempty"`
+	// RateLimited is true when the modal watcher has flagged the agent as
+	// suspected-usage-limited (rate-limit modal visible + event log stale). It
+	// is a distinct condition from idle/stalled: the agent is alive but wedged
+	// on the provider's rate-limit modal. Surfaced in `pogo status` rows and
+	// `pogo agent diagnose`.
+	RateLimited bool `json:"rate_limited,omitempty"`
+	// RateLimitedSince (RFC 3339) is when RateLimited was set; omitted when the
+	// agent is not rate-limited.
+	RateLimitedSince time.Time `json:"rate_limited_since,omitempty"`
 	// ParkedAt (RFC 3339) is set only on status=parked entries, which are
 	// synthesized from on-disk park flags rather than live registry state.
 	ParkedAt string `json:"parked_at,omitempty"`
@@ -128,7 +137,8 @@ type DiagnoseInfo struct {
 	// of its last scheduled firing — between-cron idle is by design for a
 	// cron-driven crew agent, not a wedge (mg-5b23).
 	CronCovered bool `json:"cron_covered,omitempty"`
-	// Health is a summary string: "healthy", "idle", "stalled", "exited", or "dead".
+	// Health is a summary string: "healthy", "idle", "stalled", "rate_limited",
+	// "exited", or "dead".
 	Health string `json:"health"`
 	// RecentOutputTail is the last ~500 bytes of PTY output for quick triage.
 	RecentOutputTail string `json:"recent_output_tail,omitempty"`
@@ -200,12 +210,19 @@ func diagnoseAgentAt(a *Agent, now time.Time, windows []CronWindow) DiagnoseInfo
 	// stall threshold it is "idle" (alive, between cycles); past the threshold it
 	// is "stalled". A cron-covered agent reports "idle" rather than "stalled" —
 	// its idle exceeds the recency window by construction (mg-5b23, gh #16).
+	//
+	// "rate_limited" is a distinct condition that outranks stalled/idle: a
+	// usage-limited agent is alive but wedged on the provider's rate-limit modal
+	// and would otherwise read as stalled. Surfacing it separately keeps
+	// operators from mistaking a limit wait for a genuine wedge (gh #45).
 	health := "healthy"
 	switch {
 	case info.Status == StatusExited:
 		health = "exited"
 	case a.PID > 0 && !processAlive && info.Status == StatusRunning:
 		health = "dead"
+	case info.RateLimited:
+		health = "rate_limited"
 	case stalled:
 		health = "stalled"
 	case !lastWrite.IsZero() && idleDur >= ActiveRecencyWindow:
@@ -278,6 +295,10 @@ func agentInfo(a *Agent) AgentInfo {
 		ProcessName:    ProcessName(a.Type, a.Name),
 		Uptime:         agentUptime(a),
 		WorkItemID:     a.WorkItemID,
+		RateLimited:    a.RateLimited,
+	}
+	if a.RateLimited {
+		info.RateLimitedSince = a.RateLimitedSince
 	}
 	if a.outputBuf != nil {
 		if t := a.outputBuf.LastWriteTime(); !t.IsZero() {

--- a/internal/agent/diagnose_test.go
+++ b/internal/agent/diagnose_test.go
@@ -129,6 +129,49 @@ func TestDiagnoseStalled(t *testing.T) {
 	}
 }
 
+// A rate-limited agent looks stalled by output-idle but must report the
+// distinct "rate_limited" health so operators don't mistake a usage-limit wait
+// for a genuine wedge (gh #45). rate_limited outranks stalled.
+func TestDiagnoseRateLimited(t *testing.T) {
+	buf := NewRingBuffer(1024)
+	buf.Write([]byte("old data"))
+	buf.mu.Lock()
+	buf.lastWrite = time.Now().Add(-10 * time.Minute) // would otherwise be "stalled"
+	buf.mu.Unlock()
+
+	a := &Agent{
+		Name:      "diag-ratelimited",
+		Type:      TypePolecat,
+		PID:       0,
+		Status:    StatusRunning,
+		StartTime: time.Now().Add(-15 * time.Minute),
+		outputBuf: buf,
+		done:      make(chan struct{}),
+	}
+	a.SetRateLimited(true)
+
+	diag := diagnoseAgent(a)
+	if diag.Health != "rate_limited" {
+		t.Errorf("Health = %q, want %q", diag.Health, "rate_limited")
+	}
+	if !diag.RateLimited {
+		t.Error("RateLimited should be true")
+	}
+	if diag.RateLimitedSince.IsZero() {
+		t.Error("RateLimitedSince should be set")
+	}
+
+	// Clearing it drops back to the underlying condition (stalled here).
+	a.SetRateLimited(false)
+	diag = diagnoseAgent(a)
+	if diag.Health != "stalled" {
+		t.Errorf("after clear, Health = %q, want %q", diag.Health, "stalled")
+	}
+	if diag.RateLimited {
+		t.Error("RateLimited should be false after clear")
+	}
+}
+
 func TestDiagnoseIdle(t *testing.T) {
 	// Simulate an idle agent — past the active-recency window but not stalled.
 	buf := NewRingBuffer(1024)

--- a/internal/claude/modal_hook.go
+++ b/internal/claude/modal_hook.go
@@ -68,6 +68,17 @@ type IdleGatePolicy struct {
 	Mode            IdleMode
 	IdleAfterMarker time.Duration // for ModeScannerIdle
 	EventStaleness  time.Duration // for ModeEventsStale
+
+	// UsageLimitStaleness, when > 0, enables a second, earlier stage on a
+	// ModeEventsStale matcher: while the marker is recently visible and the
+	// agent's event log has been stale for longer than this (shorter than
+	// EventStaleness), the watcher declares a *suspected usage-limit hit* —
+	// emits usage_limit_hit, flags the agent RateLimited, and notifies the
+	// fleet usage-limit coordinator. It clears (usage_limit_cleared) when the
+	// event log advances again. This is diagnostic only; it does not dismiss
+	// the modal — the EventStaleness gate still owns the 20m auto-dismissal.
+	// Zero disables the stage (used by matchers with no usage-limit semantics).
+	UsageLimitStaleness time.Duration // for ModeEventsStale (gh #45)
 }
 
 // ModalMatcher is one entry in the watcher table. Adding a matcher = adding
@@ -96,11 +107,24 @@ var DefaultModalMatchers = []ModalMatcher{
 		LineMarker: RateLimitMarker,
 		Dismissal:  []byte("1\n"),
 		IdleGate: IdleGatePolicy{
-			Mode:           ModeEventsStale,
-			EventStaleness: 20 * time.Minute,
+			Mode:                ModeEventsStale,
+			EventStaleness:      20 * time.Minute,
+			UsageLimitStaleness: UsageLimitSuspectStaleness,
 		},
 	},
 }
+
+// UsageLimitSuspectStaleness is how long the agent's event log must be stale —
+// with the rate-limit modal still recently visible — before the watcher
+// declares a suspected usage-limit hit (gh #45). It is deliberately much
+// longer than a scanner-idle window: the rate-limit marker text also appears in
+// ordinary transcripts, so a seconds-level trigger would false-positive on an
+// agent that merely quotes the phrase. Requiring ~5m of event-log silence means
+// only a genuinely wedged agent — one that has stopped producing events while
+// the modal stays on screen — trips the gate. It is shorter than
+// EventStaleness (20m) so operators learn of the wedge well before the
+// auto-dismissal fires.
+const UsageLimitSuspectStaleness = 5 * time.Minute
 
 // dismissalCooldown is the per-matcher no-re-fire window after a successful
 // dismissal write. Prevents a modal that briefly redraws its marker line from
@@ -146,6 +170,19 @@ type ModalHookDeps struct {
 	Now       func() time.Time           // overridable clock for tests
 	EmitEvent func(ev events.Event)      // dismissal observability
 	NotifyPM  func(agentID, matcherName string)
+
+	// WorkItemID is the agent's mg work item (e.g. "mg-7ffa"), stamped into the
+	// usage_limit_hit / usage_limit_cleared events and the coordinator roster.
+	// Empty for agents not tied to an item.
+	WorkItemID string
+	// SetRateLimited flags/unflags the agent's RateLimited condition (surfaced
+	// in `pogo status` and `pogo agent diagnose`). Nil in tests that don't care.
+	SetRateLimited func(bool)
+	// OnUsageLimitHit / OnUsageLimitClear notify the fleet usage-limit
+	// coordinator so it can coalesce one operator mail per fleet-wide episode
+	// (gh #45). Nil disables the coalesced-mail path.
+	OnUsageLimitHit   func(agentID, workItemID string, when time.Time)
+	OnUsageLimitClear func(agentID string, when time.Time)
 }
 
 // ModalHook is the SessionHook entrypoint. Wires production defaults and runs
@@ -160,6 +197,15 @@ func ModalHook(ctx context.Context, a *agent.Agent) {
 		Now:       time.Now,
 		EmitEvent: func(ev events.Event) { events.Emit(context.Background(), ev) },
 		NotifyPM:  defaultNotifyPM,
+
+		WorkItemID:     a.WorkItemID,
+		SetRateLimited: a.SetRateLimited,
+		OnUsageLimitHit: func(agentID, workItemID string, when time.Time) {
+			defaultUsageLimitCoordinator().OnHit(agentID, workItemID, when)
+		},
+		OnUsageLimitClear: func(agentID string, when time.Time) {
+			defaultUsageLimitCoordinator().OnClear(agentID, when)
+		},
 	}
 	RunModalHook(ctx, deps, DefaultModalMatchers)
 }
@@ -359,19 +405,55 @@ func dispatchEventsStale(ctx context.Context, idx int, m ModalMatcher, scanner *
 	defer ticker.Stop()
 	var lastDismissed time.Time
 
+	// Usage-limit hit/clear state (gh #45). hitActive is true once we've
+	// declared a suspected hit that has not yet cleared; hitEventsSeen is the
+	// event-log LastSeen value at the moment we declared it, so the clear gate
+	// can detect the log advancing (agent producing events again).
+	var (
+		hitActive     bool
+		hitEventsSeen time.Time
+	)
+
 	check := func() {
+		now := deps.Now()
 		seen := scanner.MarkerLastSeen(idx)
+		eventsLastSeen := deps.Tracker.LastSeen(deps.AgentID)
+
+		// --- usage-limit suspected-hit / clear stage -----------------------
+		// Independent of the dismissal gate below: emitting the hit is
+		// observability, not intervention. Runs only for matchers that opt in
+		// via UsageLimitStaleness > 0 (the rate-limit-options matcher).
+		if m.IdleGate.UsageLimitStaleness > 0 {
+			if !hitActive {
+				markerFresh := !seen.IsZero() && now.Sub(seen) <= markerRecency
+				// A fresh-spawned agent with no events yet is treated as fresh
+				// (never a hit); the same guard the dismissal gate uses.
+				eventsStale := !eventsLastSeen.IsZero() &&
+					now.Sub(eventsLastSeen) > m.IdleGate.UsageLimitStaleness
+				if markerFresh && eventsStale {
+					emitUsageLimitHit(deps, now)
+					hitActive = true
+					hitEventsSeen = eventsLastSeen
+				}
+			} else if !eventsLastSeen.IsZero() && eventsLastSeen.After(hitEventsSeen) {
+				// Event log advanced past the wedge point — the agent is
+				// producing events again, so the limit has cleared.
+				emitUsageLimitCleared(deps, now)
+				hitActive = false
+				hitEventsSeen = time.Time{}
+			}
+		}
+
+		// --- 20m auto-dismissal gate (unchanged) ---------------------------
 		if seen.IsZero() {
 			return
 		}
-		now := deps.Now()
 		if now.Sub(seen) > markerRecency {
 			return
 		}
 		if !lastDismissed.IsZero() && now.Sub(lastDismissed) < dismissalCooldown {
 			return
 		}
-		eventsLastSeen := deps.Tracker.LastSeen(deps.AgentID)
 		// A fresh-spawned agent without any events yet is treated as fresh;
 		// the dispatcher will get another tick once events show up. Without
 		// this guard, a missing tracker entry would fire dismissal immediately
@@ -391,12 +473,69 @@ func dispatchEventsStale(ctx context.Context, idx int, m ModalMatcher, scanner *
 	for {
 		select {
 		case <-ctx.Done():
+			// If the agent exits while still flagged, release the flag and let
+			// the coordinator drop it from the current episode so a stuck agent
+			// can't hold the episode open forever. This is a release, not a
+			// recovery — no usage_limit_cleared event is emitted (the agent's
+			// lifecycle events already record its death).
+			if hitActive {
+				if deps.SetRateLimited != nil {
+					deps.SetRateLimited(false)
+				}
+				if deps.OnUsageLimitClear != nil {
+					deps.OnUsageLimitClear(deps.AgentID, deps.Now())
+				}
+			}
 			return
 		case <-scanner.observed[idx]:
 			// Just an arming signal; the ticker drives evaluation.
 		case <-ticker.C:
 			check()
 		}
+	}
+}
+
+// emitUsageLimitHit records a suspected usage-limit hit: it flags the agent
+// RateLimited, emits the usage_limit_hit event, and notifies the fleet
+// coordinator. Called at most once per wedge (guarded by hitActive).
+func emitUsageLimitHit(deps ModalHookDeps, when time.Time) {
+	if deps.SetRateLimited != nil {
+		deps.SetRateLimited(true)
+	}
+	log.Printf("modal_hook: agent %s suspected usage-limit hit (rate-limit modal visible, event log stale)",
+		deps.AgentName)
+	deps.EmitEvent(events.Event{
+		EventType:  "usage_limit_hit",
+		Agent:      deps.AgentID,
+		WorkItemID: deps.WorkItemID,
+		Timestamp:  when.UTC().Format(time.RFC3339Nano),
+		Details: map[string]any{
+			"matcher": "rate-limit-options",
+		},
+	})
+	if deps.OnUsageLimitHit != nil {
+		deps.OnUsageLimitHit(deps.AgentID, deps.WorkItemID, when)
+	}
+}
+
+// emitUsageLimitCleared records recovery from a usage-limit hit: it clears the
+// RateLimited flag, emits usage_limit_cleared, and notifies the coordinator.
+func emitUsageLimitCleared(deps ModalHookDeps, when time.Time) {
+	if deps.SetRateLimited != nil {
+		deps.SetRateLimited(false)
+	}
+	log.Printf("modal_hook: agent %s usage limit cleared (event log advancing again)", deps.AgentName)
+	deps.EmitEvent(events.Event{
+		EventType:  "usage_limit_cleared",
+		Agent:      deps.AgentID,
+		WorkItemID: deps.WorkItemID,
+		Timestamp:  when.UTC().Format(time.RFC3339Nano),
+		Details: map[string]any{
+			"matcher": "rate-limit-options",
+		},
+	})
+	if deps.OnUsageLimitClear != nil {
+		deps.OnUsageLimitClear(deps.AgentID, when)
 	}
 }
 

--- a/internal/claude/modal_hook_test.go
+++ b/internal/claude/modal_hook_test.go
@@ -26,6 +26,13 @@ type testRig struct {
 	pmNotifications []string
 	tracker         *fakeTracker
 	now             func() time.Time
+
+	// usage-limit capture (gh #45)
+	rateLimited  int32 // last SetRateLimited value: 1 = true, 0 = false
+	hitCount     int32
+	clearCount   int32
+	lastHitAgent string
+	lastHitItem  string
 }
 
 func newTestRig(now func() time.Time) *testRig {
@@ -78,8 +85,30 @@ func (r *testRig) deps(agentID string) ModalHookDeps {
 			r.pmNotifications = append(r.pmNotifications, agentID+":"+matcherName)
 			r.mu.Unlock()
 		},
+		WorkItemID: "mg-test",
+		SetRateLimited: func(v bool) {
+			if v {
+				atomic.StoreInt32(&r.rateLimited, 1)
+			} else {
+				atomic.StoreInt32(&r.rateLimited, 0)
+			}
+		},
+		OnUsageLimitHit: func(agentID, workItemID string, _ time.Time) {
+			r.mu.Lock()
+			r.lastHitAgent = agentID
+			r.lastHitItem = workItemID
+			r.mu.Unlock()
+			atomic.AddInt32(&r.hitCount, 1)
+		},
+		OnUsageLimitClear: func(agentID string, _ time.Time) {
+			atomic.AddInt32(&r.clearCount, 1)
+		},
 	}
 }
+
+func (r *testRig) hits() int           { return int(atomic.LoadInt32(&r.hitCount)) }
+func (r *testRig) clears() int         { return int(atomic.LoadInt32(&r.clearCount)) }
+func (r *testRig) isRateLimited() bool { return atomic.LoadInt32(&r.rateLimited) == 1 }
 
 func (r *testRig) dismissals() int { return int(atomic.LoadInt32(&r.dismissCount)) }
 
@@ -156,8 +185,9 @@ func testMatchers() []ModalMatcher {
 			LineMarker: RateLimitMarker,
 			Dismissal:  []byte("1\n"),
 			IdleGate: IdleGatePolicy{
-				Mode:           ModeEventsStale,
-				EventStaleness: 20 * time.Minute,
+				Mode:                ModeEventsStale,
+				EventStaleness:      20 * time.Minute,
+				UsageLimitStaleness: UsageLimitSuspectStaleness,
 			},
 		},
 	}
@@ -391,6 +421,125 @@ func TestModalHook_Case6_RateLimitQuotedNoFire(t *testing.T) {
 	}
 	if rig.dismissals() != 0 {
 		t.Errorf("expected no dismissal for transcript-quoted marker with fresh events, got %d", rig.dismissals())
+	}
+}
+
+// --- gh #45 usage-limit hit/clear cases ------------------------------------
+
+// Marker visible + events stale past the ~5m usage-limit gate (but well under
+// the 20m dismissal gate) → a usage_limit_hit fires: the agent is flagged
+// rate-limited and the coordinator is notified, WITHOUT any modal dismissal.
+func TestModalHook_UsageLimit_HitOnStaleEvents(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(1_700_000_000, 0)}
+	rig := newTestRig(clock.Now)
+	// Events stale 6m: past UsageLimitSuspectStaleness (5m), under EventStaleness (20m).
+	rig.tracker.set("cat-test", clock.Now().Add(-6*time.Minute))
+
+	prev := setEventsStalePollIntervalForTest(20 * time.Millisecond)
+	defer setEventsStalePollIntervalForTest(prev)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go RunModalHook(ctx, rig.deps("cat-test"), testMatchers())
+	if !waitFor(t, time.Second, func() bool {
+		rig.mu.Lock()
+		ok := rig.scanner != nil
+		rig.mu.Unlock()
+		return ok
+	}) {
+		t.Fatalf("scanner never subscribed")
+	}
+
+	rig.writeOutput([]byte("What do you want to do?\n  1: " + RateLimitMarker + "\n"))
+
+	if !waitFor(t, 2*time.Second, func() bool { return rig.hits() >= 1 }) {
+		t.Fatalf("expected a usage_limit_hit, got %d", rig.hits())
+	}
+	if !rig.isRateLimited() {
+		t.Errorf("agent should be flagged rate-limited after a hit")
+	}
+	rig.mu.Lock()
+	agent, item := rig.lastHitAgent, rig.lastHitItem
+	rig.mu.Unlock()
+	if agent != "cat-test" || item != "mg-test" {
+		t.Errorf("hit carried agent=%q item=%q, want cat-test/mg-test", agent, item)
+	}
+	// The 5m stage must NOT dismiss the modal (that's the 20m gate's job).
+	if rig.dismissals() != 0 {
+		t.Errorf("suspected-hit stage must not dismiss the modal, got %d dismissals", rig.dismissals())
+	}
+}
+
+// After a hit, the event log advancing again (agent resumed producing events)
+// clears the condition: usage_limit_cleared fires and the flag is dropped.
+func TestModalHook_UsageLimit_ClearsOnResume(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(1_700_000_000, 0)}
+	rig := newTestRig(clock.Now)
+	rig.tracker.set("cat-test", clock.Now().Add(-6*time.Minute))
+
+	prev := setEventsStalePollIntervalForTest(20 * time.Millisecond)
+	defer setEventsStalePollIntervalForTest(prev)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go RunModalHook(ctx, rig.deps("cat-test"), testMatchers())
+	if !waitFor(t, time.Second, func() bool {
+		rig.mu.Lock()
+		ok := rig.scanner != nil
+		rig.mu.Unlock()
+		return ok
+	}) {
+		t.Fatalf("scanner never subscribed")
+	}
+
+	rig.writeOutput([]byte(RateLimitMarker + "\n"))
+	if !waitFor(t, 2*time.Second, func() bool { return rig.hits() >= 1 }) {
+		t.Fatalf("expected a usage_limit_hit first, got %d", rig.hits())
+	}
+
+	// Agent resumes: event log advances to "now" (fresh, after the wedge point).
+	rig.tracker.set("cat-test", clock.Now())
+	if !waitFor(t, 2*time.Second, func() bool { return rig.clears() >= 1 }) {
+		t.Fatalf("expected a usage_limit_cleared after events resumed, got %d", rig.clears())
+	}
+	if rig.isRateLimited() {
+		t.Errorf("agent should no longer be rate-limited after clear")
+	}
+}
+
+// The marker quoted in a transcript while the event log stays fresh must NOT
+// trip the hit gate — the ~5m staleness requirement is what disambiguates a
+// real wedge from an agent that merely prints the phrase (reviewer gate).
+func TestModalHook_UsageLimit_QuotedMarkerNoHit(t *testing.T) {
+	clock := &fakeClock{now: time.Unix(1_700_000_000, 0)}
+	rig := newTestRig(clock.Now)
+	rig.tracker.set("cat-test", clock.Now()) // events fresh
+
+	prev := setEventsStalePollIntervalForTest(20 * time.Millisecond)
+	defer setEventsStalePollIntervalForTest(prev)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go RunModalHook(ctx, rig.deps("cat-test"), testMatchers())
+	if !waitFor(t, time.Second, func() bool {
+		rig.mu.Lock()
+		ok := rig.scanner != nil
+		rig.mu.Unlock()
+		return ok
+	}) {
+		t.Fatalf("scanner never subscribed")
+	}
+
+	rig.writeOutput([]byte("narration: I will think about \"" + RateLimitMarker + "\" now.\n"))
+	for i := 0; i < 8; i++ {
+		time.Sleep(20 * time.Millisecond)
+		rig.tracker.set("cat-test", clock.Now())
+	}
+	if rig.hits() != 0 {
+		t.Errorf("quoted marker with fresh events must not trip a hit, got %d", rig.hits())
+	}
+	if rig.isRateLimited() {
+		t.Errorf("agent must not be flagged rate-limited on a quoted marker")
 	}
 }
 

--- a/internal/claude/usagelimit.go
+++ b/internal/claude/usagelimit.go
@@ -1,0 +1,186 @@
+// Fleet usage-limit episode coordinator (gh #45).
+//
+// The modal watcher runs one goroutine per agent, so a fleet-wide usage-limit
+// event (the provider's weekly limit hits every agent at once) would produce
+// one operator mail per agent — an N-agent notification storm. pm-pogo's
+// adjustment: coalesce to ONE mail per fleet-wide episode at hit and ONE at
+// clear.
+//
+// An "episode" opens when the first agent is reported rate-limited and closes
+// when the last rate-limited agent clears. Agents that join a live episode are
+// added to the roster silently. The hit mail fires on episode open; the clear
+// mail fires on episode close and carries a resume checklist naming every agent
+// that was limited during the episode, its work item, and a suggested recovery
+// command. Both mails go to `human`, riding the existing notify bridge (pogo
+// adds no new notifier).
+package claude
+
+import (
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/drellem2/pogo/internal/client"
+)
+
+// agentLimitInfo is one agent's membership in a usage-limit episode.
+type agentLimitInfo struct {
+	agentID    string
+	workItemID string
+	since      time.Time
+}
+
+// usageLimitCoordinator coalesces per-agent hit/clear signals into one mail per
+// fleet-wide episode. All state is guarded by mu; the send call is made outside
+// the lock so a slow mail write never blocks a modal-watcher goroutine holding
+// the fleet lock.
+type usageLimitCoordinator struct {
+	mu     sync.Mutex
+	active map[string]agentLimitInfo // currently rate-limited agents
+	roster map[string]agentLimitInfo // every agent limited during the open episode
+	send   func(to, from, subject, body string) error
+	now    func() time.Time
+}
+
+func newUsageLimitCoordinator(send func(to, from, subject, body string) error, now func() time.Time) *usageLimitCoordinator {
+	if now == nil {
+		now = time.Now
+	}
+	return &usageLimitCoordinator{
+		active: map[string]agentLimitInfo{},
+		roster: map[string]agentLimitInfo{},
+		send:   send,
+		now:    now,
+	}
+}
+
+// OnHit records agentID as rate-limited. If this opens a new episode (the
+// active set was empty), it sends the coalesced hit mail. Re-reporting an
+// already-active agent is a no-op, so the modal watcher can call this on every
+// gate evaluation.
+func (c *usageLimitCoordinator) OnHit(agentID, workItemID string, when time.Time) {
+	c.mu.Lock()
+	if _, ok := c.active[agentID]; ok {
+		c.mu.Unlock()
+		return
+	}
+	info := agentLimitInfo{agentID: agentID, workItemID: workItemID, since: when}
+	newEpisode := len(c.active) == 0
+	c.active[agentID] = info
+	c.roster[agentID] = info
+	send := c.send
+	c.mu.Unlock()
+
+	if newEpisode && send != nil {
+		subject, body := hitMail(info)
+		if err := send("human", "pogod", subject, body); err != nil {
+			log.Printf("usage-limit: failed to send hit mail: %v", err)
+		}
+	}
+}
+
+// OnClear removes agentID from the active set. When that empties the set the
+// episode closes: it snapshots and resets the roster and sends the coalesced
+// clear mail with the resume checklist. Clearing an agent that isn't active is
+// a no-op.
+func (c *usageLimitCoordinator) OnClear(agentID string, when time.Time) {
+	c.mu.Lock()
+	if _, ok := c.active[agentID]; !ok {
+		c.mu.Unlock()
+		return
+	}
+	delete(c.active, agentID)
+	if len(c.active) > 0 {
+		c.mu.Unlock()
+		return
+	}
+	roster := make([]agentLimitInfo, 0, len(c.roster))
+	for _, v := range c.roster {
+		roster = append(roster, v)
+	}
+	c.roster = map[string]agentLimitInfo{}
+	send := c.send
+	c.mu.Unlock()
+
+	if send != nil {
+		subject, body := clearMail(roster, when)
+		if err := send("human", "pogod", subject, body); err != nil {
+			log.Printf("usage-limit: failed to send clear mail: %v", err)
+		}
+	}
+}
+
+// hitMail builds the episode-open mail. It names the first affected agent and
+// explains that more agents may join the same episode silently; the full roster
+// and resume steps arrive in the clear mail.
+func hitMail(first agentLimitInfo) (subject, body string) {
+	subject = "usage limit hit — fleet episode started"
+	var b strings.Builder
+	fmt.Fprintf(&b, "pogod's modal watcher detected a suspected provider usage-limit hit.\n\n")
+	fmt.Fprintf(&b, "First affected agent: %s%s\n", first.agentID, workItemClause(first.workItemID))
+	fmt.Fprintf(&b, "Detected at: %s\n\n", first.since.UTC().Format(time.RFC3339))
+	fmt.Fprintf(&b, "Affected agents are alive but wedged on the rate-limit modal; they now\n")
+	fmt.Fprintf(&b, "report health=rate_limited in `pogo status` and `pogo agent diagnose`\n")
+	fmt.Fprintf(&b, "rather than being mistaken for stalled. To avoid a notification storm,\n")
+	fmt.Fprintf(&b, "additional agents that hit the same limit join this episode silently —\n")
+	fmt.Fprintf(&b, "you'll get ONE follow-up mail with a full resume checklist when the\n")
+	fmt.Fprintf(&b, "episode clears (the limit resets and agents resume producing events).\n\n")
+	fmt.Fprintf(&b, "No action is required now. See docs/operations.md → \"Recovering from a\n")
+	fmt.Fprintf(&b, "usage-limit episode\".\n")
+	return subject, b.String()
+}
+
+// clearMail builds the episode-close mail with a per-agent resume checklist.
+func clearMail(roster []agentLimitInfo, when time.Time) (subject, body string) {
+	sort.Slice(roster, func(i, j int) bool { return roster[i].agentID < roster[j].agentID })
+
+	subject = fmt.Sprintf("usage limit cleared — %d agent(s) recovered", len(roster))
+	var b strings.Builder
+	fmt.Fprintf(&b, "The provider usage-limit episode has cleared as of %s.\n\n", when.UTC().Format(time.RFC3339))
+	fmt.Fprintf(&b, "%d agent(s) were rate-limited during this episode. Each has resumed\n", len(roster))
+	fmt.Fprintf(&b, "producing events (or exited). Resume checklist:\n\n")
+	for _, a := range roster {
+		name := agentNameFromID(a.agentID)
+		fmt.Fprintf(&b, "- %s%s\n", a.agentID, workItemClause(a.workItemID))
+		fmt.Fprintf(&b, "    verify: pogo agent diagnose %s\n", name)
+		fmt.Fprintf(&b, "    if idle: pogo nudge %s \"usage limit reset — resume your task\"\n", name)
+		fmt.Fprintf(&b, "    if exited: pogo agent start %s\n", name)
+	}
+	fmt.Fprintf(&b, "\nSee docs/operations.md → \"Recovering from a usage-limit episode\".\n")
+	return subject, b.String()
+}
+
+func workItemClause(workItemID string) string {
+	if workItemID == "" {
+		return ""
+	}
+	return " (work item " + workItemID + ")"
+}
+
+// agentNameFromID strips the identity prefix (cat-/crew-) from an event-log
+// agent identity to recover the bare agent name that `pogo` verbs take.
+func agentNameFromID(id string) string {
+	for _, p := range []string{"cat-", "crew-"} {
+		if strings.HasPrefix(id, p) {
+			return strings.TrimPrefix(id, p)
+		}
+	}
+	return id
+}
+
+var (
+	usageLimitCoordOnce sync.Once
+	usageLimitCoord     *usageLimitCoordinator
+)
+
+// defaultUsageLimitCoordinator returns the process-wide singleton, lazily
+// wired to client.SendMGMail. Lazy so pure-library callers don't construct it.
+func defaultUsageLimitCoordinator() *usageLimitCoordinator {
+	usageLimitCoordOnce.Do(func() {
+		usageLimitCoord = newUsageLimitCoordinator(client.SendMGMail, time.Now)
+	})
+	return usageLimitCoord
+}

--- a/internal/claude/usagelimit_test.go
+++ b/internal/claude/usagelimit_test.go
@@ -1,0 +1,166 @@
+package claude
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// mailSink captures coordinator mails for assertions.
+type mailSink struct {
+	mu    sync.Mutex
+	mails []sentMail
+}
+
+type sentMail struct {
+	to, from, subject, body string
+}
+
+func (s *mailSink) send(to, from, subject, body string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mails = append(s.mails, sentMail{to, from, subject, body})
+	return nil
+}
+
+func (s *mailSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.mails)
+}
+
+func (s *mailSink) at(i int) sentMail {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mails[i]
+}
+
+func fixedNow() func() time.Time {
+	t := time.Unix(1_700_000_000, 0).UTC()
+	return func() time.Time { return t }
+}
+
+// A single agent hitting and clearing produces exactly one hit + one clear
+// mail, both to human.
+func TestUsageLimitCoordinator_SingleAgentHitAndClear(t *testing.T) {
+	sink := &mailSink{}
+	c := newUsageLimitCoordinator(sink.send, fixedNow())
+	now := fixedNow()()
+
+	c.OnHit("cat-mg-7ffa", "mg-7ffa", now)
+	if sink.count() != 1 {
+		t.Fatalf("expected 1 hit mail, got %d", sink.count())
+	}
+	hit := sink.at(0)
+	if hit.to != "human" {
+		t.Errorf("hit mail to = %q, want human", hit.to)
+	}
+	if !strings.Contains(hit.subject, "hit") {
+		t.Errorf("hit subject = %q, want it to mention hit", hit.subject)
+	}
+	if !strings.Contains(hit.body, "cat-mg-7ffa") {
+		t.Errorf("hit body should name the agent, got %q", hit.body)
+	}
+
+	c.OnClear("cat-mg-7ffa", now.Add(time.Hour))
+	if sink.count() != 2 {
+		t.Fatalf("expected 2 mails after clear, got %d", sink.count())
+	}
+	clear := sink.at(1)
+	if clear.to != "human" {
+		t.Errorf("clear mail to = %q, want human", clear.to)
+	}
+	if !strings.Contains(clear.subject, "cleared") {
+		t.Errorf("clear subject = %q, want it to mention cleared", clear.subject)
+	}
+	// Resume checklist must name the agent + a recovery command.
+	if !strings.Contains(clear.body, "cat-mg-7ffa") ||
+		!strings.Contains(clear.body, "pogo nudge mg-7ffa") {
+		t.Errorf("clear body missing resume checklist entry, got:\n%s", clear.body)
+	}
+}
+
+// Two agents hitting the same episode produce ONE hit mail (not two), and one
+// clear mail that lists BOTH agents in the roster.
+func TestUsageLimitCoordinator_CoalescesFleetEpisode(t *testing.T) {
+	sink := &mailSink{}
+	c := newUsageLimitCoordinator(sink.send, fixedNow())
+	now := fixedNow()()
+
+	c.OnHit("cat-mg-aaaa", "mg-aaaa", now)
+	c.OnHit("cat-mg-bbbb", "mg-bbbb", now.Add(time.Minute))
+	c.OnHit("cat-mg-aaaa", "mg-aaaa", now.Add(2*time.Minute)) // duplicate, no-op
+
+	if sink.count() != 1 {
+		t.Fatalf("expected exactly 1 coalesced hit mail for the episode, got %d", sink.count())
+	}
+
+	// First agent clears — episode still open (second agent active), no mail.
+	c.OnClear("cat-mg-aaaa", now.Add(time.Hour))
+	if sink.count() != 1 {
+		t.Fatalf("clearing one of two agents should not send a mail, got %d", sink.count())
+	}
+
+	// Second agent clears — episode closes, one clear mail listing both.
+	c.OnClear("cat-mg-bbbb", now.Add(2*time.Hour))
+	if sink.count() != 2 {
+		t.Fatalf("expected clear mail after last agent clears, got %d", sink.count())
+	}
+	clear := sink.at(1)
+	if !strings.Contains(clear.body, "cat-mg-aaaa") || !strings.Contains(clear.body, "cat-mg-bbbb") {
+		t.Errorf("clear roster should list both agents, got:\n%s", clear.body)
+	}
+	if !strings.Contains(clear.subject, "2 agent") {
+		t.Errorf("clear subject should report 2 agents, got %q", clear.subject)
+	}
+}
+
+// A second, separate episode after the first fully cleared gets its own hit
+// mail — the roster is reset between episodes.
+func TestUsageLimitCoordinator_SecondEpisodeAfterClear(t *testing.T) {
+	sink := &mailSink{}
+	c := newUsageLimitCoordinator(sink.send, fixedNow())
+	now := fixedNow()()
+
+	c.OnHit("cat-a", "", now)
+	c.OnClear("cat-a", now.Add(time.Hour)) // episode 1 closes (2 mails)
+	c.OnHit("cat-b", "", now.Add(2*time.Hour))
+
+	if sink.count() != 3 {
+		t.Fatalf("expected hit+clear+hit = 3 mails, got %d", sink.count())
+	}
+	// The second episode's clear mail must NOT still carry agent a.
+	c.OnClear("cat-b", now.Add(3*time.Hour))
+	clear := sink.at(3)
+	if strings.Contains(clear.body, "cat-a") {
+		t.Errorf("episode 2 clear should not list episode 1's agent, got:\n%s", clear.body)
+	}
+	if !strings.Contains(clear.body, "cat-b") {
+		t.Errorf("episode 2 clear should list cat-b, got:\n%s", clear.body)
+	}
+}
+
+// Clearing an agent that was never hit is a no-op (no mail, no panic).
+func TestUsageLimitCoordinator_ClearUnknownAgentNoop(t *testing.T) {
+	sink := &mailSink{}
+	c := newUsageLimitCoordinator(sink.send, fixedNow())
+	c.OnClear("cat-ghost", fixedNow()())
+	if sink.count() != 0 {
+		t.Fatalf("clearing an unknown agent should send no mail, got %d", sink.count())
+	}
+}
+
+func TestAgentNameFromID(t *testing.T) {
+	cases := map[string]string{
+		"cat-mg-7ffa": "mg-7ffa",
+		"crew-arch":   "arch",
+		"mayor":       "mayor",
+		"human":       "human",
+	}
+	for in, want := range cases {
+		if got := agentNameFromID(in); got != want {
+			t.Errorf("agentNameFromID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Recognizes a provider usage-limit wedge as a distinct, observable condition instead of a silent stall. Builds phase 1 of the approved plan for #45.

When an agent hits the provider's usage limit, Claude Code shows the rate-limit-options modal and the reasoning loop wedges (stops producing events but stays alive). pogod's modal watcher now detects this off the **existing** event-staleness tracker — no quota/API probe — and surfaces it:

- **Events:** `usage_limit_hit` `{agent, work_item_id, timestamp}` when the marker is recently visible AND the event log is stale past ~5m (`UsageLimitSuspectStaleness`); `usage_limit_cleared` when the event log advances again. The ~5m gate is what prevents false-positives on a transcript that merely quotes the marker text (a seconds-level trigger would fire on ordinary output). The pre-existing 20m auto-dismissal gate is unchanged.
- **Registry flag:** `Agent.RateLimited` (+ `RateLimitedSince`), set at hit, cleared on resume.
- **Surfacing:** `health=rate_limited` in `pogo agent diagnose` (a distinct condition that outranks `stalled`/`idle`, so a limit wait is never mistaken for a wedge) and `⚠ rate-limited` in `pogo status` / `pogo agent list`. Both carried in `--json`.
- **Coalesced operator mail:** ONE mail to `human` per fleet-wide *episode* — one at hit, one at clear — instead of an N-agent storm. The clear mail carries a per-agent resume checklist (which agents were limited, their work items, suggested `pogo agent diagnose` / `pogo nudge` / `pogo agent start`).
- **Docs:** `docs/operations.md` recovery runbook + `docs/event-log.md` catalog entries for the two additive event types (no schema bump).

## Deferred (explicitly not built, per scope)
Auto-resume of waiting agents, a `pogo usage`/`pogo usage status` command, provider quota-API probes.

## Risk
Detection keys off the modal marker text (`"Stop and wait for limit to reset"`); if a future Claude Code version changes that string, detection silently stops until the constant is updated. This is a pre-existing drift risk shared with the modal-dismissal watcher, and it is diagnostic-only (a miss falls back to the pre-#45 `stalled` reading).

## Notes for the reviewer
- `build.sh` / `test.sh` are green.
- `go test -race ./internal/claude/` reports a **pre-existing** data race in `TestModalHook_Case3` (leaked `RunModalHook` goroutines from earlier cases race with the `setEventsStalePollIntervalForTest` global write). It exists identically on `main` and is not part of the gate (`test.sh` runs `go test ./...` without `-race`); I left it out of scope. Happy to file a follow-up.
- Branch is `polecat-gh45b` (the worktree name); work item `mg-7ffa`.

Resolves drellem2/pogo#45

Approved triage recommendation: mg-781b (see its result packet + mayor mail 2026-07-06T03:51:45Z; public plan at https://github.com/drellem2/pogo/issues/45#issuecomment-4893044145)
Work item: mg-7ffa