### PR TITLE
FIX: derive agent socketDir from PogoHome() not os.TempDir() (mg-8532)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,11 @@ RUN apk add --no-cache ca-certificates git tini
 
 RUN addgroup -S pogo && adduser -S pogo -G pogo
 
-RUN mkdir -p /workspace/repos /tmp/pogo-agents && \
-    chown -R pogo:pogo /workspace /tmp/pogo-agents
+# Agent attach sockets used to live in /tmp/pogo-agents, pre-created here. Since
+# mg-8532 they hang off PogoHome() (POGO_HOME, else $HOME/.pogo), which pogod
+# creates itself at startup — as it already did for the rest of the state tree.
+RUN mkdir -p /workspace/repos && \
+    chown -R pogo:pogo /workspace
 
 COPY --from=builder /pogod /usr/local/bin/pogod
 

--- a/cmd/pogod/main.go
+++ b/cmd/pogod/main.go
@@ -621,8 +621,26 @@ Flags:
 		}
 	}()
 
-	// Initialize agent registry
-	socketDir := filepath.Join(os.TempDir(), "pogo-agents")
+	// Initialize agent registry. The socket dir hangs off PogoHome, not
+	// os.TempDir(): $TMPDIR is per-user, so two daemons on distinct POGO_HOME
+	// roots with identically-named agents used to share one socket file and
+	// fight the mg-d216 supervisor over it forever (mg-8532).
+	socketDir := config.AgentSocketDir()
+	if pogoHome := filepath.Clean(config.PogoHome()); strings.HasPrefix(socketDir, pogoHome+string(filepath.Separator)) {
+		// NewRegistry creates socketDir with mode 0700, and MkdirAll stamps that
+		// mode on every parent it creates on the way down — including the agents/
+		// dir the sockets share with the prompt files, which has always been
+		// 0755. Create that parent first so a fresh POGO_HOME ends up with the
+		// same layout as an existing one. socketDir itself still lands at 0700,
+		// which is what an attach socket wants.
+		if err := os.MkdirAll(agent.PromptDir(), 0755); err != nil {
+			fmt.Printf("Cannot create agent state dir %s: %v\n", agent.PromptDir(), err)
+			os.Exit(1)
+		}
+	} else {
+		log.Printf("pogod: POGO_HOME %s is too deep to hold unix sockets (sun_path limit); "+
+			"agent attach sockets live in %s instead — still unique to this POGO_HOME", pogoHome, socketDir)
+	}
 	var initErr error
 	agentRegistry, initErr = agent.NewRegistry(socketDir)
 	if initErr != nil {

--- a/cmd/pogod/main.go
+++ b/cmd/pogod/main.go
@@ -625,8 +625,8 @@ Flags:
 	// os.TempDir(): $TMPDIR is per-user, so two daemons on distinct POGO_HOME
 	// roots with identically-named agents used to share one socket file and
 	// fight the mg-d216 supervisor over it forever (mg-8532).
-	socketDir := config.AgentSocketDir()
-	if pogoHome := filepath.Clean(config.PogoHome()); strings.HasPrefix(socketDir, pogoHome+string(filepath.Separator)) {
+	socketDir, insidePogoHome := config.AgentSocketDir()
+	if insidePogoHome {
 		// NewRegistry creates socketDir with mode 0700, and MkdirAll stamps that
 		// mode on every parent it creates on the way down — including the agents/
 		// dir the sockets share with the prompt files, which has always been
@@ -639,7 +639,8 @@ Flags:
 		}
 	} else {
 		log.Printf("pogod: POGO_HOME %s is too deep to hold unix sockets (sun_path limit); "+
-			"agent attach sockets live in %s instead — still unique to this POGO_HOME", pogoHome, socketDir)
+			"agent attach sockets live in %s instead — still unique to this POGO_HOME",
+			config.PogoHome(), socketDir)
 	}
 	var initErr error
 	agentRegistry, initErr = agent.NewRegistry(socketDir)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -300,9 +300,10 @@ filesystem-coordination model.
 
 Every pogo state path derives from a single root: `$POGO_HOME`, or `~/.pogo`
 when the variable is unset (`PogoHome()` in `internal/config/config.go`). That
-one function seeds `refinery-state.json`, `schedules.json`, `agents/`,
-`polecats/`, `events.log`, `recovery/`, `projects.json`, and `plugin/` — so the
-root you pick determines where *all* daemon state lives.
+one function seeds `refinery-state.json`, `schedules.json`, `agents/` (including
+the `agents/sockets/` attach sockets), `polecats/`, `events.log`, `recovery/`,
+`projects.json`, and `plugin/` — so the root you pick determines where *all*
+daemon state lives.
 
 **Running N pogo instances requires a distinct `POGO_HOME` per instance.**
 Because every state path hangs off `PogoHome()`, overriding `POGO_HOME` (or
@@ -323,3 +324,13 @@ and pogo normalizes a `POGO_HOME` equal to the user's home directory to
 `$HOME/.pogo` (the documented default) rather than scattering state across the
 home root. See the `PogoHome()` doc comment for the full rationale, including why
 it never falls back to `os.TempDir()`.
+
+One caveat on the attach sockets: a unix domain socket path cannot exceed
+`sun_path` (103 usable bytes on darwin, 107 on linux), and a deep enough
+`POGO_HOME` leaves no room for `agents/sockets/<agent>.sock`. Such a root — a
+scratch dir under `/var/folders` on darwin, say — puts the sockets in
+`$TMPDIR/pogo-agents-<hash of the root>` instead. The hash keeps distinct roots
+distinct, so the isolation guarantee holds either way; pogod logs a line at
+startup when it takes this path. Everything else still lives under the root. If
+you want your sockets under `POGO_HOME` (nicer to inspect and clean up), pick a
+shallow root: `~/.pogo-sandbox` fits comfortably, a 90-byte path does not.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -334,3 +334,13 @@ distinct, so the isolation guarantee holds either way; pogod logs a line at
 startup when it takes this path. Everything else still lives under the root. If
 you want your sockets under `POGO_HOME` (nicer to inspect and clean up), pick a
 shallow root: `~/.pogo-sandbox` fits comfortably, a 90-byte path does not.
+
+The same limit implies a ceiling on **agent names**: pogo reserves 24 bytes for
+`<agent>.sock` when choosing the socket directory (`MaxAgentNameLen`). Real names
+are far shorter — `pm-dealdesk` is 11, a polecat is named for its work item. But
+a name longer than 24 bytes, under a root deep enough to have consumed the
+headroom (roughly 53+ bytes), produces a socket path past `sun_path`: the agent
+spawns and runs, `pogo agent attach` does not work against it, and pogod logs
+`attach listener failed`. Nothing rejects such a name at spawn today. Under the
+default `~/.pogo` root there is room for a 64-byte name, so this is only
+reachable with both a deep root and a long name.

--- a/docs/event-log.md
+++ b/docs/event-log.md
@@ -122,8 +122,15 @@ pogod repaired an agent's attach socket while the agent process kept running. Th
 socket had stopped serving connections — see `reason` — so `pogo agent attach`
 would have failed against a live, healthy agent. Emitted once per repair; the
 agent is not restarted and loses no state. A steady trickle of these for one
-agent points at whatever keeps breaking the socket (fd exhaustion, a `$TMPDIR`
-reaper) rather than at the attach mechanism itself.
+agent points at whatever keeps breaking the socket (fd exhaustion, a tmp reaper
+if this root fell back to `$TMPDIR`) rather than at the attach mechanism itself.
+
+Before mg-8532 a steady `socket_file_replaced` trickle had one more cause: a
+second pogod on a *different* `POGO_HOME` binding the same `$TMPDIR`-derived
+socket path, so the two daemons unlinked and rebound each other's live socket
+every 30s. Socket paths now derive from `PogoHome()`, so two daemons on distinct
+roots can no longer collide. Seeing this reason repeat on a modern pogod means
+something outside pogo is replacing the file.
 
 Repairs are rate-limited: a listener that fails again the instant it is rebound
 (a recurring permanent `accept(2)` error) backs off from 50ms to a ceiling of
@@ -142,7 +149,7 @@ apart each get an immediate repair. Additive — no `schema_version` bump.
     - `socket_file_replaced` — a different socket now occupies the path.
 
 ```json
-{"schema_version":1,"timestamp":"2026-07-10T09:12:03.410000000Z","event_type":"agent_attach_rebound","agent":"crew-mayor","details":{"pid":23884,"socket":"/var/folders/4n/T/pogo-agents/mayor.sock","reason":"accept_loop_stopped"}}
+{"schema_version":1,"timestamp":"2026-07-10T09:12:03.410000000Z","event_type":"agent_attach_rebound","agent":"crew-mayor","details":{"pid":23884,"socket":"/Users/daniel/.pogo/agents/sockets/mayor.sock","reason":"accept_loop_stopped"}}
 ```
 
 ### Polecat-specific lifecycle

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -156,6 +156,12 @@ If you are running an older pogod, expect `pogo agent attach` to reach whichever
 daemon bound the socket last, and expect the two daemons' attach supervisors to
 unlink and rebind each other's live socket every 30s (mg-d216).
 
+A root too deep to fit a unix socket path keeps the isolation but not the
+location: its sockets land in `$TMPDIR/pogo-agents-<hash of the root>`, still one
+directory per root, and pogod logs a line saying so at startup. See
+[docs/CONFIGURATION.md](CONFIGURATION.md#state-directory-pogo_home-and-running-multiple-instances)
+for the `sun_path` limit and the agent-name ceiling it implies.
+
 **Two instances sharing a `POGO_HOME` share all of that state — by construction.**
 Refinery counts, scheduler entries, registered agents, and mailboxes co-mingle
 because they are the same files on disk, not because state leaks across a

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -145,9 +145,16 @@ Inspect or modify with `gh api repos/drellem2/<repo>/rulesets` (effective rules:
 If you run more than one pogo instance on a host — a production fleet plus a
 sandbox for verification, say — **give each instance its own `POGO_HOME`.** Every
 pogo state path (the refinery queue, `schedules.json`, `agents/`, the Maildir,
-`events.log`) derives from `PogoHome()` (`internal/config/config.go`), which
-resolves to `$POGO_HOME` or `~/.pogo`. Distinct roots isolate distinct daemons
-completely (mg-3dc3).
+`events.log`, and the agent attach sockets in `agents/sockets/`) derives from
+`PogoHome()` (`internal/config/config.go`), which resolves to `$POGO_HOME` or
+`~/.pogo`. Distinct roots isolate distinct daemons completely (mg-3dc3, mg-8532).
+
+Attach sockets were the one exception until mg-8532: pogod derived their
+directory from `$TMPDIR`, which is per-user rather than per-`POGO_HOME`, so two
+daemons on distinct roots with identically-named agents shared one socket file.
+If you are running an older pogod, expect `pogo agent attach` to reach whichever
+daemon bound the socket last, and expect the two daemons' attach supervisors to
+unlink and rebind each other's live socket every 30s (mg-d216).
 
 **Two instances sharing a `POGO_HOME` share all of that state — by construction.**
 Refinery counts, scheduler entries, registered agents, and mailboxes co-mingle

--- a/internal/config/agent_socket_test.go
+++ b/internal/config/agent_socket_test.go
@@ -1,0 +1,202 @@
+package config
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// shortHome returns a POGO_HOME short enough that AgentSocketDir keeps the
+// sockets under it. t.TempDir() is unusable here: on darwin it returns a
+// ~72-byte path under /var/folders that trips the sun_path fallback.
+func shortHome(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "ph")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
+}
+
+// deepHome returns a POGO_HOME deep enough to force AgentSocketDir's fallback
+// on any platform. It nests until the derived dir provably cannot fit a socket,
+// rather than assuming t.TempDir() is long (it is on darwin, not on linux).
+func deepHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for agentSocketDirFits(filepath.Join(dir, "agents", "sockets")) {
+		dir = filepath.Join(dir, "deeper")
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	return dir
+}
+
+// legacySharedDir is the pre-mg-8532 path: one $TMPDIR-derived directory shared
+// by every daemon on the host regardless of POGO_HOME.
+func legacySharedDir() string {
+	return filepath.Join(os.TempDir(), "pogo-agents")
+}
+
+// TestAgentSocketDirUnderPogoHome pins the headline behavior of mg-8532: a
+// normal root keeps its attach sockets inside POGO_HOME, alongside the rest of
+// the daemon state that PogoHome() seeds.
+func TestAgentSocketDirUnderPogoHome(t *testing.T) {
+	home := shortHome(t)
+	t.Setenv("POGO_HOME", home)
+
+	want := filepath.Join(home, "agents", "sockets")
+	if got := AgentSocketDir(); got != want {
+		t.Errorf("AgentSocketDir() = %q, want %q", got, want)
+	}
+}
+
+// TestAgentSocketDirDistinctPerPogoHome is the invariant the whole change
+// exists to establish: two daemons on distinct roots never share a socket path,
+// so identically-named agents cannot collide. Before mg-8532 both roots
+// resolved to legacySharedDir().
+func TestAgentSocketDirDistinctPerPogoHome(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		home func(*testing.T) string
+	}{
+		{"shallow root", shortHome},
+		{"deep root (sun_path fallback)", deepHome},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			homeA, homeB := tc.home(t), tc.home(t)
+			if homeA == homeB {
+				t.Fatalf("test bug: both roots are %q", homeA)
+			}
+
+			t.Setenv("POGO_HOME", homeA)
+			dirA := AgentSocketDir()
+			t.Setenv("POGO_HOME", homeB)
+			dirB := AgentSocketDir()
+
+			if dirA == dirB {
+				t.Errorf("distinct POGO_HOME roots share socket dir %q", dirA)
+			}
+			for _, dir := range []string{dirA, dirB} {
+				if dir == legacySharedDir() {
+					t.Errorf("AgentSocketDir() = %q, the shared pre-mg-8532 path", dir)
+				}
+			}
+		})
+	}
+}
+
+// TestAgentSocketDirBindable is the load-bearing test for agentSocketLeafBudget:
+// a socket named for the longest agent we budget for must actually bind under
+// the returned dir, in both the PogoHome and the fallback branch. It checks the
+// constant against the kernel rather than against the 104/108 folklore.
+func TestAgentSocketDirBindable(t *testing.T) {
+	longestName := strings.Repeat("a", 24)
+
+	for _, tc := range []struct {
+		name string
+		home func(*testing.T) string
+	}{
+		{"shallow root", shortHome},
+		{"deep root (sun_path fallback)", deepHome},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("POGO_HOME", tc.home(t))
+
+			dir := AgentSocketDir()
+			if err := os.MkdirAll(dir, 0700); err != nil {
+				t.Fatalf("MkdirAll(%q): %v", dir, err)
+			}
+			t.Cleanup(func() { os.RemoveAll(dir) })
+
+			sock := filepath.Join(dir, longestName+".sock")
+			l, err := net.Listen("unix", sock)
+			if err != nil {
+				t.Fatalf("cannot bind %q (%d bytes): %v", sock, len(sock), err)
+			}
+			l.Close()
+		})
+	}
+}
+
+// TestAgentSocketDirFallbackIsShort verifies the escape hatch is only taken when
+// needed, and that when taken it lands somewhere that actually fits — a fallback
+// that still overflows sun_path would trade a collision for a dead listener.
+func TestAgentSocketDirFallbackIsShort(t *testing.T) {
+	home := deepHome(t)
+	t.Setenv("POGO_HOME", home)
+
+	dir := AgentSocketDir()
+	if strings.HasPrefix(dir, filepath.Clean(home)+string(filepath.Separator)) {
+		t.Errorf("AgentSocketDir() = %q, want a path outside the too-deep root %q", dir, home)
+	}
+	if !agentSocketDirFits(dir) {
+		t.Errorf("fallback dir %q (%d bytes) does not fit sun_path", dir, len(dir))
+	}
+}
+
+// TestAgentSocketDirStableAcrossSpellings guards the filepath.Clean inside the
+// fallback hash. LockfilePath already treats "/a/b" and "/a/b/" as one daemon;
+// the socket dir must agree, or a restart with a trailing slash would silently
+// move every agent's socket.
+func TestAgentSocketDirStableAcrossSpellings(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		home func(*testing.T) string
+	}{
+		{"shallow root", shortHome},
+		{"deep root (sun_path fallback)", deepHome},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := tc.home(t)
+
+			t.Setenv("POGO_HOME", home)
+			bare := AgentSocketDir()
+			t.Setenv("POGO_HOME", home+string(filepath.Separator))
+			slashed := AgentSocketDir()
+
+			if bare != slashed {
+				t.Errorf("POGO_HOME %q -> %q but %q/ -> %q; spellings must agree",
+					home, bare, home, slashed)
+			}
+		})
+	}
+}
+
+// TestAgentSocketDirDeterministic verifies repeated calls agree. Every agent in
+// a daemon binds independently, so a dir that varied per call would scatter
+// sockets across directories.
+func TestAgentSocketDirDeterministic(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		home func(*testing.T) string
+	}{
+		{"shallow root", shortHome},
+		{"deep root (sun_path fallback)", deepHome},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("POGO_HOME", tc.home(t))
+			if first, second := AgentSocketDir(), AgentSocketDir(); first != second {
+				t.Errorf("AgentSocketDir() not deterministic: %q then %q", first, second)
+			}
+		})
+	}
+}
+
+// TestAgentSocketDirLegacyHomeNormalized verifies the POGO_HOME=$HOME legacy
+// normalization (mg-3dc3) reaches the socket dir too: sockets belong under
+// $HOME/.pogo, not scattered at the home dir root.
+func TestAgentSocketDirLegacyHomeNormalized(t *testing.T) {
+	home := shortHome(t)
+	t.Setenv("HOME", home)
+	t.Setenv("POGO_HOME", home)
+
+	want := filepath.Join(home, ".pogo", "agents", "sockets")
+	if got := AgentSocketDir(); got != want {
+		t.Errorf("AgentSocketDir() with POGO_HOME=$HOME = %q, want %q", got, want)
+	}
+}

--- a/internal/config/agent_socket_test.go
+++ b/internal/config/agent_socket_test.go
@@ -21,6 +21,25 @@ func shortHome(t *testing.T) string {
 	return dir
 }
 
+// homeOfLen returns an existing directory whose path is exactly n bytes long, so
+// a test can sit a POGO_HOME precisely on a sun_path boundary.
+func homeOfLen(t *testing.T, n int) string {
+	t.Helper()
+	base := shortHome(t)
+	pad := n - len(base) - 1 // -1 for the separator
+	if pad < 1 {
+		t.Fatalf("cannot build a %d-byte home: base %q is already %d bytes", n, base, len(base))
+	}
+	dir := filepath.Join(base, strings.Repeat("d", pad))
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if len(dir) != n {
+		t.Fatalf("built home %q is %d bytes, want %d", dir, len(dir), n)
+	}
+	return dir
+}
+
 // deepHome returns a POGO_HOME deep enough to force AgentSocketDir's fallback
 // on any platform. It nests until the derived dir provably cannot fit a socket,
 // rather than assuming t.TempDir() is long (it is on darwin, not on linux).
@@ -42,6 +61,66 @@ func legacySharedDir() string {
 	return filepath.Join(os.TempDir(), "pogo-agents")
 }
 
+// bindOK reports whether a unix socket can actually be bound at path.
+func bindOK(t *testing.T, path string) error {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		return err
+	}
+	l.Close()
+	return nil
+}
+
+// TestMaxUnixSocketPathLenBinds pins maxUnixSocketPathLen against the running
+// kernel from above: a path of exactly that length must bind. It deliberately
+// does not assert that one more byte fails — the constant is the darwin figure
+// (103) used on every platform, and linux tolerates 107, so being conservative
+// is the intent. Too *large* a constant is the bug this catches.
+func TestMaxUnixSocketPathLenBinds(t *testing.T) {
+	sock := filepath.Join(homeOfLen(t, maxUnixSocketPathLen-len("/x.sock")), "x.sock")
+	if len(sock) != maxUnixSocketPathLen {
+		t.Fatalf("test bug: built a %d-byte path, want %d", len(sock), maxUnixSocketPathLen)
+	}
+	if err := bindOK(t, sock); err != nil {
+		t.Fatalf("maxUnixSocketPathLen=%d but binding a %d-byte path failed: %v",
+			maxUnixSocketPathLen, len(sock), err)
+	}
+}
+
+// TestAgentSocketDirBindableAtBudgetLimit is the load-bearing test for the
+// budget constants. It sizes POGO_HOME so the derived dir lands exactly on
+// agentSocketLeafBudget's limit, then binds a socket for the longest agent name
+// the budget promises. The resulting path is exactly maxUnixSocketPathLen bytes,
+// so an over-large maxUnixSocketPathLen or an under-sized leaf budget makes this
+// fail with EINVAL rather than passing quietly.
+func TestAgentSocketDirBindableAtBudgetLimit(t *testing.T) {
+	const suffix = "/agents/sockets"
+	root := homeOfLen(t, maxUnixSocketPathLen-agentSocketLeafBudget-len(suffix))
+	t.Setenv("POGO_HOME", root)
+
+	dir, inside := AgentSocketDir()
+	if !inside {
+		t.Fatalf("a root exactly at the budget limit must keep its sockets under POGO_HOME, got %q", dir)
+	}
+	sock := filepath.Join(dir, strings.Repeat("a", MaxAgentNameLen)+".sock")
+	if len(sock) != maxUnixSocketPathLen {
+		t.Fatalf("test bug: socket path is %d bytes, want exactly %d", len(sock), maxUnixSocketPathLen)
+	}
+	if err := bindOK(t, sock); err != nil {
+		t.Fatalf("a %d-byte agent name at the budget limit must bind, got: %v", MaxAgentNameLen, err)
+	}
+
+	// One byte deeper must tip into the fallback rather than into a failed bind.
+	t.Setenv("POGO_HOME", homeOfLen(t, maxUnixSocketPathLen-agentSocketLeafBudget-len(suffix)+1))
+	if dir, inside := AgentSocketDir(); inside {
+		t.Errorf("a root one byte past the budget must fall back, got %q under POGO_HOME", dir)
+	}
+}
+
 // TestAgentSocketDirUnderPogoHome pins the headline behavior of mg-8532: a
 // normal root keeps its attach sockets inside POGO_HOME, alongside the rest of
 // the daemon state that PogoHome() seeds.
@@ -50,8 +129,12 @@ func TestAgentSocketDirUnderPogoHome(t *testing.T) {
 	t.Setenv("POGO_HOME", home)
 
 	want := filepath.Join(home, "agents", "sockets")
-	if got := AgentSocketDir(); got != want {
-		t.Errorf("AgentSocketDir() = %q, want %q", got, want)
+	dir, inside := AgentSocketDir()
+	if dir != want {
+		t.Errorf("AgentSocketDir() = %q, want %q", dir, want)
+	}
+	if !inside {
+		t.Errorf("AgentSocketDir() reported the fallback for a shallow root %q", home)
 	}
 }
 
@@ -74,9 +157,9 @@ func TestAgentSocketDirDistinctPerPogoHome(t *testing.T) {
 			}
 
 			t.Setenv("POGO_HOME", homeA)
-			dirA := AgentSocketDir()
+			dirA, _ := AgentSocketDir()
 			t.Setenv("POGO_HOME", homeB)
-			dirB := AgentSocketDir()
+			dirB, _ := AgentSocketDir()
 
 			if dirA == dirB {
 				t.Errorf("distinct POGO_HOME roots share socket dir %q", dirA)
@@ -90,12 +173,11 @@ func TestAgentSocketDirDistinctPerPogoHome(t *testing.T) {
 	}
 }
 
-// TestAgentSocketDirBindable is the load-bearing test for agentSocketLeafBudget:
-// a socket named for the longest agent we budget for must actually bind under
-// the returned dir, in both the PogoHome and the fallback branch. It checks the
-// constant against the kernel rather than against the 104/108 folklore.
+// TestAgentSocketDirBindable checks that a socket for the longest budgeted agent
+// name binds under both branches for ordinary roots. The boundary case — where
+// the budget is actually load-bearing — is TestAgentSocketDirBindableAtBudgetLimit.
 func TestAgentSocketDirBindable(t *testing.T) {
-	longestName := strings.Repeat("a", 24)
+	longestName := strings.Repeat("a", MaxAgentNameLen)
 
 	for _, tc := range []struct {
 		name string
@@ -107,18 +189,13 @@ func TestAgentSocketDirBindable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("POGO_HOME", tc.home(t))
 
-			dir := AgentSocketDir()
-			if err := os.MkdirAll(dir, 0700); err != nil {
-				t.Fatalf("MkdirAll(%q): %v", dir, err)
-			}
+			dir, _ := AgentSocketDir()
 			t.Cleanup(func() { os.RemoveAll(dir) })
 
 			sock := filepath.Join(dir, longestName+".sock")
-			l, err := net.Listen("unix", sock)
-			if err != nil {
+			if err := bindOK(t, sock); err != nil {
 				t.Fatalf("cannot bind %q (%d bytes): %v", sock, len(sock), err)
 			}
-			l.Close()
 		})
 	}
 }
@@ -130,12 +207,26 @@ func TestAgentSocketDirFallbackIsShort(t *testing.T) {
 	home := deepHome(t)
 	t.Setenv("POGO_HOME", home)
 
-	dir := AgentSocketDir()
-	if strings.HasPrefix(dir, filepath.Clean(home)+string(filepath.Separator)) {
+	dir, inside := AgentSocketDir()
+	if inside {
 		t.Errorf("AgentSocketDir() = %q, want a path outside the too-deep root %q", dir, home)
 	}
 	if !agentSocketDirFits(dir) {
 		t.Errorf("fallback dir %q (%d bytes) does not fit sun_path", dir, len(dir))
+	}
+}
+
+// TestAgentSocketDirRootPogoHome guards the edge that made a prefix test the
+// wrong way to detect the fallback: POGO_HOME="/" derives "/agents/sockets",
+// which fits, so the sockets really are inside the root.
+func TestAgentSocketDirRootPogoHome(t *testing.T) {
+	t.Setenv("POGO_HOME", "/")
+	dir, inside := AgentSocketDir()
+	if want := filepath.Join("/", "agents", "sockets"); dir != want {
+		t.Errorf("AgentSocketDir() = %q, want %q", dir, want)
+	}
+	if !inside {
+		t.Errorf("AgentSocketDir() reported the fallback for POGO_HOME=/, but %q is inside it", dir)
 	}
 }
 
@@ -155,9 +246,9 @@ func TestAgentSocketDirStableAcrossSpellings(t *testing.T) {
 			home := tc.home(t)
 
 			t.Setenv("POGO_HOME", home)
-			bare := AgentSocketDir()
+			bare, _ := AgentSocketDir()
 			t.Setenv("POGO_HOME", home+string(filepath.Separator))
-			slashed := AgentSocketDir()
+			slashed, _ := AgentSocketDir()
 
 			if bare != slashed {
 				t.Errorf("POGO_HOME %q -> %q but %q/ -> %q; spellings must agree",
@@ -180,7 +271,9 @@ func TestAgentSocketDirDeterministic(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv("POGO_HOME", tc.home(t))
-			if first, second := AgentSocketDir(), AgentSocketDir(); first != second {
+			first, _ := AgentSocketDir()
+			second, _ := AgentSocketDir()
+			if first != second {
 				t.Errorf("AgentSocketDir() not deterministic: %q then %q", first, second)
 			}
 		})
@@ -196,7 +289,7 @@ func TestAgentSocketDirLegacyHomeNormalized(t *testing.T) {
 	t.Setenv("POGO_HOME", home)
 
 	want := filepath.Join(home, ".pogo", "agents", "sockets")
-	if got := AgentSocketDir(); got != want {
-		t.Errorf("AgentSocketDir() with POGO_HOME=$HOME = %q, want %q", got, want)
+	if dir, _ := AgentSocketDir(); dir != want {
+		t.Errorf("AgentSocketDir() with POGO_HOME=$HOME = %q, want %q", dir, want)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -627,28 +627,40 @@ func LockfilePath() string {
 // that one POGO_HOME resolves to the same socket dir regardless of GOOS.
 const maxUnixSocketPathLen = 103
 
+// MaxAgentNameLen is the longest agent name whose attach socket is guaranteed to
+// bind under AgentSocketDir. Real names are far shorter — "pm-dealdesk" (11) is
+// the longest crew name, and a polecat is named for its work item ("8532") — so
+// 24 bytes leaves better than 2x headroom.
+//
+// The reservation is a fixed constant rather than a function of the agent being
+// bound: every agent under one POGO_HOME must agree on one socket dir, so the
+// dir cannot depend on which agent binds first. That makes this a ceiling, not a
+// promise — a name longer than this under a root deep enough to consume the
+// headroom will fail to bind, and the agent runs with attach unavailable (pogod
+// logs "attach listener failed"). Nothing enforces the ceiling at spawn today;
+// see mg-8532 advisory 2 and its follow-up.
+const MaxAgentNameLen = 24
+
 // agentSocketLeafBudget reserves room for the "/<agent name>.sock" leaf that
-// callers append to AgentSocketDir. Real agent names are short — "pm-dealdesk"
-// (11) is the longest crew name, and a polecat is named for its work item
-// ("8532") — so 24 bytes of name leaves better than 2x headroom. The reservation
-// is a fixed constant rather than a function of the agent being bound: every
-// agent under one POGO_HOME must agree on one socket dir, so the dir cannot
-// depend on which agent binds first.
-const agentSocketLeafBudget = len("/") + 24 + len(".sock")
+// callers append to AgentSocketDir.
+const agentSocketLeafBudget = len("/") + MaxAgentNameLen + len(".sock")
 
 // AgentSocketDir returns the directory holding the per-agent unix domain sockets
-// that back `pogo agent attach`.
+// that back `pogo agent attach`, and whether that directory lives inside
+// PogoHome. Callers that want to report the fallback should use the returned
+// bool rather than re-deriving it by inspecting the path: a POGO_HOME of "/"
+// makes any prefix test lie.
 //
-// It derives from PogoHome() so two daemons on distinct POGO_HOME roots never
-// share a socket path. Deriving it from os.TempDir() instead — as pogod did
-// before mg-8532 — gave identically-named agents under different roots a single
-// shared socket file, because $TMPDIR is per-user, not per-POGO_HOME. The
-// singleton lockfile bars two pogods on the *same* root, but nothing stopped two
-// on *different* roots from colliding here. The old symptom was quiet: whichever
-// daemon bound last owned the path and the other silently lost attach. Once the
-// mg-d216 attach supervisor shipped, it turned loud — each daemon observes the
-// other's bind as its own socket being replaced, unlinks that live socket and
-// rebinds, forever, on a 30s ticker.
+// The directory derives from PogoHome() so two daemons on distinct POGO_HOME
+// roots never share a socket path. Deriving it from os.TempDir() instead — as
+// pogod did before mg-8532 — gave identically-named agents under different roots
+// a single shared socket file, because $TMPDIR is per-user, not per-POGO_HOME.
+// The singleton lockfile bars two pogods on the *same* root, but nothing stopped
+// two on *different* roots from colliding here. The old symptom was quiet:
+// whichever daemon bound last owned the path and the other silently lost attach.
+// Once the mg-d216 attach supervisor shipped, it turned loud — each daemon
+// observes the other's bind as its own socket being replaced, unlinks that live
+// socket and rebinds, forever, on a 30s ticker.
 //
 // The sun_path limit forces one wrinkle. A sufficiently deep POGO_HOME (a
 // t.TempDir() under /var/folders on darwin, say) leaves no room for the socket
@@ -657,12 +669,12 @@ const agentSocketLeafBudget = len("/") + 24 + len(".sock")
 // distinctness this function exists to guarantee survives the fallback. The hash
 // is taken over the cleaned root so that "/a/b" and "/a/b/" — which the lockfile
 // already treats as one daemon — agree on one socket dir too.
-func AgentSocketDir() string {
+func AgentSocketDir() (dir string, insidePogoHome bool) {
 	if dir := filepath.Join(PogoHome(), "agents", "sockets"); agentSocketDirFits(dir) {
-		return dir
+		return dir, true
 	}
 	sum := sha256.Sum256([]byte(filepath.Clean(PogoHome())))
-	return filepath.Join(os.TempDir(), "pogo-agents-"+hex.EncodeToString(sum[:4]))
+	return filepath.Join(os.TempDir(), "pogo-agents-"+hex.EncodeToString(sum[:4])), false
 }
 
 // agentSocketDirFits reports whether dir leaves room to bind an agent socket

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -617,6 +619,56 @@ func PogoHome() string {
 // pogod's TryLock fails instead of racing the live daemon for :10000 (#22).
 func LockfilePath() string {
 	return filepath.Join(PogoHome(), "pogo.pid")
+}
+
+// maxUnixSocketPathLen is the longest bindable AF_UNIX path. sockaddr_un's
+// sun_path field is 104 bytes on darwin and 108 on linux, both counting the NUL
+// terminator. We budget against the smaller (darwin) figure on every platform so
+// that one POGO_HOME resolves to the same socket dir regardless of GOOS.
+const maxUnixSocketPathLen = 103
+
+// agentSocketLeafBudget reserves room for the "/<agent name>.sock" leaf that
+// callers append to AgentSocketDir. Real agent names are short — "pm-dealdesk"
+// (11) is the longest crew name, and a polecat is named for its work item
+// ("8532") — so 24 bytes of name leaves better than 2x headroom. The reservation
+// is a fixed constant rather than a function of the agent being bound: every
+// agent under one POGO_HOME must agree on one socket dir, so the dir cannot
+// depend on which agent binds first.
+const agentSocketLeafBudget = len("/") + 24 + len(".sock")
+
+// AgentSocketDir returns the directory holding the per-agent unix domain sockets
+// that back `pogo agent attach`.
+//
+// It derives from PogoHome() so two daemons on distinct POGO_HOME roots never
+// share a socket path. Deriving it from os.TempDir() instead — as pogod did
+// before mg-8532 — gave identically-named agents under different roots a single
+// shared socket file, because $TMPDIR is per-user, not per-POGO_HOME. The
+// singleton lockfile bars two pogods on the *same* root, but nothing stopped two
+// on *different* roots from colliding here. The old symptom was quiet: whichever
+// daemon bound last owned the path and the other silently lost attach. Once the
+// mg-d216 attach supervisor shipped, it turned loud — each daemon observes the
+// other's bind as its own socket being replaced, unlinks that live socket and
+// rebinds, forever, on a 30s ticker.
+//
+// The sun_path limit forces one wrinkle. A sufficiently deep POGO_HOME (a
+// t.TempDir() under /var/folders on darwin, say) leaves no room for the socket
+// leaf, and bind would fail with EINVAL. Such a root falls back to a short
+// directory under os.TempDir() named for a hash of the root — so the per-root
+// distinctness this function exists to guarantee survives the fallback. The hash
+// is taken over the cleaned root so that "/a/b" and "/a/b/" — which the lockfile
+// already treats as one daemon — agree on one socket dir too.
+func AgentSocketDir() string {
+	if dir := filepath.Join(PogoHome(), "agents", "sockets"); agentSocketDirFits(dir) {
+		return dir
+	}
+	sum := sha256.Sum256([]byte(filepath.Clean(PogoHome())))
+	return filepath.Join(os.TempDir(), "pogo-agents-"+hex.EncodeToString(sum[:4]))
+}
+
+// agentSocketDirFits reports whether dir leaves room to bind an agent socket
+// beneath it without exceeding sun_path.
+func agentSocketDirFits(dir string) bool {
+	return len(dir)+agentSocketLeafBudget <= maxUnixSocketPathLen
 }
 
 // DialAddr returns a loopback TCP address (127.0.0.1:<port>) for probing


### PR DESCRIPTION
## Problem

`cmd/pogod/main.go` derived the agent attach-socket directory from `os.TempDir()/pogo-agents`. `$TMPDIR` is **per-user, not per-`POGO_HOME`**, so two daemons on distinct `POGO_HOME` roots with identically-named agents resolved to **one** socket file — while `docs/operations.md` promised distinct roots "isolate distinct daemons completely". The singleton lockfile bars two pogods on the *same* root; nothing barred two on *different* roots from colliding here.

The old symptom was quiet: whichever daemon bound last owned the path, the other silently lost `pogo agent attach`. The mg-d216 attach supervisor made it **loud** — each daemon observes the other's bind as its own socket being replaced, unlinks that live socket and rebinds, forever, on its 30s ticker.

## Fix

`config.AgentSocketDir()` derives the dir from `PogoHome()` → `$POGO_HOME/agents/sockets/`. Distinct roots get distinct paths, so the promised isolation is real.

**One wrinkle: `sun_path`.** A unix socket path cannot exceed 103 usable bytes (darwin; 107 on linux), and a deep enough `POGO_HOME` leaves no room for the `<agent>.sock` leaf — bind would fail with `EINVAL`, i.e. we'd trade a collision for a dead listener. Such a root falls back to `$TMPDIR/pogo-agents-<hash of the cleaned root>`. **The hash keeps distinct roots distinct, so the invariant this PR exists to establish holds in the fallback too.** pogod logs a line when it takes that path. For the default root the new path is *shorter* than the old one (34 bytes vs 60), so the common case gains headroom.

## Verification (before/after, real daemons)

Two sandboxed pogods on distinct `POGO_HOME` roots, each with an agent of the same name:

| binary | socket paths | rebounds in ~90s |
|---|---|---|
| pre-fix (control) | **identical** — `/tmp/pogo-agents/<name>.sock` for both | **3 per daemon**, ~one per 30s tick, all `socket_file_replaced` |
| this PR | distinct, one per root | **0**, stable inode, both sockets connectable throughout |

The control reproduces the permanent 30s reclaim war verbatim. I also drove the fallback branch end-to-end with a 76-byte root: pogod logs, relocates to `/tmp/pogo-agents-346a1be4`, and the agent's attach socket binds and accepts connections.

## Path migration & consumers of the old path

**Every agent socket path moves**, so I audited every consumer:

- **`pogod` is the only place that constructs the dir** (one call site). `internal/agent` receives it via `NewRegistry(socketDir)` and never derives it.
- **No client hardcodes the path.** `pogo agent attach` and `agent status/list` call `client.GetAgent()` and use the daemon-reported `info.SocketPath` (`internal/agent/api.go`). Since the client reaches the daemon on the port resolved from *its own* `POGO_HOME`, attach already routed per-root — only the socket *file* collided. So clients follow the daemon with no change, and a new `pogo` CLI against an old `pogod` still works.
- **No migration of existing socket files.** They are transient: bound by a live pogod, recreated on start, and unlinked on agent cleanup. Deliberately **not** deleting the old `$TMPDIR/pogo-agents/` dir — a still-running old-binary pogod on another root may own those live sockets, and unlinking them is precisely the bug being fixed. They are inert files that the OS tmp reaper collects.
- **Permissions:** `NewRegistry` does `MkdirAll(socketDir, 0700)`, and `MkdirAll` stamps that mode on every parent it creates — which would have made a fresh root's `agents/` dir `0700` instead of its historical `0755` (it is shared with the prompt files). pogod now creates that parent at `0755` first; `sockets/` still lands `0700`, which is what an attach socket wants. Verified on a fresh root.

## Tests

New `internal/config/agent_socket_test.go`. The load-bearing ones:

- **distinct roots → distinct socket dirs**, asserted in *both* the normal and the fallback branch, and never equal to the shared pre-mg-8532 path.
- **bindability**: actually `net.Listen`s a socket named for the longest agent we budget for, under both branches — this checks the budget constant against the kernel rather than against the 104/108 folklore.
- determinism, trailing-slash stability (guards the `filepath.Clean` in the hash), and that the `POGO_HOME=$HOME` legacy normalization reaches the socket dir.

I mutation-tested them: reverting `AgentSocketDir` to the old `os.TempDir()` implementation fails 3 of them, including `distinct POGO_HOME roots share socket dir "/var/folders/.../pogo-agents"`.

`./build.sh` and `./test.sh` both exit 0; gofmt and `go vet` clean.

## Sequencing

Per the ticket, this **must merge before the next controlled pogod rebuild activates the d216 attach supervisor** — otherwise the supervisor amplifies the collision into the permanent reclaim war demonstrated above.

## Notes

- Xref: mg-d216, mg-f227, drellem2/pogo#64 (cross-referenced, not resolved by this PR).
- Ticket carries no `gh:` issue ref and names no review ticket, so there is no `Resolves` line and the mayor is dispatching review.
- `./build.sh` runs `go install`, so this branch's `pogod` is now the installed binary on this host. That is the safe direction (the fix is present if pogod restarts), but worth knowing before the next rebuild.

Work item: mg-8532

🤖 Generated with [Claude Code](https://claude.com/claude-code)