### PR TITLE
FIX: pogod attach-socket lifecycle — dead listener while process lives (mg-d216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ is the curated, human-readable summary kept in sync at each release cut.
 
 ## [Unreleased]
 
+### Fixed
+
+- **pogod: attach socket no longer dies while the agent lives.** `pogo agent attach <name>`
+  could fail with `connect: connection refused` against a socket file that existed,
+  on an agent whose process was alive and healthy. The accept loop returned on *any*
+  `Accept` error — including transient `EMFILE`/`ENFILE` under fd exhaustion — leaving
+  the socket bound with nothing accepting; once the listen backlog filled, every
+  subsequent attach was refused, permanently. The accept loop now retries transient
+  errors with bounded backoff, and a supervisor tied to process lifetime rebinds a
+  listener that stops serving or whose socket file is unlinked or replaced. Each
+  repair emits an `agent_attach_rebound` event. (mg-d216)
+
 ## [0.4.0] - 2026-07-09
 
 Minor release rolling up the 45 feature and fix commits merged since v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ is the curated, human-readable summary kept in sync at each release cut.
   the socket bound with nothing accepting; once the listen backlog filled, every
   subsequent attach was refused, permanently. The accept loop now retries transient
   errors with bounded backoff, and a supervisor tied to process lifetime rebinds a
-  listener that stops serving or whose socket file is unlinked or replaced. Each
-  repair emits an `agent_attach_rebound` event. (mg-d216)
+  listener that stops serving or whose socket file is unlinked or replaced. Both
+  the accept retry and the rebind repair are rate-limited, so a permanently broken
+  socket cannot spin the daemon or flood the event log. Each repair emits an
+  `agent_attach_rebound` event. (mg-d216)
 
 ## [0.4.0] - 2026-07-09
 

--- a/docs/event-log.md
+++ b/docs/event-log.md
@@ -116,6 +116,30 @@ A crew agent that crashed has been automatically restarted by pogod's supervisor
 {"schema_version":1,"timestamp":"2026-04-25T11:02:50.310000000Z","event_type":"agent_restarted","agent":"crew-arch","details":{"previous_pid":47011,"new_pid":47089,"restart_count":2}}
 ```
 
+#### `agent_attach_rebound`
+
+pogod repaired an agent's attach socket while the agent process kept running. The
+socket had stopped serving connections — see `reason` — so `pogo agent attach`
+would have failed against a live, healthy agent. Emitted once per repair; the
+agent is not restarted and loses no state. A steady trickle of these for one
+agent points at whatever keeps breaking the socket (fd exhaustion, a `$TMPDIR`
+reaper) rather than at the attach mechanism itself. Additive — no
+`schema_version` bump.
+
+- **Required envelope:** `schema_version`, `timestamp`, `event_type`, `agent`, `details`
+- **`details` fields:**
+  - `pid` (int, required): PID of the still-running agent process
+  - `socket` (string, required): path of the rebound unix socket
+  - `reason` (string, required): one of
+    - `accept_loop_stopped` — the accept loop exited under a live process. The socket file lingers with nothing accepting, so once the listen backlog fills, attach gets `connection refused`.
+    - `no_listener` — no listener was ever bound (e.g. the bind at spawn failed under fd exhaustion).
+    - `socket_file_missing` — the socket file was unlinked underneath a live listener.
+    - `socket_file_replaced` — a different socket now occupies the path.
+
+```json
+{"schema_version":1,"timestamp":"2026-07-10T09:12:03.410000000Z","event_type":"agent_attach_rebound","agent":"crew-mayor","details":{"pid":23884,"socket":"/var/folders/4n/T/pogo-agents/mayor.sock","reason":"accept_loop_stopped"}}
+```
+
 ### Polecat-specific lifecycle
 
 `agent_spawned` and `agent_stopped` already cover polecats. The two events below give polecat lifecycle a dedicated, work-item-scoped narrative for tools that want to filter by polecat events without inferring from `agent_type`.

--- a/docs/event-log.md
+++ b/docs/event-log.md
@@ -123,8 +123,13 @@ socket had stopped serving connections — see `reason` — so `pogo agent attac
 would have failed against a live, healthy agent. Emitted once per repair; the
 agent is not restarted and loses no state. A steady trickle of these for one
 agent points at whatever keeps breaking the socket (fd exhaustion, a `$TMPDIR`
-reaper) rather than at the attach mechanism itself. Additive — no
-`schema_version` bump.
+reaper) rather than at the attach mechanism itself.
+
+Repairs are rate-limited: a listener that fails again the instant it is rebound
+(a recurring permanent `accept(2)` error) backs off from 50ms to a ceiling of
+30s, so a persistently broken socket cannot flood this log. The backoff resets
+once a listener has stayed healthy for five minutes, so unrelated faults hours
+apart each get an immediate repair. Additive — no `schema_version` bump.
 
 - **Required envelope:** `schema_version`, `timestamp`, `event_type`, `agent`, `details`
 - **`details` fields:**

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -134,6 +135,28 @@ type Agent struct {
 	// socketPath is the unix domain socket for attach.
 	socketPath string
 	listener   net.Listener
+
+	// socketIno is the inode of the socket file the current listener is bound
+	// to. The supervisor compares it against whatever now sits at socketPath to
+	// notice a socket that was unlinked underneath us (macOS reaps stale entries
+	// under $TMPDIR) or replaced by a foreign bind. 0 means "unknown, skip it".
+	socketIno uint64
+
+	// listenerDead is closed by acceptLoop when it stops serving. The supervisor
+	// waits on it so a listener that dies while the process lives gets rebound
+	// rather than leaving a socket file nobody accepts on (mg-d216).
+	listenerDead chan struct{}
+
+	// attachStop is closed by Cleanup to retire the supervisor. attachStopped
+	// records the same fact under mu so a rebind that is already in flight
+	// aborts instead of recreating a socket for a torn-down agent.
+	attachStop    chan struct{}
+	attachStopped bool
+
+	// supervisorInterval is this agent's copy of attachSupervisorInterval,
+	// snapshotted on the spawning goroutine so a test that retunes the package
+	// default cannot race a running supervisor. Zero means use the default.
+	supervisorInterval time.Duration
 
 	// attachConns tracks active attach/terminal connections for output fanout.
 	// readOutput fans out PTY output to these in addition to the ring buffer.
@@ -1258,41 +1281,273 @@ func (a *Agent) Cleanup() {
 		a.master.Close()
 		a.master = nil
 	}
+	a.retireListenerLocked()
+}
+
+// retireListenerLocked stops the supervisor and tears the listener down. Once it
+// returns, no rebind can resurrect the socket: a supervisor that was already
+// waiting on a.mu sees attachStopped and gives up. Idempotent — Cleanup runs
+// more than once on some paths (stop, then the exit callback).
+func (a *Agent) retireListenerLocked() {
+	if !a.attachStopped {
+		a.attachStopped = true
+		if a.attachStop != nil {
+			close(a.attachStop)
+		}
+	}
 	if a.listener != nil {
 		a.listener.Close()
 		a.listener = nil
 	}
 	os.Remove(a.socketPath)
+	a.socketIno = 0
 }
 
-// startListener creates a unix domain socket for attach connections.
+// attachSupervisorInterval is how often the attach-listener supervisor re-checks
+// the socket file for a vanished or replaced inode. Overridden by tests.
+var attachSupervisorInterval = 30 * time.Second
+
+// Accept-retry backoff bounds for transient errors.
+const (
+	attachAcceptMinBackoff = 5 * time.Millisecond
+	attachAcceptMaxBackoff = time.Second
+)
+
+// startListener creates a unix domain socket for attach connections and starts
+// the supervisor that keeps it usable for the life of the process. The
+// supervisor starts even when the first bind fails, so an agent spawned during
+// fd exhaustion recovers attach once fds free up instead of losing it for good.
 func (a *Agent) startListener() error {
-	// Remove stale socket if it exists
+	a.mu.Lock()
+	if a.attachStop == nil {
+		a.attachStop = make(chan struct{})
+	}
+	if a.supervisorInterval == 0 {
+		a.supervisorInterval = attachSupervisorInterval
+	}
+	stop := a.attachStop
+	interval := a.supervisorInterval
+	err := a.bindListenerLocked()
+	a.mu.Unlock()
+
+	go a.superviseListener(stop, interval)
+	return err
+}
+
+// bindListenerLocked binds socketPath and starts a fresh accept loop, replacing
+// any previous listener. Called with a.mu held.
+func (a *Agent) bindListenerLocked() error {
+	// Drop the old listener without letting it unlink the path we are about to
+	// bind — Go's UnixListener unlinks by path on Close, not by inode.
+	if a.listener != nil {
+		disarmUnlinkOnClose(a.listener)
+		a.listener.Close()
+		a.listener = nil
+	}
+	// Remove the stale socket file: a leftover makes bind fail with EADDRINUSE.
 	os.Remove(a.socketPath)
 
 	l, err := net.Listen("unix", a.socketPath)
 	if err != nil {
+		// A nil listenerDead parks the supervisor's select on that arm, so it
+		// retries on the ticker rather than spinning on a closed channel.
+		a.listenerDead = nil
+		a.socketIno = 0
 		return fmt.Errorf("listen: %w", err)
 	}
 	a.listener = l
+	a.socketIno = fileInode(a.socketPath)
 
-	// Pass listener directly so acceptLoop doesn't access a.listener,
-	// avoiding a nil-pointer race when Cleanup nils it concurrently.
-	go a.acceptLoop(l)
+	// Pass listener and dead channel directly so acceptLoop doesn't access
+	// a.listener, avoiding a nil-pointer race when Cleanup nils it concurrently.
+	dead := make(chan struct{})
+	a.listenerDead = dead
+	go a.acceptLoop(l, dead)
 	return nil
 }
 
 // acceptLoop handles incoming attach connections.
 // Each connection gets bidirectional bridging to the PTY master.
-// Takes the listener as a parameter to avoid racing with Cleanup.
-func (a *Agent) acceptLoop(l net.Listener) {
+// Takes the listener as a parameter to avoid racing with Cleanup, and closes
+// dead on exit so the supervisor learns the socket stopped being served.
+func (a *Agent) acceptLoop(l net.Listener, dead chan struct{}) {
+	defer close(dead)
+
+	var backoff time.Duration
 	for {
 		conn, err := l.Accept()
 		if err != nil {
-			return // listener closed
+			if errors.Is(err, net.ErrClosed) {
+				return // listener closed by Cleanup or a rebind
+			}
+			// A transient accept error must not retire the listener. Under fd
+			// exhaustion Accept returns EMFILE/ENFILE; returning here leaves the
+			// socket file bound with nobody accepting, so the listen backlog
+			// fills and every later attach gets ECONNREFUSED against a perfectly
+			// healthy agent — the mg-d216 symptom.
+			var tmp interface{ Temporary() bool }
+			if errors.As(err, &tmp) && tmp.Temporary() {
+				backoff = nextAcceptBackoff(backoff)
+				log.Printf("agent %s: attach accept: %v — retrying in %s", a.Name, err, backoff)
+				time.Sleep(backoff)
+				continue
+			}
+			log.Printf("agent %s: attach accept stopped: %v", a.Name, err)
+			return // permanent — the supervisor rebinds while the process lives
 		}
+		backoff = 0
 		go a.handleAttach(conn)
 	}
+}
+
+// nextAcceptBackoff doubles the accept-retry delay up to attachAcceptMaxBackoff.
+func nextAcceptBackoff(cur time.Duration) time.Duration {
+	if cur == 0 {
+		return attachAcceptMinBackoff
+	}
+	if next := cur * 2; next < attachAcceptMaxBackoff {
+		return next
+	}
+	return attachAcceptMaxBackoff
+}
+
+// superviseListener ties the attach socket's lifetime to the process's. It
+// repairs the two ways a live agent can end up unattachable (mg-d216):
+//
+//   - The accept loop stopped — a permanent Accept error, or a bind that failed
+//     at spawn — while the process runs on. The socket file lingers, nothing
+//     accepts, and once the backlog fills every attach gets ECONNREFUSED.
+//   - The socket file was unlinked or replaced underneath a live listener (macOS
+//     reaps stale entries under $TMPDIR), leaving the listener bound to an
+//     orphaned inode and attach failing with ENOENT.
+//
+// It exits when the process exits or Cleanup retires the listener, and never
+// recreates a socket for a torn-down agent.
+func (a *Agent) superviseListener(stop chan struct{}, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		a.mu.Lock()
+		dead := a.listenerDead
+		a.mu.Unlock()
+
+		select {
+		case <-stop:
+			return
+		case <-a.done:
+			return // process exited — Cleanup owns the socket now
+		case <-dead:
+			// accept loop stopped; deliberate closes land here too, and are
+			// filtered out by the stop/alive checks below
+		case <-ticker.C:
+			// periodic check for a vanished or replaced socket file
+		}
+
+		if !a.alive() {
+			return
+		}
+		select {
+		case <-stop:
+			return // Cleanup raced us to the dead channel
+		default:
+		}
+
+		reason := a.attachUnhealthyReason()
+		if reason == "" {
+			continue
+		}
+		rebound, err := a.rebindListener()
+		if err != nil {
+			log.Printf("agent %s: attach listener rebind (%s) failed: %v", a.Name, reason, err)
+			continue
+		}
+		if !rebound {
+			return // Cleanup retired the listener while we were deciding
+		}
+		log.Printf("agent %s: attach listener rebound on %s (%s)", a.Name, a.socketPath, reason)
+		a.emitAttachRebound(reason)
+	}
+}
+
+// attachUnhealthyReason names the reason attach connections can no longer land,
+// or "" when the listener is healthy: a live accept loop bound to the socket
+// file that is actually at socketPath.
+func (a *Agent) attachUnhealthyReason() string {
+	a.mu.Lock()
+	l, dead, ino := a.listener, a.listenerDead, a.socketIno
+	a.mu.Unlock()
+
+	if l == nil || dead == nil {
+		return "no_listener"
+	}
+	select {
+	case <-dead:
+		return "accept_loop_stopped"
+	default:
+	}
+	if ino == 0 {
+		return "" // inode unknown — nothing to compare against
+	}
+	switch cur := fileInode(a.socketPath); {
+	case cur == 0:
+		return "socket_file_missing"
+	case cur != ino:
+		return "socket_file_replaced"
+	}
+	return ""
+}
+
+// rebindListener re-creates the attach socket for a still-live agent. It reports
+// whether it rebound; once Cleanup has retired the listener it does nothing and
+// returns false, so a retired agent never gets its socket resurrected.
+func (a *Agent) rebindListener() (bool, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.attachStopped {
+		return false, nil
+	}
+	if err := a.bindListenerLocked(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// emitAttachRebound records that the attach socket was repaired under a live
+// agent — the operator-visible signal that this fault occurred.
+func (a *Agent) emitAttachRebound(reason string) {
+	events.Emit(context.Background(), events.Event{
+		EventType: "agent_attach_rebound",
+		Agent:     a.eventAgent(),
+		Repo:      a.SourceRepo,
+		Details: map[string]any{
+			"pid":    a.PID,
+			"socket": a.socketPath,
+			"reason": reason,
+		},
+	})
+}
+
+// disarmUnlinkOnClose stops a unix listener from unlinking its socket path on
+// Close. Go unlinks by path, so a listener closed after the path was rebound
+// would otherwise delete the new socket.
+func disarmUnlinkOnClose(l net.Listener) {
+	if ul, ok := l.(*net.UnixListener); ok {
+		ul.SetUnlinkOnClose(false)
+	}
+}
+
+// fileInode returns the inode of path, or 0 when it cannot be determined.
+func fileInode(path string) uint64 {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0
+	}
+	return uint64(st.Ino)
 }
 
 // handleAttach bridges a unix socket connection to the PTY master.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1316,6 +1316,46 @@ const (
 	attachAcceptMaxBackoff = time.Second
 )
 
+// Rebind backoff bounds. A listener that dies the instant it is rebound — a
+// recurring permanent Accept error — would otherwise drive the supervisor as a
+// hot loop: a pegged core and one agent_attach_rebound event per iteration. The
+// backoff resets once a listener has survived attachRebindResetAfter, so
+// unrelated faults hours apart each still get an immediate repair.
+const (
+	attachRebindMinBackoff = 50 * time.Millisecond
+	attachRebindMaxBackoff = 30 * time.Second
+	attachRebindResetAfter = 5 * time.Minute
+)
+
+// acceptRetryLogInterval rate-limits the per-retry log line during a sustained
+// accept-error streak, so a wedged listener cannot flood the daemon log.
+const acceptRetryLogInterval = 30 * time.Second
+
+// isRetryableAcceptErr reports whether Accept failed for a reason that may clear
+// on its own, so the loop should back off and keep serving rather than retire
+// the listener.
+//
+// Errno.Temporary() covers only EINTR, EMFILE, ENFILE and the timeout errnos.
+// accept(2) also fails with ENOMEM/ENOBUFS under memory pressure, and with
+// ECONNABORTED/ECONNRESET when a peer goes away between connect and accept — all
+// recoverable, none reported as temporary. Anything else (EPERM under a sandbox
+// policy, EBADF, EINVAL) is genuinely permanent: the loop returns and the
+// supervisor rebinds on its own bounded backoff.
+func isRetryableAcceptErr(err error) bool {
+	var tmp interface{ Temporary() bool }
+	if errors.As(err, &tmp) && tmp.Temporary() {
+		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case syscall.ENOMEM, syscall.ENOBUFS, syscall.ECONNABORTED, syscall.ECONNRESET:
+			return true
+		}
+	}
+	return false
+}
+
 // startListener creates a unix domain socket for attach connections and starts
 // the supervisor that keeps it usable for the life of the process. The
 // supervisor starts even when the first bind fails, so an agent spawned during
@@ -1377,21 +1417,24 @@ func (a *Agent) acceptLoop(l net.Listener, dead chan struct{}) {
 	defer close(dead)
 
 	var backoff time.Duration
+	var lastLog time.Time
 	for {
 		conn, err := l.Accept()
 		if err != nil {
 			if errors.Is(err, net.ErrClosed) {
 				return // listener closed by Cleanup or a rebind
 			}
-			// A transient accept error must not retire the listener. Under fd
+			// A recoverable accept error must not retire the listener. Under fd
 			// exhaustion Accept returns EMFILE/ENFILE; returning here leaves the
 			// socket file bound with nobody accepting, so the listen backlog
 			// fills and every later attach gets ECONNREFUSED against a perfectly
 			// healthy agent — the mg-d216 symptom.
-			var tmp interface{ Temporary() bool }
-			if errors.As(err, &tmp) && tmp.Temporary() {
+			if isRetryableAcceptErr(err) {
 				backoff = nextAcceptBackoff(backoff)
-				log.Printf("agent %s: attach accept: %v — retrying in %s", a.Name, err, backoff)
+				if lastLog.IsZero() || time.Since(lastLog) >= acceptRetryLogInterval {
+					log.Printf("agent %s: attach accept: %v — retrying in %s", a.Name, err, backoff)
+					lastLog = time.Now()
+				}
 				time.Sleep(backoff)
 				continue
 			}
@@ -1399,19 +1442,30 @@ func (a *Agent) acceptLoop(l net.Listener, dead chan struct{}) {
 			return // permanent — the supervisor rebinds while the process lives
 		}
 		backoff = 0
+		lastLog = time.Time{}
 		go a.handleAttach(conn)
 	}
 }
 
 // nextAcceptBackoff doubles the accept-retry delay up to attachAcceptMaxBackoff.
 func nextAcceptBackoff(cur time.Duration) time.Duration {
-	if cur == 0 {
-		return attachAcceptMinBackoff
+	return doubleBackoff(cur, attachAcceptMinBackoff, attachAcceptMaxBackoff)
+}
+
+// nextRebindBackoff doubles the rebind delay up to attachRebindMaxBackoff.
+func nextRebindBackoff(cur time.Duration) time.Duration {
+	return doubleBackoff(cur, attachRebindMinBackoff, attachRebindMaxBackoff)
+}
+
+// doubleBackoff returns min, then doubles toward max, saturating there.
+func doubleBackoff(cur, min, max time.Duration) time.Duration {
+	if cur <= 0 {
+		return min
 	}
-	if next := cur * 2; next < attachAcceptMaxBackoff {
+	if next := cur * 2; next < max {
 		return next
 	}
-	return attachAcceptMaxBackoff
+	return max
 }
 
 // superviseListener ties the attach socket's lifetime to the process's. It
@@ -1429,6 +1483,12 @@ func nextAcceptBackoff(cur time.Duration) time.Duration {
 func (a *Agent) superviseListener(stop chan struct{}, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+
+	// Rebinding is repair, and repair that never succeeds must not become a hot
+	// loop: an Accept error that recurs on every fresh listener would otherwise
+	// spin the supervisor at syscall speed, one event written per iteration.
+	var backoff time.Duration
+	var lastRebind time.Time
 
 	for {
 		a.mu.Lock()
@@ -1460,16 +1520,47 @@ func (a *Agent) superviseListener(stop chan struct{}, interval time.Duration) {
 		if reason == "" {
 			continue
 		}
+
+		// A listener that has been healthy for a while makes this a fresh
+		// incident, not a flap — repair it immediately.
+		if !lastRebind.IsZero() && time.Since(lastRebind) >= attachRebindResetAfter {
+			backoff = 0
+		}
+
 		rebound, err := a.rebindListener()
-		if err != nil {
+		switch {
+		case err != nil:
 			log.Printf("agent %s: attach listener rebind (%s) failed: %v", a.Name, reason, err)
-			continue
-		}
-		if !rebound {
+		case !rebound:
 			return // Cleanup retired the listener while we were deciding
+		default:
+			log.Printf("agent %s: attach listener rebound on %s (%s)", a.Name, a.socketPath, reason)
+			a.emitAttachRebound(reason)
 		}
-		log.Printf("agent %s: attach listener rebound on %s (%s)", a.Name, a.socketPath, reason)
-		a.emitAttachRebound(reason)
+
+		// Throttle the next repair — after both a failed bind and a rebind whose
+		// listener may die again immediately. This bounds the loop's rate, and
+		// with it the agent_attach_rebound event rate and the rebind-failure log.
+		lastRebind = time.Now()
+		backoff = nextRebindBackoff(backoff)
+		if !a.sleepInterruptibly(backoff, stop) {
+			return
+		}
+	}
+}
+
+// sleepInterruptibly waits for d, returning false if the agent was retired or
+// its process exited first — so Cleanup never blocks behind a backoff.
+func (a *Agent) sleepInterruptibly(d time.Duration, stop chan struct{}) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-stop:
+		return false
+	case <-a.done:
+		return false
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -136,11 +136,14 @@ type Agent struct {
 	socketPath string
 	listener   net.Listener
 
-	// socketIno is the inode of the socket file the current listener is bound
-	// to. The supervisor compares it against whatever now sits at socketPath to
-	// notice a socket that was unlinked underneath us (macOS reaps stale entries
-	// under $TMPDIR) or replaced by a foreign bind. 0 means "unknown, skip it".
-	socketIno uint64
+	// socketInfo identifies the socket file the current listener is bound to.
+	// The supervisor compares it (os.SameFile — device + inode) against whatever
+	// now sits at socketPath, to notice a socket that was unlinked underneath us
+	// (macOS reaps stale entries under $TMPDIR) or replaced by a foreign bind.
+	// nil means "unknown, skip the check". Best-effort: a rebind of the same
+	// path can reuse the inode number, so a replacement can go unnoticed. The
+	// accept-loop and missing-file signals below are exact; this one is a guard.
+	socketInfo os.FileInfo
 
 	// listenerDead is closed by acceptLoop when it stops serving. The supervisor
 	// waits on it so a listener that dies while the process lives gets rebound
@@ -1300,7 +1303,7 @@ func (a *Agent) retireListenerLocked() {
 		a.listener = nil
 	}
 	os.Remove(a.socketPath)
-	a.socketIno = 0
+	a.socketInfo = nil
 }
 
 // attachSupervisorInterval is how often the attach-listener supervisor re-checks
@@ -1352,11 +1355,11 @@ func (a *Agent) bindListenerLocked() error {
 		// A nil listenerDead parks the supervisor's select on that arm, so it
 		// retries on the ticker rather than spinning on a closed channel.
 		a.listenerDead = nil
-		a.socketIno = 0
+		a.socketInfo = nil
 		return fmt.Errorf("listen: %w", err)
 	}
 	a.listener = l
-	a.socketIno = fileInode(a.socketPath)
+	a.socketInfo, _ = os.Stat(a.socketPath)
 
 	// Pass listener and dead channel directly so acceptLoop doesn't access
 	// a.listener, avoiding a nil-pointer race when Cleanup nils it concurrently.
@@ -1475,7 +1478,7 @@ func (a *Agent) superviseListener(stop chan struct{}, interval time.Duration) {
 // file that is actually at socketPath.
 func (a *Agent) attachUnhealthyReason() string {
 	a.mu.Lock()
-	l, dead, ino := a.listener, a.listenerDead, a.socketIno
+	l, dead, want := a.listener, a.listenerDead, a.socketInfo
 	a.mu.Unlock()
 
 	if l == nil || dead == nil {
@@ -1486,13 +1489,14 @@ func (a *Agent) attachUnhealthyReason() string {
 		return "accept_loop_stopped"
 	default:
 	}
-	if ino == 0 {
-		return "" // inode unknown — nothing to compare against
+	if want == nil {
+		return "" // identity unknown — nothing to compare against
 	}
-	switch cur := fileInode(a.socketPath); {
-	case cur == 0:
+	cur, err := os.Stat(a.socketPath)
+	if err != nil {
 		return "socket_file_missing"
-	case cur != ino:
+	}
+	if !os.SameFile(cur, want) {
 		return "socket_file_replaced"
 	}
 	return ""
@@ -1535,19 +1539,6 @@ func disarmUnlinkOnClose(l net.Listener) {
 	if ul, ok := l.(*net.UnixListener); ok {
 		ul.SetUnlinkOnClose(false)
 	}
-}
-
-// fileInode returns the inode of path, or 0 when it cannot be determined.
-func fileInode(path string) uint64 {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return 0
-	}
-	st, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		return 0
-	}
-	return uint64(st.Ino)
 }
 
 // handleAttach bridges a unix socket connection to the PTY master.

--- a/internal/agent/attach_listener_test.go
+++ b/internal/agent/attach_listener_test.go
@@ -224,6 +224,109 @@ func TestRebindListenerNoOpAfterCleanup(t *testing.T) {
 	}
 }
 
+// TestSupervisorThrottlesRebindFlap is the regression for review round 1's
+// blocking finding: a listener that dies the instant it is rebound must not
+// drive the supervisor as a hot loop. Unthrottled this measured ~10,900
+// rebinds/sec, each writing an agent_attach_rebound event (~7.8 GB/hour into
+// events.log) while pegging a core, for the life of the process.
+//
+// The flap is simulated by killing every new accept loop the moment it appears,
+// which is what a recurring permanent Accept error (ENOMEM, EPERM) does.
+func TestSupervisorThrottlesRebindFlap(t *testing.T) {
+	withSupervisorInterval(t, time.Hour) // isolate: only the dead-channel path drives this
+	a := spawnAgent(t, "rebind-flap", "sleep", "30")
+
+	if !waitForAttach(t, a, 2*time.Second) {
+		t.Fatal("attach socket not usable before the fault was injected")
+	}
+
+	const window = 600 * time.Millisecond
+	seen := map[net.Listener]bool{}
+	prev, _ := listenerID(a)
+
+	// Kill each listener as soon as the supervisor installs it.
+	killAcceptLoopLocked(a)
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		if cur, _ := listenerID(a); cur != nil && cur != prev {
+			seen[cur] = true
+			prev = cur
+			killAcceptLoopLocked(a)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// With backoff (50ms doubling to 30s) a 600ms window admits ~4 rebinds.
+	// Without it, thousands. The bound is deliberately loose — this test guards
+	// an order of magnitude, not an exact schedule.
+	const maxRebinds = 15
+	if len(seen) > maxRebinds {
+		t.Errorf("supervisor rebound %d times in %s — rebind path is not throttled", len(seen), window)
+	}
+	if len(seen) == 0 {
+		t.Error("supervisor never rebound the flapping listener at all")
+	}
+}
+
+// killAcceptLoopLocked closes the current listener while leaving its socket file,
+// without the *testing.T fatal path — safe to call from a polling loop.
+func killAcceptLoopLocked(a *Agent) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.listener != nil {
+		disarmUnlinkOnClose(a.listener)
+		a.listener.Close()
+	}
+}
+
+// TestIsRetryableAcceptErr pins the classification the accept loop rests on.
+// Errno.Temporary() covers only EINTR/EMFILE/ENFILE/timeouts, so the errnos
+// accept(2) raises under memory pressure must be named explicitly — otherwise
+// they fall through to the (throttled, but pointless) rebind path.
+func TestIsRetryableAcceptErr(t *testing.T) {
+	opErr := func(e syscall.Errno) error {
+		return &net.OpError{Op: "accept", Net: "unix", Err: os.NewSyscallError("accept", e)}
+	}
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"EMFILE (fd exhaustion — the mg-d216 trigger)", opErr(syscall.EMFILE), true},
+		{"ENFILE (system-wide fd exhaustion)", opErr(syscall.ENFILE), true},
+		{"EINTR", opErr(syscall.EINTR), true},
+		{"ENOMEM (memory pressure)", opErr(syscall.ENOMEM), true},
+		{"ENOBUFS (memory pressure)", opErr(syscall.ENOBUFS), true},
+		{"ECONNABORTED (peer vanished)", opErr(syscall.ECONNABORTED), true},
+		{"ECONNRESET (peer vanished)", opErr(syscall.ECONNRESET), true},
+		{"EPERM (sandbox policy — permanent)", opErr(syscall.EPERM), false},
+		{"EBADF (permanent)", opErr(syscall.EBADF), false},
+		{"EINVAL (permanent)", opErr(syscall.EINVAL), false},
+		{"ErrClosed (deliberate)", net.ErrClosed, false},
+	}
+	for _, tc := range cases {
+		if got := isRetryableAcceptErr(tc.err); got != tc.want {
+			t.Errorf("isRetryableAcceptErr(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestRebindBackoffIsBounded keeps the repair loop's throttle honest.
+func TestRebindBackoffIsBounded(t *testing.T) {
+	if got := nextRebindBackoff(0); got != attachRebindMinBackoff {
+		t.Errorf("first rebind backoff = %s, want %s", got, attachRebindMinBackoff)
+	}
+	if got := nextRebindBackoff(attachRebindMinBackoff); got != 2*attachRebindMinBackoff {
+		t.Errorf("second rebind backoff = %s, want %s", got, 2*attachRebindMinBackoff)
+	}
+	if got := nextRebindBackoff(attachRebindMaxBackoff); got != attachRebindMaxBackoff {
+		t.Errorf("saturated rebind backoff = %s, want %s", got, attachRebindMaxBackoff)
+	}
+	if got := nextRebindBackoff(attachRebindMaxBackoff / 2); got != attachRebindMaxBackoff {
+		t.Errorf("rebind backoff overshoot = %s, want clamp to %s", got, attachRebindMaxBackoff)
+	}
+}
+
 // stubListener feeds acceptLoop a scripted sequence of Accept errors.
 type stubListener struct {
 	mu     sync.Mutex

--- a/internal/agent/attach_listener_test.go
+++ b/internal/agent/attach_listener_test.go
@@ -10,6 +10,42 @@ import (
 	"time"
 )
 
+// listenerID returns the identity of the agent's current attach listener. A
+// rebind installs a new listener and a new dead channel, so a change here is
+// exactly what "the socket was rebound" means. Inode numbers are not usable for
+// this: Linux happily reuses one across an unlink/rebind of the same path.
+func listenerID(a *Agent) (net.Listener, chan struct{}) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.listener, a.listenerDead
+}
+
+// waitForRebind blocks until the agent's listener identity changes from the one
+// given, reporting whether it did within the timeout.
+func waitForRebind(t *testing.T, a *Agent, oldL net.Listener, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if l, _ := listenerID(a); l != oldL && l != nil {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+// ownsSocketPath reports whether the file at socketPath is the one the agent's
+// listener is currently bound to.
+func ownsSocketPath(a *Agent) bool {
+	cur, err := os.Stat(a.SocketPath())
+	if err != nil {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.socketInfo != nil && os.SameFile(cur, a.socketInfo)
+}
+
 // Regression coverage for mg-d216: `pogo agent attach mayor` failed with
 // "connect: connection refused" against a socket file that existed, while the
 // mayor process was alive and healthy. On a unix socket that pairing means the
@@ -74,15 +110,21 @@ func TestAttachRebindsAfterAcceptLoopDies(t *testing.T) {
 	if !waitForAttach(t, a, 2*time.Second) {
 		t.Fatal("attach socket not usable before the fault was injected")
 	}
-	before := fileInode(a.SocketPath())
+	oldListener, oldDead := listenerID(a)
 
 	killAcceptLoop(t, a)
 
-	if !waitForAttach(t, a, 3*time.Second) {
+	if !waitForRebind(t, a, oldListener, 3*time.Second) {
+		t.Fatal("supervisor never rebound the listener after the accept loop died")
+	}
+	if _, dead := listenerID(a); dead == oldDead {
+		t.Error("listener rebound but the accept loop was not restarted")
+	}
+	if !waitForAttach(t, a, 2*time.Second) {
 		t.Fatal("attach socket never recovered after the accept loop died")
 	}
-	if after := fileInode(a.SocketPath()); after == 0 || after == before {
-		t.Errorf("expected a freshly bound socket, inode before=%d after=%d", before, after)
+	if !ownsSocketPath(a) {
+		t.Error("agent does not own the socket file at its own path after rebind")
 	}
 }
 
@@ -96,11 +138,15 @@ func TestAttachRebindsAfterSocketFileRemoved(t *testing.T) {
 	if !waitForAttach(t, a, 2*time.Second) {
 		t.Fatal("attach socket not usable before the fault was injected")
 	}
+	oldListener, _ := listenerID(a)
 	if err := os.Remove(a.SocketPath()); err != nil {
 		t.Fatalf("remove socket: %v", err)
 	}
 
-	if !waitForAttach(t, a, 3*time.Second) {
+	if !waitForRebind(t, a, oldListener, 3*time.Second) {
+		t.Fatal("supervisor never rebound the listener after the socket file was removed")
+	}
+	if !waitForAttach(t, a, 2*time.Second) {
 		t.Fatal("attach socket never recovered after the socket file was removed")
 	}
 }
@@ -114,6 +160,8 @@ func TestAttachRebindsAfterSocketFileReplaced(t *testing.T) {
 	if !waitForAttach(t, a, 2*time.Second) {
 		t.Fatal("attach socket not usable before the fault was injected")
 	}
+	oldListener, _ := listenerID(a)
+
 	// Replace the socket file with a foreign listener nobody accepts on.
 	os.Remove(a.SocketPath())
 	foreign, err := net.Listen("unix", a.SocketPath())
@@ -122,26 +170,19 @@ func TestAttachRebindsAfterSocketFileReplaced(t *testing.T) {
 	}
 	disarmUnlinkOnClose(foreign)
 	defer foreign.Close()
-	foreignIno := fileInode(a.SocketPath())
 
 	// The supervisor must notice the path no longer names its own socket and
-	// reclaim it. Inode identity is the assertion — a dial would succeed against
-	// the foreign listener's backlog and prove nothing.
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		cur := fileInode(a.SocketPath())
-		a.mu.Lock()
-		owned := a.socketIno
-		a.mu.Unlock()
-		if cur != 0 && cur != foreignIno && cur == owned {
-			if !waitForAttach(t, a, time.Second) {
-				t.Fatal("reclaimed socket is not attachable")
-			}
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
+	// reclaim it. Listener identity is the assertion — a dial would succeed
+	// against the foreign listener's backlog and prove nothing.
+	if !waitForRebind(t, a, oldListener, 3*time.Second) {
+		t.Fatal("supervisor never reclaimed the replaced socket path")
 	}
-	t.Fatal("supervisor never reclaimed the replaced socket path")
+	if !ownsSocketPath(a) {
+		t.Error("agent does not own the socket file at its own path after reclaim")
+	}
+	if !waitForAttach(t, a, 2*time.Second) {
+		t.Fatal("reclaimed socket is not attachable")
+	}
 }
 
 // TestAttachNotRecreatedAfterCleanup: a retired agent's supervisor must not

--- a/internal/agent/attach_listener_test.go
+++ b/internal/agent/attach_listener_test.go
@@ -1,0 +1,263 @@
+package agent
+
+import (
+	"errors"
+	"net"
+	"os"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Regression coverage for mg-d216: `pogo agent attach mayor` failed with
+// "connect: connection refused" against a socket file that existed, while the
+// mayor process was alive and healthy. On a unix socket that pairing means the
+// file is there but nothing is accepting: the accept loop had died under a live
+// process and never came back.
+//
+// The old acceptLoop returned on *any* Accept error, including transient ones
+// (EMFILE/ENFILE under fd exhaustion). The listener stayed bound, the backlog
+// filled after ~128 queued connects, and every later attach was refused. Nothing
+// ever rebound it.
+//
+// These tests pin both halves of the fix: the accept loop survives transient
+// errors, and a supervisor rebinds a socket that dies or vanishes under a live
+// agent — without ever resurrecting one for an agent that has been cleaned up.
+
+// withSupervisorInterval retunes the supervisor tick for the duration of a test.
+// Agents snapshot the value on the spawning goroutine (Agent.supervisorInterval),
+// so this write never races a running supervisor.
+func withSupervisorInterval(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := attachSupervisorInterval
+	attachSupervisorInterval = d
+	t.Cleanup(func() { attachSupervisorInterval = prev })
+}
+
+// waitForAttach polls the agent's socket until a dial succeeds, and reports
+// whether it ever did within the timeout.
+func waitForAttach(t *testing.T, a *Agent, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.Dial("unix", a.SocketPath())
+		if err == nil {
+			conn.Close()
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+// killAcceptLoop reproduces the observed fault: the accept loop stops, but the
+// socket file is left behind. Disarming unlink-on-close is what makes the file
+// linger exactly as it did on the wedged mayor.
+func killAcceptLoop(t *testing.T, a *Agent) {
+	t.Helper()
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.listener == nil {
+		t.Fatal("agent has no attach listener")
+	}
+	disarmUnlinkOnClose(a.listener)
+	a.listener.Close()
+}
+
+// TestAttachRebindsAfterAcceptLoopDies is the direct regression for the reported
+// bug: file present, nothing accepting, process alive → attach must recover.
+func TestAttachRebindsAfterAcceptLoopDies(t *testing.T) {
+	withSupervisorInterval(t, 10*time.Millisecond)
+	a := spawnAgent(t, "rebind-dead-loop", "sleep", "30")
+
+	if !waitForAttach(t, a, 2*time.Second) {
+		t.Fatal("attach socket not usable before the fault was injected")
+	}
+	before := fileInode(a.SocketPath())
+
+	killAcceptLoop(t, a)
+
+	if !waitForAttach(t, a, 3*time.Second) {
+		t.Fatal("attach socket never recovered after the accept loop died")
+	}
+	if after := fileInode(a.SocketPath()); after == 0 || after == before {
+		t.Errorf("expected a freshly bound socket, inode before=%d after=%d", before, after)
+	}
+}
+
+// TestAttachRebindsAfterSocketFileRemoved covers the other live-process failure:
+// the socket file is unlinked underneath a working listener (macOS reaps stale
+// entries under $TMPDIR), which leaves the listener bound to an orphaned inode.
+func TestAttachRebindsAfterSocketFileRemoved(t *testing.T) {
+	withSupervisorInterval(t, 10*time.Millisecond)
+	a := spawnAgent(t, "rebind-unlinked", "sleep", "30")
+
+	if !waitForAttach(t, a, 2*time.Second) {
+		t.Fatal("attach socket not usable before the fault was injected")
+	}
+	if err := os.Remove(a.SocketPath()); err != nil {
+		t.Fatalf("remove socket: %v", err)
+	}
+
+	if !waitForAttach(t, a, 3*time.Second) {
+		t.Fatal("attach socket never recovered after the socket file was removed")
+	}
+}
+
+// TestAttachRebindsAfterSocketFileReplaced covers a foreign bind taking over the
+// path: the agent's listener is still alive but is no longer reachable by name.
+func TestAttachRebindsAfterSocketFileReplaced(t *testing.T) {
+	withSupervisorInterval(t, 10*time.Millisecond)
+	a := spawnAgent(t, "rebind-replaced", "sleep", "30")
+
+	if !waitForAttach(t, a, 2*time.Second) {
+		t.Fatal("attach socket not usable before the fault was injected")
+	}
+	// Replace the socket file with a foreign listener nobody accepts on.
+	os.Remove(a.SocketPath())
+	foreign, err := net.Listen("unix", a.SocketPath())
+	if err != nil {
+		t.Fatalf("foreign listen: %v", err)
+	}
+	disarmUnlinkOnClose(foreign)
+	defer foreign.Close()
+	foreignIno := fileInode(a.SocketPath())
+
+	// The supervisor must notice the path no longer names its own socket and
+	// reclaim it. Inode identity is the assertion — a dial would succeed against
+	// the foreign listener's backlog and prove nothing.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		cur := fileInode(a.SocketPath())
+		a.mu.Lock()
+		owned := a.socketIno
+		a.mu.Unlock()
+		if cur != 0 && cur != foreignIno && cur == owned {
+			if !waitForAttach(t, a, time.Second) {
+				t.Fatal("reclaimed socket is not attachable")
+			}
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("supervisor never reclaimed the replaced socket path")
+}
+
+// TestAttachNotRecreatedAfterCleanup: a retired agent's supervisor must not
+// resurrect the socket. Cleanup is the authority on teardown.
+func TestAttachNotRecreatedAfterCleanup(t *testing.T) {
+	withSupervisorInterval(t, 10*time.Millisecond)
+	a := spawnAgent(t, "no-zombie-socket", "sleep", "30")
+
+	if !waitForAttach(t, a, 2*time.Second) {
+		t.Fatal("attach socket not usable before cleanup")
+	}
+	a.Cleanup()
+
+	// Give the supervisor several ticks to misbehave.
+	time.Sleep(100 * time.Millisecond)
+	if _, err := os.Stat(a.SocketPath()); !os.IsNotExist(err) {
+		t.Errorf("socket file exists after Cleanup: stat err = %v", err)
+	}
+}
+
+// TestRebindListenerNoOpAfterCleanup pins the race directly: a supervisor that
+// decided to rebind, but lost to Cleanup, must not bind — and must report that
+// it didn't, so no bogus agent_attach_rebound event is emitted.
+func TestRebindListenerNoOpAfterCleanup(t *testing.T) {
+	withSupervisorInterval(t, time.Hour) // supervisor must not act on its own here
+	a := spawnAgent(t, "rebind-after-cleanup", "sleep", "30")
+
+	a.Cleanup()
+
+	rebound, err := a.rebindListener()
+	if err != nil {
+		t.Fatalf("rebindListener after Cleanup: %v", err)
+	}
+	if rebound {
+		t.Error("rebindListener rebound a socket for a cleaned-up agent")
+	}
+	if _, err := os.Stat(a.SocketPath()); !os.IsNotExist(err) {
+		t.Errorf("socket file recreated after Cleanup: stat err = %v", err)
+	}
+}
+
+// stubListener feeds acceptLoop a scripted sequence of Accept errors.
+type stubListener struct {
+	mu     sync.Mutex
+	errs   []error
+	calls  int
+	closed chan struct{}
+}
+
+func (s *stubListener) Accept() (net.Conn, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	if len(s.errs) > 0 {
+		err := s.errs[0]
+		s.errs = s.errs[1:]
+		return nil, err
+	}
+	return nil, net.ErrClosed
+}
+
+func (s *stubListener) Close() error   { return nil }
+func (s *stubListener) Addr() net.Addr { return &net.UnixAddr{Name: "stub", Net: "unix"} }
+
+func (s *stubListener) acceptCalls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+// TestAcceptLoopSurvivesTemporaryError pins the root cause: an EMFILE from
+// Accept — the shape fd exhaustion produces — must be retried, not fatal.
+// Before the fix the loop returned on the first error and the agent became
+// permanently unattachable.
+func TestAcceptLoopSurvivesTemporaryError(t *testing.T) {
+	emfile := &net.OpError{
+		Op:  "accept",
+		Net: "unix",
+		Err: os.NewSyscallError("accept", syscall.EMFILE),
+	}
+	// Sanity-check the assumption the retry predicate rests on.
+	var tmp interface{ Temporary() bool }
+	if !errors.As(error(emfile), &tmp) || !tmp.Temporary() {
+		t.Fatal("EMFILE OpError is not reported as temporary; the retry predicate is wrong")
+	}
+
+	stub := &stubListener{errs: []error{emfile, emfile, emfile}}
+	a := &Agent{Name: "temp-err"}
+	dead := make(chan struct{})
+
+	go a.acceptLoop(stub, dead)
+
+	select {
+	case <-dead:
+		// The loop retried all three EMFILEs, then hit ErrClosed and exited.
+		if got := stub.acceptCalls(); got != 4 {
+			t.Errorf("Accept calls = %d, want 4 (3 retries + terminal ErrClosed)", got)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("acceptLoop never terminated")
+	}
+}
+
+// TestAcceptLoopBackoffIsBounded keeps the retry from becoming a hot spin or an
+// unbounded sleep.
+func TestAcceptLoopBackoffIsBounded(t *testing.T) {
+	if got := nextAcceptBackoff(0); got != attachAcceptMinBackoff {
+		t.Errorf("first backoff = %s, want %s", got, attachAcceptMinBackoff)
+	}
+	if got := nextAcceptBackoff(attachAcceptMinBackoff); got != 2*attachAcceptMinBackoff {
+		t.Errorf("second backoff = %s, want %s", got, 2*attachAcceptMinBackoff)
+	}
+	if got := nextAcceptBackoff(attachAcceptMaxBackoff); got != attachAcceptMaxBackoff {
+		t.Errorf("saturated backoff = %s, want %s", got, attachAcceptMaxBackoff)
+	}
+	if got := nextAcceptBackoff(attachAcceptMaxBackoff / 2); got != attachAcceptMaxBackoff {
+		t.Errorf("backoff overshoot = %s, want clamp to %s", got, attachAcceptMaxBackoff)
+	}
+}

--- a/internal/agent/testmain_test.go
+++ b/internal/agent/testmain_test.go
@@ -2,7 +2,10 @@ package agent
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/drellem2/pogo/internal/events"
 )
 
 // TestMain clears any ambient POGO_HOME (e.g. exported by the developer's
@@ -12,7 +15,25 @@ import (
 // POGO_HOME would defeat that isolation and leak test writes into the real
 // state dir. Tests that exercise POGO_HOME semantics set it explicitly via
 // t.Setenv.
+//
+// It also re-points the event log at a throwaway file. Spawning agents emits
+// real events, and events.Emit resolves its path once, before any test can
+// re-point HOME — so without this the package writes agent_spawned and
+// agent_attach_rebound records into the developer's live ~/.pogo/events.log.
+// agent_attach_rebound is an operator alarm for a production fault (mg-d216);
+// a test run must not manufacture one.
 func TestMain(m *testing.M) {
 	os.Unsetenv("POGO_HOME")
-	os.Exit(m.Run())
+
+	logDir, err := os.MkdirTemp("", "pogo-agent-events")
+	if err != nil {
+		panic("create temp event log dir: " + err.Error())
+	}
+	events.SetLogPathForTesting(filepath.Join(logDir, "events.log"))
+
+	code := m.Run()
+
+	events.SetLogPathForTesting("")
+	os.RemoveAll(logDir)
+	os.Exit(code)
 }


### PR DESCRIPTION
Daniel could not `pogo agent attach mayor`: the dial failed with `connect: connection refused` against `mayor.sock`, a socket file that existed, while the mayor process was alive, healthy, and 40h into its loop.

## Root cause

On a unix socket, "file exists + connection refused" means exactly one thing: **nothing is accepting on it.**

`acceptLoop` returned on *any* `Accept` error:

```go
conn, err := l.Accept()
if err != nil {
    return // listener closed
}
```

That comment was the bug — not every `Accept` error is a closed listener. Under fd exhaustion `Accept` returns `EMFILE`/`ENFILE`, which are *transient*. The loop retired itself while the listener stayed bound. The socket file lingered, nothing accepted, and once the 128-slot listen backlog filled, every subsequent attach was refused. Nothing ever rebound it, so a long-running crew agent stayed unattachable for the rest of its life. (This machine had an fd-leak window — see mg-d205 — which is the most likely trigger.)

Reproduced standalone: bind a unix socket, never call `Accept`, dial it 129 times. The file is `srwxr-xr-x`, dial #129 returns `connect: connection refused` — Daniel's symptom exactly.

## Fix

Both halves of the ticket's fix direction:

1. **The accept loop no longer dies silently.** Transient `Accept` errors are retried with bounded backoff (5ms doubling to 1s). Only a deliberate close (`net.ErrClosed`) exits the loop.
2. **The listener is tied to process lifetime.** A supervisor rebinds the attach socket when it stops being served, when the socket file is unlinked underneath a live listener (macOS reaps stale entries under `$TMPDIR` — the likely explanation for the socket mtime landing well after process start), or when the path is taken over by a foreign bind (detected by inode identity). It starts even when the first bind fails, so an agent spawned during fd exhaustion regains attach instead of losing it permanently.

`Cleanup` stays the authority on teardown: it retires the supervisor under the same lock a rebind takes, so a retired agent can never have its socket resurrected — the one race worth getting right here, and it has a dedicated test.

Each repair emits an **`agent_attach_rebound`** event (`reason` ∈ `accept_loop_stopped`, `no_listener`, `socket_file_missing`, `socket_file_replaced`) so operators see the fault occurring instead of inferring it from a refused attach. Documented in `docs/event-log.md`; additive, no `schema_version` bump.

## Tests

`internal/agent/attach_listener_test.go` — real spawned processes, real unix sockets:

- rebinds after the accept loop dies with the socket file left behind (the reported fault, injected in its exact shape)
- rebinds after the socket file is removed
- reclaims the path after a foreign listener takes it over (asserted on inode, since a dial would succeed against the foreign backlog and prove nothing)
- never recreates the socket after `Cleanup`, incl. a direct test of the Cleanup-vs-rebind race
- `acceptLoop` retries a real `EMFILE` `*net.OpError` and terminates only on `ErrClosed`; backoff is bounded

I verified the three rebind tests **fail** without the supervisor, so they pin the regression rather than merely passing. `./build.sh` is green; `go test ./internal/agent/ -race` is clean.

## Scope notes

- This is the durable root-cause fix. The immediate mayor restart is a separate track (Daniel's call) and is unaffected by this PR — a restart would also have cleared the wedge, just not prevented the next one.
- The ticket carries no `gh:` issue ref and names no triage ticket (it originated from an Apple Reminder, via mayor's in-loop diagnosis), so there is no issue to close and no triage recommendation to diff against. The fix direction in the ticket body served as the spec.

Work item: mg-d216