### PR TITLE
fix: reap-after-merge id mismatch — resolve polecat by work-item id (drellem2/pogo#48)

### DIFF
--- a/cmd/pogod/main.go
+++ b/cmd/pogod/main.go
@@ -852,23 +852,7 @@ Flags:
 			fmt.Printf("Warning: refinery failed to start: %v\n", refErr)
 		} else {
 			mergeQueue.SetOnSubmit(func(mr *refinery.MergeRequest) {
-				// When a polecat submits an MR, unlink its worktree so the
-				// branch is no longer marked as "checked out" in the source
-				// repo. This prevents "already checked out" errors in the
-				// refinery's clone. The polecat's directory is left intact
-				// so it can continue polling for merge results.
-				if mr.Author == "" {
-					return
-				}
-				a := agentRegistry.Get(mr.Author)
-				if a == nil || a.WorktreeDir == "" || a.SourceRepo == "" {
-					return
-				}
-				if err := refinery.UnlinkWorktree(a.SourceRepo, a.WorktreeDir); err != nil {
-					log.Printf("refinery: failed to unlink polecat worktree for %s: %v", mr.Author, err)
-				} else {
-					log.Printf("refinery: unlinked polecat worktree for %s at %s", mr.Author, a.WorktreeDir)
-				}
+				unlinkSubmittedPolecatWorktree(agentRegistry, mr, refinery.UnlinkWorktree)
 			})
 			mergeQueue.SetOnMerged(func(mr *refinery.MergeRequest) {
 				log.Printf("refinery: merged %s (branch=%s, author=%s)", mr.ID, mr.Branch, mr.Author)

--- a/cmd/pogod/reap.go
+++ b/cmd/pogod/reap.go
@@ -16,7 +16,7 @@ const mergedPolecatStopTimeout = 5 * time.Second
 
 // polecatReaper is the slice of agent.Registry that reapMergedPolecat needs.
 type polecatReaper interface {
-	Get(name string) *agent.Agent
+	GetByWorkItemOrName(id string) *agent.Agent
 	Stop(name string, timeout time.Duration) error
 }
 
@@ -38,7 +38,11 @@ func reapMergedPolecat(reg polecatReaper, mr *refinery.MergeRequest, complete fu
 	if mr.Author == "" {
 		return
 	}
-	a := reg.Get(mr.Author)
+	// Resolve by work-item id OR registry name: a polecat registers under its
+	// bare id (a.Name, e.g. "d087") but authors its MR with the full work-item
+	// id (mr.Author == a.WorkItemID, e.g. "mg-d087"), so a plain Get(mr.Author)
+	// misses and the polecat lingers post-merge (gh #48).
+	a := reg.GetByWorkItemOrName(mr.Author)
 	if a == nil || a.Type != agent.TypePolecat {
 		return
 	}
@@ -46,7 +50,8 @@ func reapMergedPolecat(reg polecatReaper, mr *refinery.MergeRequest, complete fu
 	// Record completion before stopping: the polecat's own protocol runs
 	// mg done when it observes the merged status, but it will be gone
 	// before its next poll. If the polecat won the race after all, the
-	// call fails with an already-done error — harmless.
+	// call fails with an already-done error — harmless. Keyed on mr.Author,
+	// which is the mg work-item id.
 	result, _ := json.Marshal(map[string]string{
 		"branch":       mr.Branch,
 		"mr":           mr.ID,
@@ -56,9 +61,42 @@ func reapMergedPolecat(reg polecatReaper, mr *refinery.MergeRequest, complete fu
 		log.Printf("refinery: mg done %s on merged polecat's behalf failed (may already be done): %v", mr.Author, err)
 	}
 
-	if err := reg.Stop(mr.Author, mergedPolecatStopTimeout); err != nil {
-		log.Printf("refinery: failed to stop merged polecat %s: %v", mr.Author, err)
+	// Stop keys on the registry name, which is the bare id — not mr.Author.
+	if err := reg.Stop(a.Name, mergedPolecatStopTimeout); err != nil {
+		log.Printf("refinery: failed to stop merged polecat %s: %v", a.Name, err)
 		return
 	}
-	log.Printf("refinery: stopped merged polecat %s (event-driven, gh #35)", mr.Author)
+	log.Printf("refinery: stopped merged polecat %s (event-driven, gh #35)", a.Name)
+}
+
+// worktreeUnlinker is the slice of agent.Registry that
+// unlinkSubmittedPolecatWorktree needs.
+type worktreeUnlinker interface {
+	GetByWorkItemOrName(id string) *agent.Agent
+}
+
+// unlinkSubmittedPolecatWorktree runs on the refinery's OnSubmit hook: when a
+// polecat submits an MR, its worktree is unlinked so the branch is no longer
+// marked "checked out" in the source repo, which would otherwise trigger
+// "already checked out" errors in the refinery's clone. The polecat's directory
+// is left intact so it can keep polling for merge results.
+//
+// Like reapMergedPolecat, it resolves the polecat by work-item id OR registry
+// name: mr.Author carries the full work-item id (== a.WorkItemID) while the
+// polecat registers under its bare id (a.Name), so a plain Get(mr.Author)
+// misses — the same gh #48 defect as the reap path. unlink is injected so the
+// hook is testable without touching git.
+func unlinkSubmittedPolecatWorktree(reg worktreeUnlinker, mr *refinery.MergeRequest, unlink func(sourceRepo, worktreeDir string) error) {
+	if mr.Author == "" {
+		return
+	}
+	a := reg.GetByWorkItemOrName(mr.Author)
+	if a == nil || a.WorktreeDir == "" || a.SourceRepo == "" {
+		return
+	}
+	if err := unlink(a.SourceRepo, a.WorktreeDir); err != nil {
+		log.Printf("refinery: failed to unlink polecat worktree for %s: %v", mr.Author, err)
+	} else {
+		log.Printf("refinery: unlinked polecat worktree for %s at %s", mr.Author, a.WorktreeDir)
+	}
 }

--- a/cmd/pogod/reap_test.go
+++ b/cmd/pogod/reap_test.go
@@ -11,23 +11,43 @@ import (
 )
 
 // fakeReaper is a polecatReaper backed by a static agent map, recording
-// Stop calls.
+// Stop calls. Its GetByWorkItemOrName mirrors the real registry: a direct
+// key (registry name) lookup first, then a scan by WorkItemID — so a polecat
+// registered under its bare id resolves from the full work-item id an MR
+// carries as its author.
 type fakeReaper struct {
 	agents  map[string]*agent.Agent
 	stopped []string
 	stopErr error
 }
 
-func (f *fakeReaper) Get(name string) *agent.Agent { return f.agents[name] }
+func (f *fakeReaper) GetByWorkItemOrName(id string) *agent.Agent {
+	if id == "" {
+		return nil
+	}
+	if a := f.agents[id]; a != nil {
+		return a
+	}
+	for _, a := range f.agents {
+		if a.WorkItemID == id {
+			return a
+		}
+	}
+	return nil
+}
 
 func (f *fakeReaper) Stop(name string, timeout time.Duration) error {
 	f.stopped = append(f.stopped, name)
 	return f.stopErr
 }
 
+// TestReapMergedPolecat_StopsPolecatAndMarksDone is the gh #48 regression: the
+// polecat is registered under its BARE id ("1234") but authors its MR with the
+// FULL work-item id ("mg-1234"). Reap must (a) resolve it via WorkItemID, (b)
+// mg done the FULL id (mr.Author), and (c) Stop the BARE id (registry name).
 func TestReapMergedPolecat_StopsPolecatAndMarksDone(t *testing.T) {
 	reg := &fakeReaper{agents: map[string]*agent.Agent{
-		"mg-1234": {Name: "mg-1234", Type: agent.TypePolecat},
+		"1234": {Name: "1234", WorkItemID: "mg-1234", Type: agent.TypePolecat},
 	}}
 	var completedID, completedResult string
 	complete := func(id, resultJSON string) error {
@@ -40,7 +60,7 @@ func TestReapMergedPolecat_StopsPolecatAndMarksDone(t *testing.T) {
 	reapMergedPolecat(reg, mr, complete)
 
 	if completedID != "mg-1234" {
-		t.Errorf("expected mg done for mg-1234, got %q", completedID)
+		t.Errorf("expected mg done for work-item id mg-1234, got %q", completedID)
 	}
 	var result map[string]string
 	if err := json.Unmarshal([]byte(completedResult), &result); err != nil {
@@ -49,8 +69,10 @@ func TestReapMergedPolecat_StopsPolecatAndMarksDone(t *testing.T) {
 	if result["branch"] != "polecat-mg-1234" || result["mr"] != "mr-42" || result["completed_by"] != "refinery" {
 		t.Errorf("unexpected result sidecar: %q", completedResult)
 	}
-	if len(reg.stopped) != 1 || reg.stopped[0] != "mg-1234" {
-		t.Errorf("expected exactly one Stop(mg-1234), got %v", reg.stopped)
+	// Stop must key on the registry name (bare id), not mr.Author — otherwise
+	// the lookup succeeds but the stop silently misses and the polecat lingers.
+	if len(reg.stopped) != 1 || reg.stopped[0] != "1234" {
+		t.Errorf("expected exactly one Stop(1234) keyed on bare name, got %v", reg.stopped)
 	}
 }
 
@@ -99,21 +121,21 @@ func TestReapMergedPolecat_StopsEvenWhenDoneFails(t *testing.T) {
 	// "Already done" (the polecat won the race) must not leave the polecat
 	// running.
 	reg := &fakeReaper{agents: map[string]*agent.Agent{
-		"mg-1234": {Name: "mg-1234", Type: agent.TypePolecat},
+		"1234": {Name: "1234", WorkItemID: "mg-1234", Type: agent.TypePolecat},
 	}}
 	complete := func(string, string) error { return errors.New("mg done failed: already done") }
 
 	reapMergedPolecat(reg, &refinery.MergeRequest{ID: "mr-1", Branch: "b", Author: "mg-1234"}, complete)
 
-	if len(reg.stopped) != 1 || reg.stopped[0] != "mg-1234" {
-		t.Errorf("expected Stop(mg-1234) despite mg done failure, got %v", reg.stopped)
+	if len(reg.stopped) != 1 || reg.stopped[0] != "1234" {
+		t.Errorf("expected Stop(1234) despite mg done failure, got %v", reg.stopped)
 	}
 }
 
 func TestReapMergedPolecat_StopFailureIsNonFatal(t *testing.T) {
 	reg := &fakeReaper{
 		agents: map[string]*agent.Agent{
-			"mg-1234": {Name: "mg-1234", Type: agent.TypePolecat},
+			"1234": {Name: "1234", WorkItemID: "mg-1234", Type: agent.TypePolecat},
 		},
 		stopErr: errors.New("agent wedged"),
 	}
@@ -121,5 +143,83 @@ func TestReapMergedPolecat_StopFailureIsNonFatal(t *testing.T) {
 	// Must not panic; the mayor's backstop picks up the still-running polecat.
 	if len(reg.stopped) != 1 {
 		t.Errorf("expected one Stop attempt, got %v", reg.stopped)
+	}
+}
+
+// fakeUnlinker is a worktreeUnlinker backed by a static agent map, using the
+// same name-or-work-item resolution as the real registry.
+type fakeUnlinker struct {
+	agents map[string]*agent.Agent
+}
+
+func (f *fakeUnlinker) GetByWorkItemOrName(id string) *agent.Agent {
+	if id == "" {
+		return nil
+	}
+	if a := f.agents[id]; a != nil {
+		return a
+	}
+	for _, a := range f.agents {
+		if a.WorkItemID == id {
+			return a
+		}
+	}
+	return nil
+}
+
+// TestUnlinkSubmittedPolecatWorktree_ResolvesByWorkItemID is the OnSubmit twin
+// of the gh #48 regression: a polecat registered under its BARE id must have
+// its worktree unlinked when the MR it submits carries the FULL work-item id.
+func TestUnlinkSubmittedPolecatWorktree_ResolvesByWorkItemID(t *testing.T) {
+	reg := &fakeUnlinker{agents: map[string]*agent.Agent{
+		"1234": {
+			Name:        "1234",
+			WorkItemID:  "mg-1234",
+			Type:        agent.TypePolecat,
+			WorktreeDir: "/wt/1234",
+			SourceRepo:  "/src/pogo",
+		},
+	}}
+	var gotSource, gotWorktree string
+	unlink := func(sourceRepo, worktreeDir string) error {
+		gotSource, gotWorktree = sourceRepo, worktreeDir
+		return nil
+	}
+
+	mr := &refinery.MergeRequest{ID: "mr-7", Branch: "polecat-mg-1234", Author: "mg-1234"}
+	unlinkSubmittedPolecatWorktree(reg, mr, unlink)
+
+	if gotSource != "/src/pogo" || gotWorktree != "/wt/1234" {
+		t.Errorf("expected unlink(/src/pogo, /wt/1234), got unlink(%q, %q)", gotSource, gotWorktree)
+	}
+}
+
+func TestUnlinkSubmittedPolecatWorktree_IgnoresEmptyAuthor(t *testing.T) {
+	reg := &fakeUnlinker{agents: map[string]*agent.Agent{}}
+	called := false
+	unlinkSubmittedPolecatWorktree(reg, &refinery.MergeRequest{ID: "mr-1", Branch: "b"}, func(string, string) error {
+		called = true
+		return nil
+	})
+	if called {
+		t.Error("expected no unlink for authorless MR")
+	}
+}
+
+func TestUnlinkSubmittedPolecatWorktree_IgnoresUnknownAndWorktreeless(t *testing.T) {
+	// Unknown author, and a known agent without worktree metadata, are both
+	// no-ops.
+	reg := &fakeUnlinker{agents: map[string]*agent.Agent{
+		"1234": {Name: "1234", WorkItemID: "mg-1234", Type: agent.TypePolecat},
+	}}
+	for _, author := range []string{"mg-gone", "mg-1234"} {
+		called := false
+		unlinkSubmittedPolecatWorktree(reg, &refinery.MergeRequest{ID: "mr-1", Branch: "b", Author: author}, func(string, string) error {
+			called = true
+			return nil
+		})
+		if called {
+			t.Errorf("expected no unlink for author %q (missing worktree metadata)", author)
+		}
 	}
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -762,6 +762,32 @@ func (r *Registry) Get(name string) *Agent {
 	return r.agents[name]
 }
 
+// GetByWorkItemOrName resolves an agent by matching id against either the
+// agent's registry Name or its WorkItemID, returning nil if neither matches.
+//
+// This exists because a polecat registers under its bare id (agent Name, e.g.
+// "d087") while a merge request it authors carries the full work-item id (e.g.
+// "mg-d087"): a plain Get(mr.Author) misses. Matching WorkItemID == id is
+// prefix-agnostic and robust — it works regardless of the mg-/ca- prefix in
+// use — while the Name fallback preserves lookups keyed on the bare id. A fast
+// direct Get is tried first; the WorkItemID scan runs only on a Name miss.
+func (r *Registry) GetByWorkItemOrName(id string) *Agent {
+	if id == "" {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if a := r.agents[id]; a != nil {
+		return a
+	}
+	for _, a := range r.agents {
+		if a.WorkItemID == id {
+			return a
+		}
+	}
+	return nil
+}
+
 // List returns all running agents sorted by type (crew first) then name.
 func (r *Registry) List() []*Agent {
 	r.mu.RLock()

--- a/internal/agent/getbyworkitem_test.go
+++ b/internal/agent/getbyworkitem_test.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestGetByWorkItemOrName locks the gh #48 resolution contract: an agent
+// registered under its bare id resolves both from that bare id (Name) and from
+// the full work-item id (WorkItemID) an authored MR carries, while a plain Get
+// only matches the registry key.
+func TestGetByWorkItemOrName(t *testing.T) {
+	reg, err := NewRegistry(filepath.Join(t.TempDir(), "sockets"))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	bare := &Agent{Name: "1234", WorkItemID: "mg-1234", Type: TypePolecat}
+	noItem := &Agent{Name: "mayor", Type: TypeCrew}
+	reg.agents["1234"] = bare
+	reg.agents["mayor"] = noItem
+
+	tests := []struct {
+		name string
+		id   string
+		want *Agent
+	}{
+		{"bare name (registry key)", "1234", bare},
+		{"full work-item id", "mg-1234", bare},
+		{"name with no work-item id", "mayor", noItem},
+		{"empty id", "", nil},
+		{"unknown id", "mg-gone", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := reg.GetByWorkItemOrName(tt.id); got != tt.want {
+				t.Errorf("GetByWorkItemOrName(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+
+	// The bug: a plain Get keyed on the full work-item id misses.
+	if got := reg.Get("mg-1234"); got != nil {
+		t.Errorf("Get(mg-1234) should miss (registry key is bare), got %v", got)
+	}
+}


### PR DESCRIPTION
## Problem

A polecat registers in the agent registry under its **bare id** (agent `Name`, e.g. `d087`), but the merge request it authors carries the **full work-item id** as author (`mr.Author == a.WorkItemID`, e.g. `mg-d087`). Both the event-driven reap path and the OnSubmit worktree-unlink hook did `reg.Get(mr.Author)`, which misses the bare registry key and returns `nil` — so the merged polecat was never `Stop`ped and lingered post-merge holding a slot + a live process. This defeats gh #35 and was reproduced live (e726, b383 lingered; mayor stopped them manually as a workaround).

## Fix

- Add `Registry.GetByWorkItemOrName(id)`, which resolves an agent by matching `id` against **both** `a.Name` and `a.WorkItemID`. Since `WorkItemID == mr.Author` exactly, this is prefix-agnostic — no `mg-`/`ca-` string stripping. Fast direct-key lookup first; the `WorkItemID` scan runs only on a name miss.
- Apply it at both `Get(mr.Author)` sites:
  - `cmd/pogod/reap.go` (`reapMergedPolecat`) — the reported path. `reg.Stop` now keys on `a.Name` (the registry key), not `mr.Author`, so the stop actually lands; `mg done` still keys on `mr.Author` (the work-item id), which is correct.
  - `cmd/pogod/main.go` OnSubmit hook — the identical latent bug. Its body is extracted into `unlinkSubmittedPolecatWorktree` (in `reap.go`) so it is unit-testable with an injected unlink func.

Rejected in triage (not taken here): prefix-strip (brittle), system-wide id-unification (large blast radius).

## Tests

- `reap_test.go`: both paths asserted for a polecat registered as `<bare>` when `mr.Author == <full>` — reap → `Stop(<bare>)` + `mg done <full>`, and OnSubmit → unlink. The prior reap test passed only because it registered under the full id, baking in the false `Name == full-id` assumption; it now registers under the bare id.
- `internal/agent/getbyworkitem_test.go`: registry-level contract for `GetByWorkItemOrName` (bare name, full work-item id, no-work-item agent, empty/unknown), plus a guard that plain `Get(<full>)` still misses.

`./build.sh` (fmt + full test + install) green.

Resolves drellem2/pogo#48

Approved triage recommendation: mg-d087 (see mg-d087.result.json)
Work item: mg-a58e