### PR TITLE
build.sh: build into ./bin instead of go install into GOBIN (mg-b630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ is the curated, human-readable summary kept in sync at each release cut.
 
 ### Fixed
 
+- **`build.sh` no longer overwrites the installed binaries.** The build step ran
+  `go install ./cmd/...`, writing to GOBIN (`~/go/bin`). Because `build.sh` also runs
+  unattended in agent worktrees and as the refinery's quality gate, every build that
+  touched `cmd/pogod` silently replaced the machine's installed `pogod` with an
+  unreviewed branch build — so a daemon restart could launch whatever branch compiled
+  last. `build.sh` now compiles into `./bin` (gitignored, overridable with
+  `POGO_BUILD_DIR`) and still fails on a compile error. Installing into GOBIN is now
+  opt-in via `./build.sh --install`. (mg-b630)
+
 - **pogod: attach socket no longer dies while the agent lives.** `pogo agent attach <name>`
   could fail with `connect: connection refused` against a socket file that existed,
   on an agent whose process was alive and healthy. The accept loop returned on *any*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,10 +66,14 @@ If you add or advance an integration, update both `README.md` and this table.
 Go project. Build and test:
 
 ```bash
-./build.sh       # Build all binaries (runs fmt + test + install)
+./build.sh       # Build all binaries into ./bin (runs fmt + test + build)
 ./test.sh        # Run tests
 ./fmt.sh         # Format code (go fmt)
 ```
+
+`./build.sh` compiles into `./bin` and does **not** `go install` into GOBIN —
+that would overwrite the machine's live `pogod` with a branch build. Pass
+`--install` if you want the binaries on `PATH`.
 
 Binaries are in `cmd/`: `cmd/pogo`, `cmd/lsp`, `cmd/pose`, `cmd/pogod` (daemon).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,19 +6,26 @@ Thanks for your interest in contributing to pogo! This guide covers the basics o
 
 1. Fork and clone the repository
 2. Install Go (1.24+)
-3. Run `./build.sh` to build, test, and install
+3. Run `./build.sh` to build and test
 
 ## Development Workflow
 
 ### Building
 
 ```bash
-./build.sh    # Format, test, and install all binaries
-./test.sh     # Run tests only
-./fmt.sh      # Format code only
+./build.sh              # Format, test, and build all binaries into ./bin
+./build.sh --install    # ...and also `go install` them into GOBIN
+./test.sh               # Run tests only
+./fmt.sh                # Format code only
 ```
 
-`./build.sh` runs all three steps (format, test, install) and is the recommended way to verify your changes before committing.
+`./build.sh` runs all three steps (format, test, build) and is the recommended way to verify your changes before committing.
+
+Binaries land in `./bin` (gitignored). `./build.sh` deliberately does *not* write
+to GOBIN: it runs unattended in agent worktrees and as the refinery's quality
+gate, where a `go install` would overwrite the machine's installed `pogod` with
+an unreviewed branch build. Pass `--install` when you actually want the binaries
+on your `PATH`, or set `POGO_BUILD_DIR` to redirect the output directory.
 
 ### Code Style
 

--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,57 @@
 #!/bin/bash
+# build.sh — format, test, and compile every binary under cmd/.
+#
+# Binaries land in ./bin (gitignored); build.sh does NOT `go install` into
+# GOBIN. build.sh is executed in polecat worktrees and as the refinery's
+# quality gate, so a `go install` here silently overwrites the host's live
+# ~/go/bin/pogod with an unreviewed branch build — a later pogod restart would
+# then launch whatever branch happened to compile last (mg-b630).
+#
+# Usage:
+#   ./build.sh                # fmt + test + build into ./bin
+#   ./build.sh --skip-tests   # fmt + build
+#   ./build.sh --install      # also `go install ./cmd/...` into GOBIN (opt-in)
+#
+# Environment:
+#   POGO_BUILD_DIR   Output directory for the built binaries. Default: ./bin
+set -e
 
 skip_tests=false
+do_install=false
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./build.sh                # fmt + test + build into ./bin
+  ./build.sh --skip-tests   # fmt + build
+  ./build.sh --install      # also `go install ./cmd/...` into GOBIN (opt-in)
+
+Environment:
+  POGO_BUILD_DIR   Output directory for the built binaries. Default: ./bin
+EOF
+}
 
 for arg in "$@"; do
   case "$arg" in
     --skip-tests)
       skip_tests=true
       ;;
+    --install)
+      do_install=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "build.sh: unknown flag: $arg" >&2
+      usage >&2
+      exit 2
+      ;;
   esac
 done
+
+build_dir="${POGO_BUILD_DIR:-./bin}"
 
 echo "Starting build"
 ./fmt.sh || exit 1
@@ -17,5 +60,11 @@ if [ "$skip_tests" = false ]; then
   ./test.sh || exit 1
 fi
 
-echo "Step 3: Building binaries..." && \
-go install ./cmd/...
+echo "Step 3: Building binaries into ${build_dir}..."
+mkdir -p "$build_dir"
+go build -o "${build_dir%/}/" ./cmd/... || exit 1
+
+if [ "$do_install" = true ]; then
+  echo "Step 4: Installing binaries into GOBIN..."
+  go install ./cmd/... || exit 1
+fi

--- a/build_test.sh
+++ b/build_test.sh
@@ -1,0 +1,159 @@
+#!/bin/bash
+# Tests for build.sh
+#
+# The contract under test (mg-b630): build.sh compiles into a scratch build dir
+# and never writes GOBIN unless --install is passed, while still failing the
+# build on a compile error. Every case runs the real build.sh against a
+# synthetic single-binary Go module in a temp dir, with GOBIN redirected to a
+# temp dir, so the host's ~/go/bin is never touched by this test either.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_SCRIPT="${SCRIPT_DIR}/build.sh"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1" >&2; }
+
+echo "=== build.sh tests ==="
+
+# --- Test 1: Script is valid shell ---
+echo ""
+echo "Test 1: Script syntax check"
+if bash -n "$BUILD_SCRIPT" 2>/dev/null; then
+  pass "build.sh has valid bash syntax"
+else
+  fail "build.sh has syntax errors"
+fi
+
+# --- Fixture: a throwaway Go module that mimics the repo's shape ---
+# fmt.sh / test.sh are stubbed so the tests exercise build.sh alone and stay
+# fast; each stub drops a marker file so we can assert whether it ran.
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+fixture="${tmpdir}/module"
+gobin="${tmpdir}/gobin"
+mkdir -p "${fixture}/cmd/hello" "$gobin"
+
+cp "$BUILD_SCRIPT" "${fixture}/build.sh"
+printf '#!/bin/bash\ntouch ran-fmt\n' > "${fixture}/fmt.sh"
+printf '#!/bin/bash\ntouch ran-tests\n' > "${fixture}/test.sh"
+chmod +x "${fixture}/build.sh" "${fixture}/fmt.sh" "${fixture}/test.sh"
+
+printf 'module example.com/hello\n\ngo 1.25.0\n' > "${fixture}/go.mod"
+good_main='package main
+
+func main() { println("hello") }
+'
+bad_main='package main
+
+func main() { this is not go }
+'
+printf '%s' "$good_main" > "${fixture}/cmd/hello/main.go"
+
+# GOBIN governs where `go install` writes. Point it at a temp dir we can assert
+# on, and export it for every build.sh invocation below.
+export GOBIN="$gobin"
+
+gobin_empty() {
+  [ -z "$(ls -A "$gobin")" ]
+}
+
+# --- Test 2: default build compiles into ./bin, not GOBIN ---
+echo ""
+echo "Test 2: Default build writes ./bin and leaves GOBIN untouched"
+if (cd "$fixture" && ./build.sh >/dev/null 2>&1); then
+  if [ -x "${fixture}/bin/hello" ]; then
+    pass "build.sh compiled cmd/hello into ./bin"
+  else
+    fail "build.sh did not produce ./bin/hello"
+  fi
+  if gobin_empty; then
+    pass "build.sh left GOBIN empty (no go install)"
+  else
+    fail "build.sh wrote into GOBIN: $(ls -A "$gobin")"
+  fi
+  if [ -f "${fixture}/ran-tests" ]; then
+    pass "build.sh ran the test step"
+  else
+    fail "build.sh skipped the test step"
+  fi
+else
+  fail "build.sh failed on a module that compiles cleanly"
+fi
+
+# --- Test 3: --skip-tests skips test.sh but still builds ---
+echo ""
+echo "Test 3: --skip-tests skips the test step"
+rm -rf "${fixture}/bin" "${fixture}/ran-tests"
+if (cd "$fixture" && ./build.sh --skip-tests >/dev/null 2>&1); then
+  if [ ! -f "${fixture}/ran-tests" ] && [ -x "${fixture}/bin/hello" ]; then
+    pass "--skip-tests skipped test.sh and still built the binary"
+  else
+    fail "--skip-tests did not behave as expected"
+  fi
+else
+  fail "build.sh --skip-tests failed on a clean module"
+fi
+
+# --- Test 4: POGO_BUILD_DIR redirects the output dir ---
+echo ""
+echo "Test 4: POGO_BUILD_DIR overrides the build directory"
+rm -rf "${fixture}/bin"
+if (cd "$fixture" && POGO_BUILD_DIR="${tmpdir}/out" ./build.sh --skip-tests >/dev/null 2>&1); then
+  if [ -x "${tmpdir}/out/hello" ] && [ ! -d "${fixture}/bin" ]; then
+    pass "POGO_BUILD_DIR redirected the binaries"
+  else
+    fail "POGO_BUILD_DIR was not honored"
+  fi
+else
+  fail "build.sh failed with POGO_BUILD_DIR set"
+fi
+
+# --- Test 5: a compile error still fails the build ---
+# This is the regression that matters: dropping `go install` must not weaken
+# build.sh as a quality gate.
+echo ""
+echo "Test 5: A compile error fails the build"
+rm -rf "${fixture}/bin"
+printf '%s' "$bad_main" > "${fixture}/cmd/hello/main.go"
+if (cd "$fixture" && ./build.sh --skip-tests >/dev/null 2>&1); then
+  fail "build.sh exited 0 despite a compile error"
+else
+  pass "build.sh exited non-zero on a compile error"
+fi
+if gobin_empty; then
+  pass "A failed build left GOBIN empty"
+else
+  fail "A failed build wrote into GOBIN: $(ls -A "$gobin")"
+fi
+printf '%s' "$good_main" > "${fixture}/cmd/hello/main.go"
+
+# --- Test 6: --install is the opt-in that populates GOBIN ---
+echo ""
+echo "Test 6: --install populates GOBIN"
+if (cd "$fixture" && ./build.sh --skip-tests --install >/dev/null 2>&1); then
+  if [ -x "${gobin}/hello" ]; then
+    pass "--install placed the binary in GOBIN"
+  else
+    fail "--install did not populate GOBIN"
+  fi
+else
+  fail "build.sh --skip-tests --install failed on a clean module"
+fi
+rm -f "${gobin}/hello"
+
+# --- Test 7: unknown flags are rejected rather than silently ignored ---
+echo ""
+echo "Test 7: Unknown flags are rejected"
+if (cd "$fixture" && ./build.sh --no-such-flag >/dev/null 2>&1); then
+  fail "build.sh accepted an unknown flag"
+else
+  pass "build.sh rejected an unknown flag"
+fi
+
+echo ""
+echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+[ "$FAIL" -eq 0 ]

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,12 +11,18 @@ git clone https://github.com/drellem2/pogo.git && cd pogo && ./build.sh
 Requires [Go](https://go.dev/dl/) 1.21+.
 
 ```sh
-./build.sh       # Format, test, build, install
-./test.sh        # Run tests only
-./fmt.sh         # Format code only
+./build.sh              # Format, test, build all binaries into ./bin
+./build.sh --install    # ...and also `go install` them into GOBIN
+./test.sh               # Run tests only
+./fmt.sh                # Format code only
 ```
 
 Always run `./build.sh` before committing. If it fails, fix the issue before pushing.
+
+`./build.sh` builds into `./bin` (gitignored) and never writes GOBIN, so an
+unattended build in an agent worktree or in the refinery's quality gate cannot
+overwrite the installed `pogod`. Use `--install` to put binaries on your `PATH`;
+set `POGO_BUILD_DIR` to build somewhere other than `./bin`.
 
 ## Pre-commit hook
 

--- a/test.sh
+++ b/test.sh
@@ -18,3 +18,6 @@ bash nvim/test_nvim.sh
 
 echo "Testing bash shell integration"
 bash shell/bashrc_test.sh
+
+echo "Testing build.sh"
+bash build_test.sh


### PR DESCRIPTION
## Problem

`build.sh` ended in `go install ./cmd/...`, which writes to GOBIN (`~/go/bin`). But `build.sh` is not only a developer command — it also runs unattended in polecat worktrees and as the refinery's default quality gate. So **every** build that touched `cmd/pogod` silently overwrote the machine's installed `pogod` with an unreviewed branch build, and a later `pogod` restart could launch whatever branch happened to compile last.

## Change

- `build.sh` now runs `go build -o ./bin/ ./cmd/...`. `./bin` is already gitignored (`/bin`); `POGO_BUILD_DIR` overrides it.
- Installing into GOBIN is opt-in: `./build.sh --install`.
- Unknown flags are now rejected (exit 2) instead of being silently ignored, so a typo'd `--install` can't quietly do the wrong thing.
- `build_test.sh` (new, wired into `test.sh`) exercises the real `build.sh` against a synthetic Go module with `GOBIN` redirected to a temp dir.
- Docs updated: `CLAUDE.md`, `CONTRIBUTING.md`, `docs/development.md`, `CHANGELOG.md`.

## The gate still gates

The property the refinery depends on is "a compile error fails the script," and that is covered directly: test 5 plants a syntax error in the fixture module and asserts `build.sh` exits non-zero **and** leaves GOBIN empty. Verified on this branch: a full `./build.sh` exits 0, and `shasum ~/go/bin/pogod` is byte-identical before and after.

```
Test 2: Default build writes ./bin and leaves GOBIN untouched
Test 3: --skip-tests skips the test step
Test 4: POGO_BUILD_DIR overrides the build directory
Test 5: A compile error fails the build   <- and leaves GOBIN empty
Test 6: --install populates GOBIN
Test 7: Unknown flags are rejected
=== Results: 10 passed, 0 failed ===
```

## No consumer depended on the `go install`

Checked before removing it: CI (`.github/workflows/ci.yml`) never invokes `build.sh`; releases are cut by goreleaser; `install.sh` downloads release archives rather than building; `Dockerfile` and `run.sh` don't rely on GOBIN. The only references to `build.sh` are as a refinery quality gate, which cares only about the exit status.

## Notes

- This ticket is internal (`mg-b630`) and has no originating GitHub issue, so there is no `Resolves #n` line. The recommendation is inline in the ticket body: *"polecat build.sh should 'go build -o <scratch path>' (or a build dir) rather than 'go install' to GOBIN … Verify no consumer depends on go-install populating GOBIN during a build."*
- The branch is `polecat-b630`, following the repo's existing `polecat-<id>` convention.
- Out of scope, noted not fixed: `run.sh` still sets `GOPATH` and builds a `bin/plugin/pogo-plugin-search` that no longer exists in the tree — it looks like pre-modules archeology. Xref: mg-8532, mg-d216.

Work item: mg-b630