### PR TITLE
coordinator priority-wake platform W-1/W-2/W-4 (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ is the curated, human-readable summary kept in sync at each release cut.
 ## [Unreleased]
 
 ### Added
+- **Coordinator priority wake** (gh #61, mg-b1d9). The stall watcher now has a
+  priority-aware branch: a **ready, high-priority** `available` work item
+  assigned to (or unassigned and pickup-expected by) the watched coordinator
+  bypasses the 10-minute unclaimed-item gate and is delivered after a short
+  `high_priority_wake_delay` (default 30s) via the **same wait-idle nudge** — so
+  a busy coordinator is never interrupted mid-turn and an idle one is woken at
+  once. This closes the idle-latency gap where a `priority = high` item with no
+  accompanying mail could wait up to ~30 minutes for pickup. A dedicated
+  `high_priority_wake_cooldown` (default 3m) plus scanning only `available/`
+  (never `pending/` or `claimed/`) means a blocked, gated, or already-claimed
+  item cannot loop-nudge. New `[stall_watch]` knobs: `priority_wake_enabled`
+  (default true), `high_priority_wake_delay`, `high_priority_wake_cooldown`,
+  `fast_priorities` (default `["high"]`). The wake policy lives entirely in
+  pogod, keyed off the generic `WorkItem.Priority` field — no `mg` flag, no
+  mg→pogod event. See [docs/design/priority-wake-design.md](docs/design/priority-wake-design.md).
 - **Install default-migration guard** (mg-7d95, flavor-rename mechanism). On an
   *existing* install, `pogo install` and pogod boot now pin the current role
   defaults (`coordinator = "mayor"`, `worker = "polecat"`) into `config.toml`

--- a/cmd/pogod/main.go
+++ b/cmd/pogod/main.go
@@ -516,6 +516,30 @@ func resolveAgentProvider(id string) *agent.Provider {
 	return p
 }
 
+// newStallNudger builds the stall watcher's delivery function, mirroring the
+// scheduler's PogodDeliverer: when the target agent is running, deliver via the
+// PTY in wait-idle mode; otherwise fall back to durable macguffin mail so the
+// signal survives an offline recipient.
+//
+// The wait-idle mode is the load-bearing choice for gh drellem2/pogo #61: it
+// blocks until the agent's PTY goes quiet before writing, so a BUSY agent is
+// never interrupted mid-turn (the write lands at the next turn boundary) and an
+// idle agent is woken at once. The priority wake reuses this exact nudger — it
+// does not introduce a second, more aggressive delivery path — so it inherits
+// the never-interrupt-a-busy-agent guarantee. Extracted from main so the
+// wait-idle behavior is unit-testable (see main_stallnudger_test.go).
+func newStallNudger(reg *agent.Registry, mail func(to, from, subject, body string) error) stallwatch.Nudger {
+	return func(agentName, message string) error {
+		if reg != nil {
+			a := reg.Get(agentName)
+			if a != nil && a.Status == agent.StatusRunning {
+				return a.NudgeWithMode(message, agent.NudgeWaitIdle, agent.DefaultNudgeTimeout)
+			}
+		}
+		return mail(agentName, "stall-watch", "stall-watch: work piling up", message)
+	}
+}
+
 func main() {
 	flag.Usage = func() {
 		fmt.Fprint(flag.CommandLine.Output(), `pogod — the pogo daemon.
@@ -774,23 +798,19 @@ Flags:
 	var stallWatcher *stallwatch.Watcher
 	if cfg.StallWatch.Enabled {
 		stallWatcher = stallwatch.New(cfg.StallWatch, stallwatch.Options{
-			// Mirror the scheduler's PogodDeliverer: nudge the PTY when the
-			// agent is running, fall back to mail so the signal is durable when
-			// it is offline.
-			Nudge: func(agentName, message string) error {
-				if agentRegistry != nil {
-					a := agentRegistry.Get(agentName)
-					if a != nil && a.Status == agent.StatusRunning {
-						return a.NudgeWithMode(message, agent.NudgeWaitIdle, agent.DefaultNudgeTimeout)
-					}
-				}
-				return client.SendMGMail(agentName, "stall-watch", "stall-watch: work piling up", message)
-			},
+			Nudge: newStallNudger(agentRegistry, client.SendMGMail),
+			// Let a priority wake short-circuit the ~30s heartbeat poll for a
+			// prompt follow-up sweep (gh #61). hb.Nudge coalesces, so this can't
+			// storm the loop; the priority cooldown bounds it to one extra tick
+			// per wake.
+			FastPoll: hb.Nudge,
 		})
-		log.Printf("pogod: stall watcher enabled (agent=%s item_age=%s mail_age=%s max_mail=%d cooldown=%s)",
+		log.Printf("pogod: stall watcher enabled (agent=%s item_age=%s mail_age=%s max_mail=%d cooldown=%s priority_wake=%t wake_delay=%s wake_cooldown=%s fast_priorities=%s)",
 			cfg.StallWatch.Agent, cfg.StallWatch.UnclaimedItemAgeThreshold,
 			cfg.StallWatch.UnreadMailAgeThreshold, cfg.StallWatch.MaxUnreadMailCount,
-			cfg.StallWatch.NudgeCooldown)
+			cfg.StallWatch.NudgeCooldown, cfg.StallWatch.PriorityWakeEnabled,
+			cfg.StallWatch.HighPriorityWakeDelay, cfg.StallWatch.HighPriorityWakeCooldown,
+			strings.Join(cfg.StallWatch.FastPriorities, ","))
 	}
 
 	// Drive both heartbeat-piggybacked subsystems from a single OnTick. The

--- a/cmd/pogod/main_stallnudger_test.go
+++ b/cmd/pogod/main_stallnudger_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drellem2/pogo/internal/agent"
+)
+
+// TestStallNudgerNeverInterruptsBusyAgent is the end-to-end proof of gh
+// drellem2/pogo #61 review point (a): the priority wake reuses newStallNudger,
+// and the nudger delivers in wait-idle mode, so a BUSY agent (PTY never quiet)
+// is never interrupted mid-turn — the wake message never reaches its PTY. This
+// complements internal/agent TestNudgeWithModeWaitIdleTimeoutOnBusy (which
+// proves the wait-idle primitive) by exercising the exact function the stall
+// watcher and priority wake call.
+func TestStallNudgerNeverInterruptsBusyAgent(t *testing.T) {
+	reg, err := agent.NewRegistry(filepath.Join(t.TempDir(), "sockets"))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	// A shell that prints forever — the PTY is never quiet, so the agent never
+	// satisfies the 2s idle threshold and wait-idle can never deliver.
+	a, err := reg.Spawn(agent.SpawnRequest{
+		Name:    "busy-coordinator",
+		Type:    agent.TypeCrew,
+		Command: []string{"sh", "-c", "while true; do printf x; sleep 0.05; done"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait until it is genuinely busy (has produced output), not just-spawned.
+	deadline := time.Now().Add(2 * time.Second)
+	for len(a.RecentOutput(16)) == 0 && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if len(a.RecentOutput(16)) == 0 {
+		t.Fatal("busy agent never produced output")
+	}
+
+	nudge := newStallNudger(reg, func(to, from, subject, body string) error {
+		t.Errorf("must not fall back to mail for a running agent (would double-deliver)")
+		return nil
+	})
+
+	// Deliver in the background — wait-idle blocks up to DefaultNudgeTimeout
+	// against a never-quiet agent. StopAll (deferred) unblocks it at teardown.
+	const sentinel = "PRIORITY_WAKE_SENTINEL"
+	go func() { _ = nudge("busy-coordinator", sentinel) }()
+
+	// Sleep well past the 2s idle threshold: an IDLE agent would have been
+	// delivered to by now, so if the sentinel is still absent the busy agent was
+	// genuinely never interrupted (not merely still-within-the-idle-wait).
+	time.Sleep(3 * time.Second)
+	if strings.Contains(string(a.RecentOutput(1<<16)), sentinel) {
+		t.Fatal("wait-idle nudge interrupted a busy agent — the wake reached its PTY")
+	}
+}
+
+// TestStallNudgerFallsBackToMailWhenOffline: when the target agent is not
+// registered/running, the nudger delivers via macguffin mail so the signal is
+// durable rather than dropped.
+func TestStallNudgerFallsBackToMailWhenOffline(t *testing.T) {
+	reg, err := agent.NewRegistry(filepath.Join(t.TempDir(), "sockets"))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	var got struct{ to, from, subject, body string }
+	mailed := false
+	nudge := newStallNudger(reg, func(to, from, subject, body string) error {
+		mailed = true
+		got.to, got.from, got.subject, got.body = to, from, subject, body
+		return nil
+	})
+
+	if err := nudge("ghost-agent", "priority-wake: urgent"); err != nil {
+		t.Fatalf("nudge: %v", err)
+	}
+	if !mailed {
+		t.Fatal("expected mail fallback for an unregistered agent")
+	}
+	if got.to != "ghost-agent" || got.body != "priority-wake: urgent" {
+		t.Errorf("mail routed wrong: to=%q body=%q", got.to, got.body)
+	}
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -154,10 +154,46 @@ unclaimed_item_age_threshold = "10m"    # Threshold A
 unread_mail_age_threshold = "10m"       # Threshold B (age)
 max_unread_mail_count = 5               # Threshold B (count)
 nudge_cooldown = "5m"                   # min gap between same-category nudges
+
+# Priority wake (gh #61): a high-priority available item skips the 10m gate.
+priority_wake_enabled = true            # default true
+high_priority_wake_delay = "30s"        # min age before a high-priority item wakes
+high_priority_wake_cooldown = "3m"      # min gap between priority-wake nudges
+fast_priorities = ["high"]              # Priority values that trigger the wake
 ```
 
+### Priority wake
+
+Threshold A treats every unclaimed item the same — it waits out the full
+`unclaimed_item_age_threshold` (10m) regardless of priority. That is the wrong
+latency for urgent work: when the coordinator is idle and has backed its polling
+off, a `priority = high` item with no accompanying mail could sit up to ~30
+minutes before pickup (gh drellem2/pogo #61).
+
+The priority wake is a priority-aware branch on the *same* 30s available/ scan.
+An item that is **ready** (deps met — it is in `available/`, not `pending/`),
+**assigned to the watched agent** (or unassigned), and carries a priority in
+`fast_priorities` bypasses the 10m gate and is delivered after only
+`high_priority_wake_delay` — via the **same wait-idle nudge**, so a busy agent is
+never interrupted (the write lands at its next turn boundary) and an idle agent
+is woken at once. A dedicated `high_priority_wake_cooldown` keeps an item that
+stays available (e.g. it can't be dispatched yet) from re-nudging every tick;
+blocked (`pending/`) and already-claimed (`claimed/`) items are never scanned, so
+they cannot loop-nudge either. When the wake is disabled, high-priority items
+fall back to the standard 10m gate — disabling it never silences them.
+
+This is a sanctioned system-event nudge (gh #33), not a producer-attributed ask:
+the wake policy lives entirely in pogod, keyed off the generic
+`WorkItem.Priority` field, so `mg` stays a decoupled work queue with no
+pogo-specific "wake" flag.
+
+Note on `pogo agent diagnose`: diagnose measures a coordinator's health against
+its ~30-min backstop cron, so it does **not** surface this idle-latency gap — the
+priority wake, not diagnose, is the real fast path for urgent work.
+
 Source of truth: `internal/stallwatch/`; see
-[docs/design/stall-watch-design.md](design/stall-watch-design.md).
+[docs/design/stall-watch-design.md](design/stall-watch-design.md) and
+[docs/design/priority-wake-design.md](design/priority-wake-design.md).
 
 ## Agent registry
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -15,6 +15,7 @@ doubt, the code is the source of truth.
 | [mg-domain-audit.md](mg-domain-audit.md) | Whether macguffin's work-item store is domain-neutral (not coding-specific) | Audit; durable orientation, concrete follow-ups filed separately |
 | [multi-provider-architecture-survey.md](multi-provider-architecture-survey.md) | Phase 2: provider-abstraction architecture (design-of-record) | Survey; Codex provider since shipped (`internal/codex/`) |
 | [pa-thread-index-design.md](pa-thread-index-design.md) | pa's local-only, pointer-only thread-index git repo (payloads stay in self-mail) | Shipped (mg-da41, decision mg-9a32); machine-local state, archeology |
+| [priority-wake-design.md](priority-wake-design.md) | Priority-aware fast wake so urgent work skips the coordinator idle-polling gap | Shipped (gh #61, `internal/stallwatch/`) |
 | [prompt-customization-design.md](prompt-customization-design.md) | Customizing agent prompts so edits survive `pogo install --force` | Shipped (`internal/agent/tomlmerge.go`); user guide: [../prompt-customization.md](../prompt-customization.md) |
 | [rate-limit-modal-watcher-design.md](rate-limit-modal-watcher-design.md) | Auto-dismissing the Claude API rate-limit-options modal | Shipped (mg-4421, `internal/claude/modal_hook.go`); archeology |
 | [rating-dialog-watcher-design.md](rating-dialog-watcher-design.md) | Auto-dismissing Claude Code's mid-session rating dialog | Shipped (mg-4421, `internal/claude/modal_hook.go`); archeology |

--- a/docs/design/priority-wake-design.md
+++ b/docs/design/priority-wake-design.md
@@ -1,0 +1,111 @@
+# Priority-aware fast wake (coordinator idle-latency)
+
+**Status:** Shipped — gh drellem2/pogo #61, `internal/stallwatch/`.
+**Scope of this doc:** the platform half (W-1 config + branch, W-2 knobs, W-4
+tests/docs). The coordinator prompt's bounded idle-backoff (W-3, `mayor.md`) is a
+separate, prompt-only change tracked independently.
+
+## The problem
+
+The coordinator runs two timers: a fast in-harness self-wake (30–60s while
+busy) and a ~30-min pogo-schedule backstop. When the queue is quiet it lengthens
+its own self-wake to conserve tokens and coasts near the backstop cadence. That
+is reasonable — *except* that a `priority = high` work item which arrives with no
+accompanying mail has no fast path: it waits out whichever timer fires next,
+up to ~30 minutes, and worst exactly when the system is idle. Observed with a
+high-priority voice-pr dispatch.
+
+`pogo agent diagnose` does **not** reveal this: it measures coordinator health
+against the ~30-min backstop cron, so an item picked up "within one cron
+interval" looks healthy while a human waited half an hour.
+
+## Why not a new IPC channel
+
+pogod cannot cheaply wake an agent parked on its in-harness self-wake without a
+PTY write — a file flag or a mail the coordinator only reads on its *next* cycle
+cannot reduce idle latency, because the parked coordinator won't look until it
+wakes on its own anyway. The one inbound channel that already collapses idle
+latency *without* interrupting in-flight work is the existing **wait-idle
+nudge**: for an idle agent the PTY is quiescent so it fires promptly; for a busy
+agent it blocks until the current turn ends, then injects. So the missing piece
+is not a new channel — it is a **priority-aware trigger** on the delivery pogod
+already performs.
+
+pogod's stall watcher already lists `~/.macguffin/work/available/` every 30s
+heartbeat tick and already has `WorkItem.Priority` in hand; it was simply
+priority-blind and 10-min-gated. The fix is a branch, not new plumbing. The wake
+policy stays entirely in pogod, keyed off the generic `Priority` field, so `mg`
+needs no `--wake` flag and no mg→pogod event — it remains a decoupled work queue.
+
+## The design (Lever A)
+
+In `stallwatch.checkUnclaimedItems`, over the same `available/` listing, add a
+priority pass (`checkPriorityWake`):
+
+- An item qualifies when it is **assigned to the watched agent** (or unassigned),
+  its priority is in `fast_priorities` (default `["high"]`), and it has aged past
+  the short **`high_priority_wake_delay`** (default 30s) rather than the 10-min
+  `unclaimed_item_age_threshold`. The small delay lets a burst of enqueues settle
+  so a batch is one nudge, not one per item.
+- Delivery reuses the **same wait-idle nudger** the standard checks use (see
+  `newStallNudger` in `cmd/pogod/main.go`) — so a **busy agent is never
+  interrupted** and an idle one is woken at once.
+- A dedicated **`high_priority_wake_cooldown`** (default 3m, separate from the
+  standard `nudge_cooldown`) gates repeats.
+- On a fire, pogod's `heartbeat.Nudge` is invoked (via the optional `FastPoll`
+  hook) to collapse the next ~30s poll for a prompt follow-up sweep. It cannot
+  storm the loop: `FastPoll` runs only on an actual fire, and the cooldown
+  suppresses the immediately-following check, so at most one extra tick follows
+  each wake.
+
+The standard 10-min pass skips fast-priority items *only while the wake is
+enabled* — they are owned by the fast path, so a stuck high-priority item draws
+one fast nudge, not a second slow one. Disable the wake and those items fall
+straight back to the 10-min gate; the feature never silences them.
+
+## Why it cannot loop-nudge a stuck item
+
+Two structural guarantees, both asserted by tests:
+
+1. **Only `available/` is scanned.** An item with unmet deps sits in `pending/`
+   and an already-claimed item in `claimed/`; `workitem.ListFrom(root,
+   "available")` returns neither, so a blocked or claimed high-priority item is
+   never even seen — it cannot wake anything.
+2. **The dedicated cooldown** caps a ready-but-undispatchable item to one nudge
+   per `high_priority_wake_cooldown`, not one per heartbeat tick.
+
+## Tests (W-4)
+
+`internal/stallwatch/stallwatch_test.go`:
+
+- `TestPriorityWakeBypassesTenMinuteGate` — high-priority item past the wake
+  delay but far under the 10m gate fires a `priority_wake` nudge.
+- `TestPriorityWakeRespectsWakeDelay` — younger than the delay does not fire.
+- `TestPriorityWakeCooldownPreventsLoopNudge` — a stuck available item nudges
+  once per cooldown across many ticks (review point **b**).
+- `TestBlockedOrClaimedHighPriorityDoesNotWake` — `pending/` and `claimed/`
+  high-priority items never wake (review point **b**).
+- `TestTenMinuteGateStillAppliesToNonHighPriority` — non-high items keep the 10m
+  gate (review point **c**).
+- `TestPriorityWakeDisabledFallsBackToStandardGate` — disabling never silences a
+  high-priority item.
+- `TestPriorityWakeAndStandardHaveIndependentCooldowns`,
+  `TestPriorityWakeFastPollInvokedOnFire`,
+  `TestPriorityWakeIgnoresItemsAssignedElsewhere`,
+  `TestPriorityWakeCaseInsensitivePriority`, and the zero-config default check.
+
+`cmd/pogod/main_stallnudger_test.go`:
+
+- `TestStallNudgerNeverInterruptsBusyAgent` — end-to-end proof of review point
+  **a**: through the exact nudger the wake uses, a perpetually-busy agent never
+  receives the wake in its PTY.
+- `TestStallNudgerFallsBackToMailWhenOffline` — durable mail delivery for an
+  offline agent.
+
+The wait-idle primitive itself is proven in
+`internal/agent/nudge_test.go:TestNudgeWithModeWaitIdleTimeoutOnBusy`.
+
+## Configuration
+
+See [../CONFIGURATION.md](../CONFIGURATION.md) §"Priority wake". All knobs live
+under `[stall_watch]`; the wake is default-on for the watched coordinator.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,7 +110,25 @@ const (
 	// same threshold category, so a persistent backlog produces one nudge per
 	// cooldown rather than one per heartbeat tick. Mirrors gh #12's 300s.
 	DefaultStallNudgeCooldown = 5 * time.Minute
+	// DefaultHighPriorityWakeDelay is the minimum age a high-priority available
+	// item must reach before the priority wake fires. Small enough to feel
+	// immediate versus the old up-to-30-min idle-poll gap, large enough to let
+	// a burst of enqueues settle so a batch produces one nudge rather than one
+	// per item. See the priority-wake half of gh drellem2/pogo #61.
+	DefaultHighPriorityWakeDelay = 30 * time.Second
+	// DefaultHighPriorityWakeCooldown is the minimum gap between two
+	// priority-wake nudges. It is deliberately shorter than the standard stall
+	// cooldown (urgent work should recover fast) but long enough that a
+	// high-priority item which stays available — e.g. the coordinator can't
+	// dispatch it yet — does not re-nudge every heartbeat tick.
+	DefaultHighPriorityWakeCooldown = 3 * time.Minute
 )
+
+// DefaultFastPriorities is the set of WorkItem.Priority values that trigger the
+// priority wake. Just "high" today; extend it (e.g. add "critical") if the
+// priority vocabulary grows. Kept as a var because a slice cannot be a const;
+// treat it as read-only.
+var DefaultFastPriorities = []string{"high"}
 
 // Config holds pogo daemon configuration.
 type Config struct {
@@ -168,6 +186,28 @@ type StallWatchConfig struct {
 	// NudgeCooldown is the minimum gap between two nudges for the same
 	// threshold category. Zero falls back to DefaultStallNudgeCooldown.
 	NudgeCooldown time.Duration
+
+	// PriorityWakeEnabled turns on the priority-aware fast wake (gh
+	// drellem2/pogo #61): a ready, watched, high-priority available item
+	// bypasses UnclaimedItemAgeThreshold and is delivered promptly via the same
+	// wait-idle nudge, so urgent work no longer waits out the idle-coordinator
+	// polling gap. Because New() cannot distinguish an unset bool from an
+	// explicit false, the production default (true) is applied by Load(), not
+	// New(); a hand-built config must set this field to activate the wake.
+	PriorityWakeEnabled bool
+	// HighPriorityWakeDelay is the minimum age a high-priority available item
+	// must reach before the priority wake fires (bypassing
+	// UnclaimedItemAgeThreshold). Zero falls back to
+	// DefaultHighPriorityWakeDelay.
+	HighPriorityWakeDelay time.Duration
+	// HighPriorityWakeCooldown is the minimum gap between two priority-wake
+	// nudges — a dedicated cooldown so a high-priority item that stays available
+	// does not re-nudge every tick. Zero falls back to
+	// DefaultHighPriorityWakeCooldown.
+	HighPriorityWakeCooldown time.Duration
+	// FastPriorities lists the WorkItem.Priority values that trigger the
+	// priority wake. Empty falls back to DefaultFastPriorities (["high"]).
+	FastPriorities []string
 }
 
 // GitGCConfig configures pogod's periodic polecat git garbage collector.
@@ -316,10 +356,11 @@ type RefineryConfig struct {
 // "unset" from "set to a zero value" (e.g. enabled = false).
 type parsedConfig struct {
 	Config
-	refineryEnabledSet   bool
-	gitgcEnabledSet      bool
-	stallWatchEnabledSet bool
-	agentsAutoStartSet   bool
+	refineryEnabledSet     bool
+	gitgcEnabledSet        bool
+	stallWatchEnabledSet   bool
+	priorityWakeEnabledSet bool
+	agentsAutoStartSet     bool
 }
 
 // Load reads configuration from (in priority order):
@@ -351,6 +392,11 @@ func Load() *Config {
 			UnreadMailAgeThreshold:    DefaultUnreadMailAgeThreshold,
 			MaxUnreadMailCount:        DefaultMaxUnreadMailCount,
 			NudgeCooldown:             DefaultStallNudgeCooldown,
+			// Priority wake is default-on for the watched coordinator (gh #61).
+			PriorityWakeEnabled:      true,
+			HighPriorityWakeDelay:    DefaultHighPriorityWakeDelay,
+			HighPriorityWakeCooldown: DefaultHighPriorityWakeCooldown,
+			FastPriorities:           DefaultFastPriorities,
 		},
 	}
 
@@ -416,6 +462,18 @@ func Load() *Config {
 		}
 		if fileCfg.StallWatch.NudgeCooldown > 0 {
 			cfg.StallWatch.NudgeCooldown = fileCfg.StallWatch.NudgeCooldown
+		}
+		if fileCfg.priorityWakeEnabledSet {
+			cfg.StallWatch.PriorityWakeEnabled = fileCfg.StallWatch.PriorityWakeEnabled
+		}
+		if fileCfg.StallWatch.HighPriorityWakeDelay > 0 {
+			cfg.StallWatch.HighPriorityWakeDelay = fileCfg.StallWatch.HighPriorityWakeDelay
+		}
+		if fileCfg.StallWatch.HighPriorityWakeCooldown > 0 {
+			cfg.StallWatch.HighPriorityWakeCooldown = fileCfg.StallWatch.HighPriorityWakeCooldown
+		}
+		if len(fileCfg.StallWatch.FastPriorities) > 0 {
+			cfg.StallWatch.FastPriorities = fileCfg.StallWatch.FastPriorities
 		}
 	}
 
@@ -692,6 +750,19 @@ func loadConfigFile() (*parsedConfig, error) {
 				if d, err := time.ParseDuration(unquotedVal); err == nil {
 					cfg.StallWatch.NudgeCooldown = d
 				}
+			case "priority_wake_enabled":
+				cfg.StallWatch.PriorityWakeEnabled = val == "true"
+				cfg.priorityWakeEnabledSet = true
+			case "high_priority_wake_delay":
+				if d, err := time.ParseDuration(unquotedVal); err == nil {
+					cfg.StallWatch.HighPriorityWakeDelay = d
+				}
+			case "high_priority_wake_cooldown":
+				if d, err := time.ParseDuration(unquotedVal); err == nil {
+					cfg.StallWatch.HighPriorityWakeCooldown = d
+				}
+			case "fast_priorities":
+				cfg.StallWatch.FastPriorities = parseStringArray(val)
 			}
 		case "agents":
 			switch key {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -736,6 +736,19 @@ func TestStallWatchDefaults(t *testing.T) {
 	if cfg.StallWatch.NudgeCooldown != DefaultStallNudgeCooldown {
 		t.Errorf("cooldown = %v, want %v", cfg.StallWatch.NudgeCooldown, DefaultStallNudgeCooldown)
 	}
+	// Priority wake (gh #61) is default-on for the watched coordinator.
+	if !cfg.StallWatch.PriorityWakeEnabled {
+		t.Error("priority wake should be enabled by default")
+	}
+	if cfg.StallWatch.HighPriorityWakeDelay != DefaultHighPriorityWakeDelay {
+		t.Errorf("wake delay = %v, want %v", cfg.StallWatch.HighPriorityWakeDelay, DefaultHighPriorityWakeDelay)
+	}
+	if cfg.StallWatch.HighPriorityWakeCooldown != DefaultHighPriorityWakeCooldown {
+		t.Errorf("wake cooldown = %v, want %v", cfg.StallWatch.HighPriorityWakeCooldown, DefaultHighPriorityWakeCooldown)
+	}
+	if len(cfg.StallWatch.FastPriorities) != 1 || cfg.StallWatch.FastPriorities[0] != "high" {
+		t.Errorf("fast priorities = %v, want [high]", cfg.StallWatch.FastPriorities)
+	}
 }
 
 func TestStallWatchConfigFile(t *testing.T) {
@@ -753,11 +766,27 @@ unclaimed_item_age_threshold = "3m"
 unread_mail_age_threshold = "4m"
 max_unread_mail_count = 9
 nudge_cooldown = "90s"
+priority_wake_enabled = false
+high_priority_wake_delay = "10s"
+high_priority_wake_cooldown = "90s"
+fast_priorities = ["high", "critical"]
 `), 0644)
 
 	cfg := Load()
 	if cfg.StallWatch.Enabled {
 		t.Error("stall watch should be disabled by config file")
+	}
+	if cfg.StallWatch.PriorityWakeEnabled {
+		t.Error("priority wake should be disabled by config file")
+	}
+	if cfg.StallWatch.HighPriorityWakeDelay != 10*time.Second {
+		t.Errorf("wake delay = %v, want 10s", cfg.StallWatch.HighPriorityWakeDelay)
+	}
+	if cfg.StallWatch.HighPriorityWakeCooldown != 90*time.Second {
+		t.Errorf("wake cooldown = %v, want 90s", cfg.StallWatch.HighPriorityWakeCooldown)
+	}
+	if len(cfg.StallWatch.FastPriorities) != 2 || cfg.StallWatch.FastPriorities[0] != "high" || cfg.StallWatch.FastPriorities[1] != "critical" {
+		t.Errorf("fast priorities = %v, want [high critical]", cfg.StallWatch.FastPriorities)
 	}
 	if cfg.StallWatch.Agent != "director" {
 		t.Errorf("agent = %q, want director", cfg.StallWatch.Agent)
@@ -797,6 +826,34 @@ nudge_cooldown = "2m"
 	}
 	if cfg.StallWatch.NudgeCooldown != 2*time.Minute {
 		t.Errorf("cooldown = %v, want 2m", cfg.StallWatch.NudgeCooldown)
+	}
+	// The priority wake likewise stays at its default-on unless explicitly set.
+	if !cfg.StallWatch.PriorityWakeEnabled {
+		t.Error("priority wake should remain enabled when only nudge_cooldown is set")
+	}
+}
+
+// TestPriorityWakeUnrelatedKeysDontDisableIt: setting only a wake tuning knob
+// must leave priority_wake_enabled at its default-true (the priorityWakeEnabledSet
+// flag distinguishes unset from an explicit false).
+func TestPriorityWakeUnrelatedKeysDontDisableIt(t *testing.T) {
+	dir := t.TempDir()
+	os.Setenv("XDG_CONFIG_HOME", dir)
+	defer os.Unsetenv("XDG_CONFIG_HOME")
+
+	pogoDir := filepath.Join(dir, "pogo")
+	os.MkdirAll(pogoDir, 0755)
+	os.WriteFile(filepath.Join(pogoDir, "config.toml"), []byte(`
+[stall_watch]
+high_priority_wake_delay = "5s"
+`), 0644)
+
+	cfg := Load()
+	if !cfg.StallWatch.PriorityWakeEnabled {
+		t.Error("priority wake should remain enabled when only a wake knob is set")
+	}
+	if cfg.StallWatch.HighPriorityWakeDelay != 5*time.Second {
+		t.Errorf("wake delay = %v, want 5s", cfg.StallWatch.HighPriorityWakeDelay)
 	}
 }
 

--- a/internal/stallwatch/stallwatch.go
+++ b/internal/stallwatch/stallwatch.go
@@ -44,6 +44,10 @@ import (
 const (
 	categoryUnclaimedItems = "unclaimed_items"
 	categoryUnreadMail     = "unread_mail"
+	// categoryPriorityWake keys the priority-wake cooldown and stamps the
+	// emitted event. It is deliberately distinct from categoryUnclaimedItems so
+	// the fast wake and the standard 10-min stall nudge cool down independently.
+	categoryPriorityWake = "priority_wake"
 )
 
 // Nudger delivers a short message to an agent. pogod injects an implementation
@@ -67,6 +71,14 @@ type Options struct {
 	Nudge Nudger
 	// Emit writes the stall_watch_fired event. Defaults to events.Emit.
 	Emit Emitter
+	// FastPoll, if set, requests an out-of-band heartbeat tick right after a
+	// priority wake fires, so pogod re-checks the queue well before the next
+	// ~30s poll instead of waiting a full interval. pogod wires this to
+	// heartbeat.Detector.Nudge; tests leave it nil. Strictly optional — the
+	// wake is correct without it. It cannot loop: it is only called on an
+	// actual fire, and the priority cooldown suppresses the very next check,
+	// so at most one extra tick follows each wake.
+	FastPoll func()
 }
 
 // Watcher samples macguffin state and nudges the watched agent on stall.
@@ -76,6 +88,7 @@ type Watcher struct {
 	mailRoot string
 	nudge    Nudger
 	emit     Emitter
+	fastPoll func()
 
 	mu        sync.Mutex
 	lastNudge map[string]time.Time
@@ -98,6 +111,20 @@ func New(cfg config.StallWatchConfig, opts Options) *Watcher {
 	}
 	if cfg.NudgeCooldown <= 0 {
 		cfg.NudgeCooldown = config.DefaultStallNudgeCooldown
+	}
+	// Priority-wake defaults. PriorityWakeEnabled is intentionally NOT defaulted
+	// here: New() cannot tell an unset bool from an explicit false, so the
+	// production default (true) is set by config.Load(); a zero-value config
+	// leaves the wake off. The numeric/slice knobs still default so a config
+	// that enables the wake without tuning it is usable.
+	if cfg.HighPriorityWakeDelay <= 0 {
+		cfg.HighPriorityWakeDelay = config.DefaultHighPriorityWakeDelay
+	}
+	if cfg.HighPriorityWakeCooldown <= 0 {
+		cfg.HighPriorityWakeCooldown = config.DefaultHighPriorityWakeCooldown
+	}
+	if len(cfg.FastPriorities) == 0 {
+		cfg.FastPriorities = config.DefaultFastPriorities
 	}
 
 	workRoot := opts.WorkRoot
@@ -124,6 +151,7 @@ func New(cfg config.StallWatchConfig, opts Options) *Watcher {
 		mailRoot:  mailRoot,
 		nudge:     opts.Nudge,
 		emit:      emit,
+		fastPoll:  opts.FastPoll,
 		lastNudge: make(map[string]time.Time),
 	}
 }
@@ -152,9 +180,26 @@ func (w *Watcher) checkUnclaimedItems(now time.Time) {
 		return
 	}
 
+	// Priority-aware fast wake (gh drellem2/pogo #61). A ready, watched,
+	// high-priority available item bypasses the 10-min UnclaimedItemAgeThreshold
+	// and is delivered promptly via the same wait-idle nudge, so urgent work no
+	// longer waits out the idle-coordinator polling gap. This scans the same
+	// listing, so it is nearly free.
+	w.checkPriorityWake(now, items)
+
+	// Standard unclaimed-item stall: an assigned available item aged past the
+	// 10-min threshold. When the priority wake is active it OWNS fast-priority
+	// items (they follow the short priority cooldown, not the 10-min gate), so
+	// skip them here — otherwise a stuck high-priority item would draw a second,
+	// slower nudge on top of the fast one. When the wake is disabled they fall
+	// through to the standard gate exactly as before, so disabling the feature
+	// never silences a high-priority item.
 	var stale []workitem.WorkItem
 	for _, it := range items {
 		if !w.assignedToWatched(it.Assignee) {
+			continue
+		}
+		if w.cfg.PriorityWakeEnabled && w.isFastPriority(it.Priority) {
 			continue
 		}
 		if it.ModTime.IsZero() {
@@ -168,7 +213,7 @@ func (w *Watcher) checkUnclaimedItems(now time.Time) {
 		return
 	}
 
-	if !w.tryFire(categoryUnclaimedItems, now) {
+	if !w.tryFire(categoryUnclaimedItems, now, w.cfg.NudgeCooldown) {
 		return
 	}
 
@@ -190,6 +235,99 @@ func (w *Watcher) checkUnclaimedItems(now time.Time) {
 		"age_threshold":      w.cfg.UnclaimedItemAgeThreshold.String(),
 		"oldest_age_seconds": now.Sub(oldestModTime(stale)).Seconds(),
 	})
+}
+
+// checkPriorityWake delivers the priority-aware fast wake (gh drellem2/pogo
+// #61). It fires when one or more ready, watched, high-priority items sit in
+// available/ — bypassing the 10-min UnclaimedItemAgeThreshold in favor of the
+// much shorter HighPriorityWakeDelay — and delivers via the same wait-idle
+// nudge the standard checks use, so a BUSY agent is never interrupted (the
+// nudge blocks until the agent's PTY goes quiet) and an idle agent is woken at
+// once. items is the caller's already-listed available/ snapshot.
+//
+// Two structural properties keep it from loop-nudging a stuck item:
+//
+//   - Only available/ is listed. An item with unmet deps sits in pending/ and
+//     an already-claimed item in claimed/, so neither is ever seen here — a
+//     blocked or claimed high-priority item cannot trigger a wake at all.
+//   - The dedicated HighPriorityWakeCooldown gates repeats, so a ready
+//     high-priority item that simply stays available (e.g. the coordinator
+//     can't dispatch it yet) draws at most one nudge per cooldown, not one per
+//     heartbeat tick.
+func (w *Watcher) checkPriorityWake(now time.Time, items []workitem.WorkItem) {
+	if !w.cfg.PriorityWakeEnabled {
+		return
+	}
+
+	var ready []workitem.WorkItem
+	for _, it := range items {
+		if !w.assignedToWatched(it.Assignee) {
+			continue
+		}
+		if !w.isFastPriority(it.Priority) {
+			continue
+		}
+		if it.ModTime.IsZero() {
+			continue
+		}
+		if now.Sub(it.ModTime) >= w.cfg.HighPriorityWakeDelay {
+			ready = append(ready, it)
+		}
+	}
+	if len(ready) == 0 {
+		return
+	}
+
+	if !w.tryFire(categoryPriorityWake, now, w.cfg.HighPriorityWakeCooldown) {
+		return
+	}
+
+	sort.Slice(ready, func(i, j int) bool { return ready[i].ID < ready[j].ID })
+	ids := make([]string, len(ready))
+	for i, it := range ready {
+		ids[i] = it.ID
+	}
+
+	msg := fmt.Sprintf(
+		"priority-wake: %d high-priority work item(s) are ready and unclaimed — claim or dispatch now: %s",
+		len(ready), strings.Join(ids, ", "))
+
+	w.fire(categoryPriorityWake, msg, map[string]any{
+		"category":       categoryPriorityWake,
+		"watched_agent":  w.cfg.Agent,
+		"item_count":     len(ready),
+		"item_ids":       ids,
+		"wake_delay":     w.cfg.HighPriorityWakeDelay.String(),
+		"wake_cooldown":  w.cfg.HighPriorityWakeCooldown.String(),
+		"fast_priority":  strings.Join(w.cfg.FastPriorities, ","),
+		"oldest_age_sec": now.Sub(oldestModTime(ready)).Seconds(),
+	})
+
+	// Collapse the ~30s poll for the follow-up check so pogod re-samples the
+	// queue promptly (e.g. to notice the item got claimed, or that more urgent
+	// work landed) instead of waiting a full interval. Safe from looping: the
+	// priority cooldown suppresses the immediate re-check, so this yields at
+	// most one extra tick per wake. See Options.FastPoll.
+	if w.fastPoll != nil {
+		w.fastPoll()
+	}
+}
+
+// isFastPriority reports whether a work item's Priority value is in the
+// configured fast-priority set (default ["high"]). The comparison is
+// case-insensitive and whitespace-trimmed so a "High" or " high " frontmatter
+// value still triggers the wake.
+func (w *Watcher) isFastPriority(priority string) bool {
+	p := strings.ToLower(strings.TrimSpace(priority))
+	if p == "" {
+		return false
+	}
+	for _, fp := range w.cfg.FastPriorities {
+		if p == strings.ToLower(strings.TrimSpace(fp)) {
+			return true
+		}
+	}
+	return false
 }
 
 // checkUnreadMail fires when the watched agent's new/ maildir holds a message
@@ -228,7 +366,7 @@ func (w *Watcher) checkUnreadMail(now time.Time) {
 		return
 	}
 
-	if !w.tryFire(categoryUnreadMail, now) {
+	if !w.tryFire(categoryUnreadMail, now, w.cfg.NudgeCooldown) {
 		return
 	}
 
@@ -265,15 +403,17 @@ func (w *Watcher) assignedToWatched(assignee string) bool {
 	return a == "" || a == w.cfg.Agent
 }
 
-// tryFire enforces the per-category cooldown. It returns true and records the
+// tryFire enforces a per-category cooldown. It returns true and records the
 // fire time when a nudge is allowed, false when the category is still cooling
-// down. Recording before the nudge attempt means a failed delivery still
-// counts toward the cooldown — better to retry next cooldown window than to
-// hammer a wedged recipient every tick.
-func (w *Watcher) tryFire(category string, now time.Time) bool {
+// down. The caller passes the cooldown so each category can have its own — the
+// priority wake recovers faster (HighPriorityWakeCooldown) than the standard
+// stall categories (NudgeCooldown). Recording before the nudge attempt means a
+// failed delivery still counts toward the cooldown — better to retry next
+// cooldown window than to hammer a wedged recipient every tick.
+func (w *Watcher) tryFire(category string, now time.Time, cooldown time.Duration) bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if last, ok := w.lastNudge[category]; ok && now.Sub(last) < w.cfg.NudgeCooldown {
+	if last, ok := w.lastNudge[category]; ok && now.Sub(last) < cooldown {
 		return false
 	}
 	w.lastNudge[category] = now

--- a/internal/stallwatch/stallwatch_test.go
+++ b/internal/stallwatch/stallwatch_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -76,8 +77,32 @@ func testEnv(t *testing.T, cfg config.StallWatchConfig) (*Watcher, *recorder, st
 // mtime to age-old relative to now.
 func writeItem(t *testing.T, workRoot, id, assignee string, modTime time.Time) {
 	t.Helper()
-	path := filepath.Join(workRoot, "available", id+".md")
-	content := fmt.Sprintf("---\nid: %s\ntype: task\nassignee: %s\n---\n# %s\n", id, assignee, id)
+	writeItemIn(t, workRoot, "available", id, assignee, "", modTime)
+}
+
+// writePriorityItem writes an available work item carrying a priority value.
+func writePriorityItem(t *testing.T, workRoot, id, assignee, priority string, modTime time.Time) {
+	t.Helper()
+	writeItemIn(t, workRoot, "available", id, assignee, priority, modTime)
+}
+
+// writeItemIn writes a work item into an arbitrary status directory (statusDir)
+// with an optional priority, so tests can model blocked (pending/) and claimed
+// (claimed/) items as well as available ones. The directory is created if it
+// does not already exist so tests can exercise pending/, which testEnv does not
+// pre-create.
+func writeItemIn(t *testing.T, workRoot, statusDir, id, assignee, priority string, modTime time.Time) {
+	t.Helper()
+	dir := filepath.Join(workRoot, statusDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, id+".md")
+	content := fmt.Sprintf("---\nid: %s\ntype: task\nassignee: %s\n", id, assignee)
+	if priority != "" {
+		content += fmt.Sprintf("priority: %s\n", priority)
+	}
+	content += fmt.Sprintf("---\n# %s\n", id)
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -110,6 +135,10 @@ func baseConfig() config.StallWatchConfig {
 		UnreadMailAgeThreshold:    10 * time.Minute,
 		MaxUnreadMailCount:        5,
 		NudgeCooldown:             5 * time.Minute,
+		PriorityWakeEnabled:       true,
+		HighPriorityWakeDelay:     30 * time.Second,
+		HighPriorityWakeCooldown:  3 * time.Minute,
+		FastPriorities:            []string{"high"},
 	}
 }
 
@@ -324,6 +353,252 @@ func TestNudgeErrorStillEmitsEvent(t *testing.T) {
 	}
 	if rec.events[0].Details["nudge_error"] != "agent offline" {
 		t.Errorf("expected nudge_error recorded, got %v", rec.events[0].Details["nudge_error"])
+	}
+}
+
+// --- Priority wake (gh drellem2/pogo #61) ---------------------------------
+
+// TestPriorityWakeBypassesTenMinuteGate: a high-priority item that has aged past
+// the short HighPriorityWakeDelay but is nowhere near the 10-min
+// UnclaimedItemAgeThreshold fires a priority_wake nudge — the core latency win.
+func TestPriorityWakeBypassesTenMinuteGate(t *testing.T) {
+	w, rec, workRoot, _ := testEnv(t, baseConfig())
+	now := time.Now()
+	// 1 minute old: over the 30s wake delay, far under the 10m gate.
+	writePriorityItem(t, workRoot, "mg-hi01", "mayor", "high", now.Add(-1*time.Minute))
+
+	w.Check(now)
+
+	if rec.nudgeCount() != 1 {
+		t.Fatalf("expected 1 priority-wake nudge, got %d", rec.nudgeCount())
+	}
+	if rec.eventCount() != 1 {
+		t.Fatalf("expected 1 event, got %d", rec.eventCount())
+	}
+	if rec.events[0].Details["category"] != categoryPriorityWake {
+		t.Errorf("category = %v, want %s", rec.events[0].Details["category"], categoryPriorityWake)
+	}
+	if !strings.Contains(rec.nudges[0].message, "priority-wake") {
+		t.Errorf("nudge message = %q, want it to mention priority-wake", rec.nudges[0].message)
+	}
+	if !strings.Contains(rec.nudges[0].message, "mg-hi01") {
+		t.Errorf("nudge message = %q, want it to name the item", rec.nudges[0].message)
+	}
+}
+
+// TestPriorityWakeRespectsWakeDelay: a high-priority item younger than the wake
+// delay must not fire yet — the delay lets a burst of enqueues settle so a batch
+// is one nudge, not one per item.
+func TestPriorityWakeRespectsWakeDelay(t *testing.T) {
+	w, rec, workRoot, _ := testEnv(t, baseConfig())
+	now := time.Now()
+	// 10 seconds old: under the 30s wake delay.
+	writePriorityItem(t, workRoot, "mg-hi02", "mayor", "high", now.Add(-10*time.Second))
+
+	w.Check(now)
+
+	if rec.nudgeCount() != 0 {
+		t.Fatalf("expected no wake for an item under the wake delay, got %d", rec.nudgeCount())
+	}
+}
+
+// TestPriorityWakeCooldownPreventsLoopNudge covers architect review point (b):
+// a high-priority item that stays available (e.g. the coordinator can't dispatch
+// it yet) must NOT re-nudge every tick. The dedicated priority cooldown caps it
+// to one nudge per cooldown window.
+func TestPriorityWakeCooldownPreventsLoopNudge(t *testing.T) {
+	w, rec, workRoot, _ := testEnv(t, baseConfig())
+	now := time.Now()
+	writePriorityItem(t, workRoot, "mg-hi03", "mayor", "high", now.Add(-1*time.Minute))
+
+	// Simulate many rapid heartbeat ticks (30s apart) with the item still sitting
+	// available the whole time.
+	for i := 0; i < 6; i++ {
+		w.Check(now.Add(time.Duration(i) * 30 * time.Second))
+	}
+	if rec.nudgeCount() != 1 {
+		t.Fatalf("cooldown should hold a stuck item to 1 nudge, got %d", rec.nudgeCount())
+	}
+
+	// Past the 3m cooldown it may fire once more.
+	w.Check(now.Add(4 * time.Minute))
+	if rec.nudgeCount() != 2 {
+		t.Fatalf("expected a second wake after the cooldown, got %d", rec.nudgeCount())
+	}
+}
+
+// TestBlockedOrClaimedHighPriorityDoesNotWake covers architect review point (b):
+// a high-priority item that is blocked (unmet deps → sits in pending/) or already
+// claimed (in claimed/) must never trigger a wake. Only available/ is scanned,
+// so such items are never even seen — they cannot loop-nudge.
+func TestBlockedOrClaimedHighPriorityDoesNotWake(t *testing.T) {
+	w, rec, workRoot, _ := testEnv(t, baseConfig())
+	now := time.Now()
+	old := now.Add(-1 * time.Minute)
+	// Blocked: high-priority, assigned to mayor, but gated in pending/.
+	writeItemIn(t, workRoot, "pending", "mg-blk1", "mayor", "high", old)
+	// Already claimed: high-priority, assigned to mayor, in claimed/.
+	writeItemIn(t, workRoot, "claimed", "mg-clm1", "mayor", "high", old)
+
+	w.Check(now)
+
+	if rec.nudgeCount() != 0 {
+		t.Fatalf("blocked/claimed high-priority items must not wake, got %d nudges", rec.nudgeCount())
+	}
+}
+
+// TestTenMinuteGateStillAppliesToNonHighPriority covers architect review point
+// (c): a non-high-priority item keeps the original 10-min gate — the short wake
+// delay must not apply to it.
+func TestTenMinuteGateStillAppliesToNonHighPriority(t *testing.T) {
+	w, rec, workRoot, _ := testEnv(t, baseConfig())
+	now := time.Now()
+	// medium priority, 1 minute old: over the wake delay but under the 10m gate.
+	writePriorityItem(t, workRoot, "mg-md01", "mayor", "medium", now.Add(-1*time.Minute))
+
+	w.Check(now)
+	if rec.nudgeCount() != 0 {
+		t.Fatalf("non-high item under the 10m gate must not fire, got %d", rec.nudgeCount())
+	}
+
+	// Age it past the 10m gate: now the standard unclaimed-items nudge fires.
+	writePriorityItem(t, workRoot, "mg-md01", "mayor", "medium", now.Add(-11*time.Minute))
+	w.Check(now)
+	if rec.nudgeCount() != 1 {
+		t.Fatalf("expected the 10m gate to fire for a non-high item, got %d", rec.nudgeCount())
+	}
+	if rec.events[0].Details["category"] != categoryUnclaimedItems {
+		t.Errorf("category = %v, want %s", rec.events[0].Details["category"], categoryUnclaimedItems)
+	}
+}
+
+// TestPriorityWakeDisabledFallsBackToStandardGate: with the wake disabled, a
+// high-priority item must NOT get the fast path but must STILL get the standard
+// 10-min nudge — disabling the feature never silences a high-priority item.
+func TestPriorityWakeDisabledFallsBackToStandardGate(t *testing.T) {
+	cfg := baseConfig()
+	cfg.PriorityWakeEnabled = false
+	w, rec, workRoot, _ := testEnv(t, cfg)
+	now := time.Now()
+
+	// 1 minute old, high priority: no fast wake because the feature is off.
+	writePriorityItem(t, workRoot, "mg-hi04", "mayor", "high", now.Add(-1*time.Minute))
+	w.Check(now)
+	if rec.nudgeCount() != 0 {
+		t.Fatalf("wake disabled: no nudge expected under the 10m gate, got %d", rec.nudgeCount())
+	}
+
+	// Aged past the 10m gate: the standard path fires (not silenced).
+	writePriorityItem(t, workRoot, "mg-hi04", "mayor", "high", now.Add(-11*time.Minute))
+	w.Check(now)
+	if rec.nudgeCount() != 1 {
+		t.Fatalf("wake disabled: high-priority item must still get the 10m nudge, got %d", rec.nudgeCount())
+	}
+	if rec.events[0].Details["category"] != categoryUnclaimedItems {
+		t.Errorf("category = %v, want %s", rec.events[0].Details["category"], categoryUnclaimedItems)
+	}
+}
+
+// TestPriorityWakeAndStandardHaveIndependentCooldowns: a high-priority (fast)
+// item and a stale non-high item fire on the same tick under separate cooldowns.
+func TestPriorityWakeAndStandardHaveIndependentCooldowns(t *testing.T) {
+	w, rec, workRoot, _ := testEnv(t, baseConfig())
+	now := time.Now()
+	writePriorityItem(t, workRoot, "mg-hi05", "mayor", "high", now.Add(-1*time.Minute))
+	writeItem(t, workRoot, "mg-old5", "mayor", now.Add(-20*time.Minute))
+
+	w.Check(now)
+
+	if rec.nudgeCount() != 2 {
+		t.Fatalf("expected 2 nudges (priority wake + standard stall), got %d", rec.nudgeCount())
+	}
+	cats := map[any]bool{}
+	for _, ev := range rec.events {
+		cats[ev.Details["category"]] = true
+	}
+	if !cats[categoryPriorityWake] || !cats[categoryUnclaimedItems] {
+		t.Errorf("expected both categories to fire, got %v", cats)
+	}
+}
+
+// TestPriorityWakeFastPollInvokedOnFire: the FastPoll hook is called exactly once
+// when a wake fires, and NOT called when a subsequent within-cooldown check is
+// suppressed — the property that keeps FastPoll from storming the heartbeat.
+func TestPriorityWakeFastPollInvokedOnFire(t *testing.T) {
+	root := t.TempDir()
+	workRoot := filepath.Join(root, "work")
+	mailRoot := filepath.Join(root, "mail")
+	for _, d := range []string{"available", "claimed", "done"} {
+		if err := os.MkdirAll(filepath.Join(workRoot, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rec := &recorder{}
+	var fastPolls int
+	w := New(baseConfig(), Options{
+		WorkRoot: workRoot,
+		MailRoot: mailRoot,
+		Nudge:    rec.nudge,
+		Emit:     rec.emit,
+		FastPoll: func() { fastPolls++ },
+	})
+	now := time.Now()
+	writePriorityItem(t, workRoot, "mg-hi06", "mayor", "high", now.Add(-1*time.Minute))
+
+	w.Check(now)
+	if fastPolls != 1 {
+		t.Fatalf("expected FastPoll called once on fire, got %d", fastPolls)
+	}
+	// A second check inside the cooldown is suppressed and must not FastPoll.
+	w.Check(now.Add(30 * time.Second))
+	if fastPolls != 1 {
+		t.Fatalf("FastPoll must not fire on a cooled-down check, got %d", fastPolls)
+	}
+}
+
+// TestPriorityWakeIgnoresItemsAssignedElsewhere: a high-priority item assigned to
+// another agent is not the watched agent's concern and must not wake it.
+func TestPriorityWakeIgnoresItemsAssignedElsewhere(t *testing.T) {
+	w, rec, workRoot, _ := testEnv(t, baseConfig())
+	now := time.Now()
+	writePriorityItem(t, workRoot, "mg-hi07", "alice", "high", now.Add(-1*time.Minute))
+
+	w.Check(now)
+	if rec.nudgeCount() != 0 {
+		t.Fatalf("high-priority item assigned elsewhere must not wake, got %d", rec.nudgeCount())
+	}
+}
+
+// TestPriorityWakeCaseInsensitivePriority: a "High" frontmatter value still
+// triggers the wake — priority matching is case-insensitive and trimmed.
+func TestPriorityWakeCaseInsensitivePriority(t *testing.T) {
+	w, rec, workRoot, _ := testEnv(t, baseConfig())
+	now := time.Now()
+	writePriorityItem(t, workRoot, "mg-hi08", "mayor", "High", now.Add(-1*time.Minute))
+
+	w.Check(now)
+	if rec.nudgeCount() != 1 {
+		t.Fatalf("expected wake for case-variant 'High', got %d", rec.nudgeCount())
+	}
+}
+
+func TestPriorityWakeDefaultsAppliedFromZeroConfig(t *testing.T) {
+	root := t.TempDir()
+	rec := &recorder{}
+	w := New(config.StallWatchConfig{Enabled: true, PriorityWakeEnabled: true}, Options{
+		WorkRoot: filepath.Join(root, "work"),
+		MailRoot: filepath.Join(root, "mail"),
+		Nudge:    rec.nudge,
+		Emit:     rec.emit,
+	})
+	if w.cfg.HighPriorityWakeDelay != config.DefaultHighPriorityWakeDelay {
+		t.Errorf("wake delay = %v, want default", w.cfg.HighPriorityWakeDelay)
+	}
+	if w.cfg.HighPriorityWakeCooldown != config.DefaultHighPriorityWakeCooldown {
+		t.Errorf("wake cooldown = %v, want default", w.cfg.HighPriorityWakeCooldown)
+	}
+	if len(w.cfg.FastPriorities) != 1 || w.cfg.FastPriorities[0] != "high" {
+		t.Errorf("fast priorities = %v, want default [high]", w.cfg.FastPriorities)
 	}
 }
 


### PR DESCRIPTION
## Summary

Platform half (W-1/W-2/W-4) of the coordinator idle-latency priority wake. Adds a **priority-aware branch** to pogod's stall watcher so urgent work skips the coordinator idle-polling gap.

Today the stall watcher lists `~/.macguffin/work/available/` every 30s but is priority-blind and 10-min-gated, so a `priority = high` item with no accompanying mail can wait up to ~30 minutes for pickup — worst exactly when the coordinator is idle and has backed its polling off.

**The change (Lever A — a trigger on the EXISTING wait-idle delivery, not a new IPC channel):**

- **W-1** — `checkPriorityWake` branch in `stallwatch.checkUnclaimedItems`: a **ready, watched, high-priority** `available` item bypasses the 10-min `UnclaimedItemAgeThreshold` and is delivered after the short `high_priority_wake_delay` (default 30s) via the **same wait-idle nudge** the standard checks use — so a busy coordinator is never interrupted mid-turn and an idle one is woken at once. Optional `FastPoll` hook wired to `heartbeat.Nudge` collapses the next poll for a prompt follow-up. `newStallNudger` extracted in `cmd/pogod` for testability.
- **W-2** — `[stall_watch]` knobs: `priority_wake_enabled` (default **true** for the watched coordinator), `high_priority_wake_delay`, `high_priority_wake_cooldown` (a **dedicated** cooldown), `fast_priorities` (default `["high"]`). Wake policy stays entirely in pogod keyed off the generic `WorkItem.Priority` field — **no `mg` flag, no mg→pogod event** (deliberately rejected coupling).
- **W-4** — tests + docs.

**Never-loop / never-interrupt guarantees (asserted by tests):**

- **(a) busy agent never interrupted** — `TestStallNudgerNeverInterruptsBusyAgent` drives the exact nudger through a perpetually-busy spawned agent; the wake never reaches its PTY. Backed by the wait-idle primitive test in `internal/agent`.
- **(b) blocked/gated/already-claimed high-prio never loop-nudges** — only `available/` is scanned (`pending/` and `claimed/` are never listed), plus the dedicated cooldown caps a ready-but-undispatchable item to one nudge per window. `TestBlockedOrClaimedHighPriorityDoesNotWake`, `TestPriorityWakeCooldownPreventsLoopNudge`.
- **(c) 10-min gate still applies to non-high items** — `TestTenMinuteGateStillAppliesToNonHighPriority`; disabling the wake never silences high-prio items (`TestPriorityWakeDisabledFallsBackToStandardGate`).

`build.sh` + `test.sh` green.

**Out of scope (held for separate explicit sign-off):** W-3, the `mayor.md` bounded idle-backoff prompt change — not touched here.

Resolves drellem2/pogo#61

Approved triage recommendation: mg-83ee (architect design pass; full design at /Users/daniel/.pogo/shared/mg-61-priority-wake-design.md)
Work item: mg-b1d9