### PR TITLE
FOLLOW-UP: enforce MaxAgentNameLen at agent spawn (mg-ef80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,34 @@ is the curated, human-readable summary kept in sync at each release cut.
 
 ## [Unreleased]
 
+### Changed
+
+- **pogod: agent names longer than 24 bytes are refused at spawn.** `MaxAgentNameLen`
+  was the byte budget pogod reserves for `<agent>.sock` when choosing the attach
+  socket directory, but nothing enforced it. Under a `POGO_HOME` deep enough to
+  consume the remaining headroom, a longer name produced a socket path past the
+  `sun_path` limit: the bind failed, pogod logged `attach listener failed`, and
+  `POST /agents/start` still returned 201 for an agent that could never be
+  attached to. Such a name now gets a 400 from every spawn endpoint, under every
+  root — a name's fate must not depend on how deep the operator's root happens to
+  be. Real names are far shorter (`pm-dealdesk` is 11; a polecat is named for its
+  work item), and the default `~/.pogo` root always had room for a 64-byte name,
+  so no default deployment could reach the old failure. **Operator note:** a crew
+  agent whose configured name exceeds 24 bytes will now fail to start (and fail to
+  auto-start or wake) with an explicit error, where it previously started without
+  a working `pogo agent attach`. Rename it to 24 bytes or fewer. (mg-ef80)
+
 ### Fixed
+
+- **pogod: a spawn whose attach socket cannot bind now fails instead of lying.**
+  Backstop for the name check above: if binding the attach socket fails for a reason
+  no retry can clear — the path overruns `sun_path` — the spawn is torn down and
+  reports an error rather than returning a live agent nobody can reach. Transient
+  bind failures (fd exhaustion) still keep the agent, and the mg-d216 supervisor
+  rebinds once they clear. Relatedly, `AgentSocketDir`'s fallback root is now
+  guaranteed to leave room for the reserved name budget: it previously derived from
+  `os.TempDir()` unchecked, so a `TMPDIR` over ~52 bytes produced a socket directory
+  in which no legal agent name could bind. (mg-ef80)
 
 - **`build.sh` no longer overwrites the installed binaries.** The build step ran
   `go install ./cmd/...`, writing to GOBIN (`~/go/bin`). Because `build.sh` also runs

--- a/cmd/pogod/main_stallnudger_test.go
+++ b/cmd/pogod/main_stallnudger_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -8,6 +9,22 @@ import (
 
 	"github.com/drellem2/pogo/internal/agent"
 )
+
+// shortSocketDir returns a socket dir short enough that "<dir>/<name>.sock"
+// fits AF_UNIX's sun_path limit. t.TempDir() on darwin lives under
+// /var/folders/... and already exceeds it on its own, so a registry rooted
+// there cannot bind an attach socket for any agent — which fails the spawn
+// outright since mg-ef80. Production takes this dir from config.AgentSocketDir,
+// which guarantees the fit.
+func shortSocketDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "pogo-pogod-sock-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, "s")
+}
 
 // TestStallNudgerNeverInterruptsBusyAgent is the end-to-end proof of gh
 // drellem2/pogo #61 review point (a): the priority wake reuses newStallNudger,
@@ -17,7 +34,7 @@ import (
 // proves the wait-idle primitive) by exercising the exact function the stall
 // watcher and priority wake call.
 func TestStallNudgerNeverInterruptsBusyAgent(t *testing.T) {
-	reg, err := agent.NewRegistry(filepath.Join(t.TempDir(), "sockets"))
+	reg, err := agent.NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -66,7 +83,7 @@ func TestStallNudgerNeverInterruptsBusyAgent(t *testing.T) {
 // registered/running, the nudger delivers via macguffin mail so the signal is
 // durable rather than dropped.
 func TestStallNudgerFallsBackToMailWhenOffline(t *testing.T) {
-	reg, err := agent.NewRegistry(filepath.Join(t.TempDir(), "sockets"))
+	reg, err := agent.NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -335,12 +335,18 @@ startup when it takes this path. Everything else still lives under the root. If
 you want your sockets under `POGO_HOME` (nicer to inspect and clean up), pick a
 shallow root: `~/.pogo-sandbox` fits comfortably, a 90-byte path does not.
 
-The same limit implies a ceiling on **agent names**: pogo reserves 24 bytes for
-`<agent>.sock` when choosing the socket directory (`MaxAgentNameLen`). Real names
-are far shorter — `pm-dealdesk` is 11, a polecat is named for its work item. But
-a name longer than 24 bytes, under a root deep enough to have consumed the
-headroom (roughly 53+ bytes), produces a socket path past `sun_path`: the agent
-spawns and runs, `pogo agent attach` does not work against it, and pogod logs
-`attach listener failed`. Nothing rejects such a name at spawn today. Under the
-default `~/.pogo` root there is room for a 64-byte name, so this is only
-reachable with both a deep root and a long name.
+The same limit implies a hard ceiling on **agent names**: pogo reserves 24 bytes
+for `<agent>.sock` when choosing the socket directory (`MaxAgentNameLen`). Real
+names are far shorter — `pm-dealdesk` is 11, a polecat is named for its work
+item — so you are unlikely to meet this limit. A name longer than 24 bytes is
+rejected at spawn with HTTP 400 (`pogo agent start` and `pogo agent spawn-polecat`
+print the error and exit non-zero).
+
+The rejection is unconditional, not conditional on your root's depth. Only a root
+deep enough to have consumed the socket directory's headroom (roughly 53+ bytes)
+would actually push such a name's socket path past `sun_path` — the default
+`~/.pogo` root has room for a 64-byte name — but a name that works on one machine
+and silently loses attach on another is worse than a name that is refused
+everywhere. If pogod cannot bind an agent's attach socket at all, the spawn now
+fails outright rather than returning a running agent that `pogo agent attach`
+cannot reach.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -335,6 +335,14 @@ startup when it takes this path. Everything else still lives under the root. If
 you want your sockets under `POGO_HOME` (nicer to inspect and clean up), pick a
 shallow root: `~/.pogo-sandbox` fits comfortably, a 90-byte path does not.
 
+`$TMPDIR` is itself unbounded, so if it is long enough to squeeze out the
+reserved name budget (roughly 52+ bytes), the sockets degrade one step further to
+`/tmp/pogo-agents-<hash of the root>`, which fits under any root. The hash — and
+with it the per-root isolation — is unchanged. This only matters if you run pogod
+with an unusually deep `TMPDIR`; the guarantee it protects is that **the 24-byte
+agent-name budget below holds under every root and every `TMPDIR`**, so a legal
+name never fails to bind.
+
 The same limit implies a hard ceiling on **agent names**: pogo reserves 24 bytes
 for `<agent>.sock` when choosing the socket directory (`MaxAgentNameLen`). Real
 names are far shorter — `pm-dealdesk` is 11, a polecat is named for its work

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -609,6 +609,15 @@ type SpawnRequest struct {
 
 // Spawn starts a new agent process with a PTY.
 func (r *Registry) Spawn(req SpawnRequest) (*Agent, error) {
+	// Validate before taking the lock or touching the filesystem: a name pogod
+	// cannot bind an attach socket for is rejected outright rather than spawned
+	// with attach quietly unavailable (mg-ef80). This is the choke point every
+	// spawn path funnels through — the generic POST /agents, StartCrewAgent,
+	// and handleSpawnPolecat.
+	if err := ValidateAgentName(req.Name); err != nil {
+		return nil, err
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -729,18 +738,32 @@ func (r *Registry) Spawn(req SpawnRequest) (*Agent, error) {
 		outputDone:     make(chan struct{}),
 	}
 
+	// Bind the attach socket before the PTY plumbing goroutines start and
+	// before the agent enters the registry, so a permanent bind failure can be
+	// undone with a kill instead of a partial teardown.
+	//
+	// A permanent failure means this agent could never be attached to — the
+	// socket path itself is unusable — and returning a live agent (and a 201)
+	// for it would be a lie. Every other bind failure is transient from the
+	// supervisor's point of view: it keeps retrying on its ticker, so an agent
+	// spawned during fd exhaustion recovers attach once fds free up rather than
+	// losing it for good (mg-d216). See mg-ef80.
+	if err := a.startListener(); err != nil {
+		if isFatalListenErr(err) {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+			a.Cleanup()
+			return nil, fmt.Errorf("%w: agent %s at %s: %w", ErrAttachSocketUnusable, req.Name, a.socketPath, err)
+		}
+		log.Printf("agent %s: attach listener failed: %v — supervisor will retry", req.Name, err)
+	}
+
 	// Start output reader — sole reader of master fd, fans out to
 	// ring buffer + any active attach connections
 	go a.readOutput()
 
 	// Start process reaper — waits for exit, fires onExit callback
 	go r.waitAndHandle(a)
-
-	// Start attach listener
-	if err := a.startListener(); err != nil {
-		// Non-fatal — agent runs fine, just can't attach
-		log.Printf("agent %s: attach listener failed: %v", req.Name, err)
-	}
 
 	r.agents[req.Name] = a
 	log.Printf("agent %s: spawned pid=%d type=%s proc=%s", req.Name, a.PID, req.Type, procName)
@@ -1356,10 +1379,36 @@ func isRetryableAcceptErr(err error) bool {
 	return false
 }
 
+// ErrAttachSocketUnusable reports a spawn abandoned because the agent's attach
+// socket could never be bound. It is a property of the environment (a POGO_HOME
+// deep enough to push the socket path past sun_path), not of the request, so the
+// API handlers answer 500 rather than the legacy catch-all 409.
+var ErrAttachSocketUnusable = errors.New("attach socket cannot be bound")
+
+// isFatalListenErr reports whether binding the attach socket failed for a
+// reason no retry can clear, because the socket path itself is unusable.
+//
+// The class that matters is a path that overruns sockaddr_un's sun_path.
+// syscall.SockaddrUnix.sockaddr rejects such a path with EINVAL on darwin and
+// linux alike, before the bind syscall is ever made, so EINVAL is the errno to
+// key on rather than the ENAMETOOLONG one might expect. ENAMETOOLONG is checked
+// too, for the paths a kernel does reject itself (a component past NAME_MAX).
+//
+// Everything else — EMFILE/ENFILE under fd exhaustion, EADDRINUSE against a
+// racing daemon, a socket dir that a sweep removed out from under us — may clear
+// on its own, and the supervisor rebinds when it does. Spawn kills the agent for
+// a fatal error, so this set stays deliberately narrow: a false positive costs
+// an agent that would otherwise have recovered.
+func isFatalListenErr(err error) bool {
+	return errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENAMETOOLONG)
+}
+
 // startListener creates a unix domain socket for attach connections and starts
 // the supervisor that keeps it usable for the life of the process. The
 // supervisor starts even when the first bind fails, so an agent spawned during
 // fd exhaustion recovers attach once fds free up instead of losing it for good.
+// Spawn checks the returned error with isFatalListenErr: a bind that can never
+// succeed fails the spawn rather than leaving a live agent nobody can attach to.
 func (a *Agent) startListener() error {
 	a.mu.Lock()
 	if a.attachStop == nil {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestSpawnAndNudge(t *testing.T) {
-	tmpDir := t.TempDir()
-	socketDir := filepath.Join(tmpDir, "sockets")
+	socketDir := shortSocketDir(t)
 
 	reg, err := NewRegistry(socketDir)
 	if err != nil {
@@ -64,8 +63,7 @@ func TestSpawnAndNudge(t *testing.T) {
 // input field rather than a submit. Regression test for the bug where crew
 // nudges sat unsent in architect's input box.
 func TestNudgeSplitsBodyAndSubmit(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -101,8 +99,7 @@ func TestNudgeSplitsBodyAndSubmit(t *testing.T) {
 // skips the delay — there's nothing for the receiver to read separately, and
 // the delay would just slow down the submit.
 func TestNudgeEmptyMessageNoDelay(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -139,8 +136,7 @@ func TestNudgeEmptyMessageNoDelay(t *testing.T) {
 // sentinel ("? for shortcuts", mg-ce61), so the fake harness must emit a line
 // containing that sentinel before the nudge will deliver.
 func TestInitialNudgeAutoDelivers(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -184,8 +180,7 @@ func TestInitialNudgeAutoDelivers(t *testing.T) {
 // restart-on-crash re-exec re-delivers it, and a.InitialNudge stays empty so
 // Respawn doesn't also re-nudge.
 func TestInitialPromptViaArgvAppendsToCommand(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -237,8 +232,7 @@ func TestInitialPromptViaArgvAppendsToCommand(t *testing.T) {
 // nothing to deliver — the command must run unmodified even for an
 // argv-capable provider.
 func TestInitialPromptViaArgvEmptyNudgeNoAppend(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -262,8 +256,7 @@ func TestInitialPromptViaArgvEmptyNudgeNoAppend(t *testing.T) {
 }
 
 func TestSpawnDuplicate(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -289,8 +282,7 @@ func TestSpawnDuplicate(t *testing.T) {
 }
 
 func TestListAndGet(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -319,8 +311,7 @@ func TestListAndGet(t *testing.T) {
 }
 
 func TestStopAgent(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -371,8 +362,7 @@ func TestSocketPath(t *testing.T) {
 }
 
 func TestProcessExit(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -406,8 +396,7 @@ func TestProcessName(t *testing.T) {
 }
 
 func TestEnvInjection(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -452,7 +441,7 @@ func TestEnvInjection(t *testing.T) {
 // working directory before the process starts.
 func TestSpawnContextFileInjection(t *testing.T) {
 	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -516,7 +505,7 @@ func TestSpawnContextFileInjection(t *testing.T) {
 // as polecats. See docs/investigations/codex-e2e-validation.md.
 func TestSpawnContextFileInjectionCrew(t *testing.T) {
 	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -568,7 +557,7 @@ func TestSpawnContextFileInjectionCrew(t *testing.T) {
 // for a flag-injection provider: no stray AGENTS.override.md is written.
 func TestSpawnNoContextFileForClaude(t *testing.T) {
 	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -608,8 +597,7 @@ func TestSpawnNoContextFileForClaude(t *testing.T) {
 }
 
 func TestAgentStatus(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -635,8 +623,7 @@ func TestAgentStatus(t *testing.T) {
 }
 
 func TestExitStatus(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -683,8 +670,7 @@ func TestExitStatus(t *testing.T) {
 }
 
 func TestOnExitCallback(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -714,8 +700,7 @@ func TestOnExitCallback(t *testing.T) {
 }
 
 func TestRespawn(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -750,8 +735,7 @@ func TestRespawn(t *testing.T) {
 }
 
 func TestWorktreeFieldsSetBeforeSpawn(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -778,8 +762,7 @@ func TestWorktreeFieldsSetBeforeSpawn(t *testing.T) {
 }
 
 func TestWorktreeFieldsVisibleInOnExit(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -824,8 +807,7 @@ func TestWorktreeFieldsVisibleInOnExit(t *testing.T) {
 }
 
 func TestDoneBlocksUntilOnExitCompletes(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -857,8 +839,7 @@ func TestDoneBlocksUntilOnExitCompletes(t *testing.T) {
 }
 
 func TestWorkItemIDSetOnSpawn(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -879,8 +860,7 @@ func TestWorkItemIDSetOnSpawn(t *testing.T) {
 }
 
 func TestWorkItemIDEmptyByDefault(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -949,8 +929,7 @@ func TestWorkItemIDOmittedWhenEmpty(t *testing.T) {
 // is respawned by pogod's onExit handler — the work item link must survive so
 // spend tracking and the agent registry stay correct after the restart.
 func TestWorkItemIDPreservedAcrossRespawn(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -1007,8 +986,7 @@ func wedgeDeadAgent(t *testing.T, reg *Registry, name string) *Agent {
 // a RestartOnCrash agent that Stop otherwise leaves intact, so a subsequent
 // start is not blocked by a dead pid.
 func TestStopClearsDeadRestartAgent(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -1027,8 +1005,7 @@ func TestStopClearsDeadRestartAgent(t *testing.T) {
 // gh #19, Fix 3: pogo agent start overwrites a dead-process registration
 // rather than refusing with "already running".
 func TestStartOverwritesDeadRegistration(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -1061,8 +1038,7 @@ func TestStartOverwritesDeadRegistration(t *testing.T) {
 // duplicate name whose process is actually running, and Stop tears it down
 // normally. Verified on a distinct agent name per acceptance bar 4.
 func TestSpawnRefusesLiveDuplicate(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -1101,8 +1077,7 @@ func TestSpawnRefusesLiveDuplicate(t *testing.T) {
 // at either side kills both — pogo doctor / any agent spawn takes down
 // pogod and every sibling agent at once.
 func TestSpawnProcessGroupIsolation(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -387,7 +387,7 @@ func (r *Registry) handleAgents(w http.ResponseWriter, req *http.Request) {
 			RestartOnCrash: ResolveRestartOnCrash(spawnReq.PromptFile, spawnReq.Type),
 		})
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusConflict)
+			http.Error(w, err.Error(), spawnErrStatus(err))
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -396,6 +396,22 @@ func (r *Registry) handleAgents(w http.ResponseWriter, req *http.Request) {
 
 	default:
 		http.Error(w, "", http.StatusMethodNotAllowed)
+	}
+}
+
+// spawnErrStatus maps a Registry.Spawn error to an HTTP status. A name pogod
+// refuses is the caller's mistake (400); an attach socket that can never bind is
+// the daemon's environment, not the request (500). Everything else keeps the
+// legacy catch-all of 409 — the errors Spawn returned before mg-ef80 were all
+// registry conflicts ("agent %q already running").
+func spawnErrStatus(err error) int {
+	switch {
+	case errors.Is(err, ErrInvalidAgentName):
+		return http.StatusBadRequest
+	case errors.Is(err, ErrAttachSocketUnusable):
+		return http.StatusInternalServerError
+	default:
+		return http.StatusConflict
 	}
 }
 
@@ -650,6 +666,13 @@ type StartErrorResponse struct {
 // Returns ErrPromptNotFound (wrapped) when the prompt file is missing, or any
 // error from Spawn (e.g. when the agent is already registered).
 func (r *Registry) StartCrewAgent(name string) (*Agent, error) {
+	// Reject an unusable name up front. Spawn checks it again, but the callers
+	// that reach this function directly — autostart and Wake — would otherwise
+	// create the agent dir and expand a prompt for a name that cannot spawn.
+	if err := ValidateAgentName(name); err != nil {
+		return nil, err
+	}
+
 	// Look up prompt file: the coordinator's mayor.md is in PromptDir, crew
 	// in CrewPromptDir. This on-disk file is the operator-editable stub —
 	// kept separate from the (possibly synthesized) promptFile below because
@@ -748,8 +771,8 @@ func (r *Registry) handleStart(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if startReq.Name == "" {
-		http.Error(w, "name is required", http.StatusBadRequest)
+	if err := ValidateAgentName(startReq.Name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -763,6 +786,8 @@ func (r *Registry) handleStart(w http.ResponseWriter, req *http.Request) {
 	a, err := r.StartCrewAgent(startReq.Name)
 	if err != nil {
 		switch {
+		case errors.Is(err, ErrInvalidAgentName):
+			http.Error(w, err.Error(), http.StatusBadRequest)
 		case errors.Is(err, ErrPromptNotFound):
 			// Emit a structured JSON body so the CLI can distinguish
 			// "prompt missing on the server" from "endpoint missing because
@@ -806,8 +831,10 @@ func (r *Registry) handleSpawnPolecat(w http.ResponseWriter, req *http.Request) 
 		return
 	}
 
-	if spawnReq.Name == "" {
-		http.Error(w, "name is required", http.StatusBadRequest)
+	// Validate before the worktree, agent dir, and expanded prompt file get
+	// created — a rejected name should leave nothing behind (mg-ef80).
+	if err := ValidateAgentName(spawnReq.Name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -1017,7 +1044,7 @@ func (r *Registry) handleSpawnPolecat(w http.ResponseWriter, req *http.Request) 
 	if err != nil {
 		os.Remove(promptFile) // Clean up temp file on spawn failure
 		cleanupFailedPolecatSpawn(sourceRepo, worktreeDir, branchName)
-		http.Error(w, err.Error(), http.StatusConflict)
+		http.Error(w, err.Error(), spawnErrStatus(err))
 		return
 	}
 

--- a/internal/agent/api_test.go
+++ b/internal/agent/api_test.go
@@ -23,8 +23,7 @@ func (catCommandConfig) AgentCommand(string) string  { return "cat" }
 func (catCommandConfig) AgentProvider(string) string { return "" }
 
 func TestAgentInfoLastActivity(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -55,8 +54,7 @@ func TestAgentInfoLastActivity(t *testing.T) {
 }
 
 func TestAgentInfoLastActivityEmpty(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -237,7 +235,7 @@ func TestHandleStart_NudgeOnStartFromFrontmatter(t *testing.T) {
 		t.Fatalf("write prompt: %v", err)
 	}
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -264,7 +262,7 @@ func TestHandleStart_MayorFallbackNudge(t *testing.T) {
 		t.Fatalf("write mayor prompt: %v", err)
 	}
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -322,7 +320,7 @@ func TestHandleStart_RecoversWedgedCrewAgent(t *testing.T) {
 		t.Fatalf("InitPromptDirs: %v", err)
 	}
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -359,7 +357,7 @@ func TestHandleStop_ClearsWedgedCrewAgent(t *testing.T) {
 		t.Fatalf("InitPromptDirs: %v", err)
 	}
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -396,7 +394,7 @@ func TestHandleStart_PromptNotFoundStructured(t *testing.T) {
 	}
 	// Intentionally do NOT create crew/missing.md — handleStart should 404.
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -448,7 +446,7 @@ func TestHandleStart_CrewFallbackNudge(t *testing.T) {
 		t.Fatalf("write prompt: %v", err)
 	}
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -500,7 +498,7 @@ func TestHandleSpawnPolecat_NudgeOnStartFromFrontmatter(t *testing.T) {
 
 	writeTemplate(t, "fronted", "+++\nnudge_on_start = \"custom polecat nudge\"\n+++\nbody {{.Id}}\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -528,7 +526,7 @@ func TestHandleSpawnPolecat_NudgeOnStartTemplateExpanded(t *testing.T) {
 
 	writeTemplate(t, "templated", "+++\nnudge_on_start = \"work item: {{.Id}}\"\n+++\nbody\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -554,7 +552,7 @@ func TestHandleSpawnPolecat_FallbackNudge(t *testing.T) {
 
 	writeTemplate(t, "plainpc", "# plain polecat\nbody {{.Id}}\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -585,7 +583,7 @@ func TestHandleSpawnPolecat_FailureCleansUpBranch(t *testing.T) {
 
 	writeTemplate(t, "retrypc", "+++\nnudge_on_start = \"{{.Bogus\"\n+++\n# polecat\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -633,7 +631,7 @@ func TestHandleSpawnPolecat_WorktreeFalseSkipsCreation(t *testing.T) {
 
 	writeTemplate(t, "noworktree", "+++\nworktree = false\n+++\n# polecat without worktree\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -674,7 +672,7 @@ func TestHandleSpawnPolecat_WorktreeTrueCreatesWorktree(t *testing.T) {
 
 	writeTemplate(t, "wantsworktree", "+++\nworktree = true\n+++\n# polecat with worktree\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -706,7 +704,7 @@ func TestHandleSpawnPolecat_WorktreeDefaultWhenRepoSet(t *testing.T) {
 
 	writeTemplate(t, "defaultwt", "# polecat with default worktree behavior\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -738,7 +736,7 @@ func TestHandleSpawnPolecat_NoWorktreeFlagSkipsCreation(t *testing.T) {
 	// Even with worktree=true frontmatter AND a Repo, --no-worktree wins.
 	writeTemplate(t, "nowtflag", "+++\nworktree = true\n+++\n# polecat in-place\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -791,7 +789,7 @@ func TestHandleSpawnPolecat_NoWorktreeNoRepoSucceeds(t *testing.T) {
 
 	writeTemplate(t, "nowtnorepo", "# in-place polecat, no repo\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -823,7 +821,7 @@ func TestHandleSpawnPolecat_NoWorktreeVarExposed(t *testing.T) {
 	writeTemplate(t, "nowtvar",
 		"# polecat\n{{if .NoWorktree}}MODE: in-place at {{.WorktreeDir}}{{else}}MODE: worktree{{end}}\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -858,7 +856,7 @@ func TestHandleSpawnPolecat_FrontmatterStrippedFromBody(t *testing.T) {
 
 	writeTemplate(t, "stripfm", "+++\nnudge_on_start = \"go\"\n+++\nID is {{.Id}}\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -895,7 +893,7 @@ func TestHandleSpawnPolecat_WorkItemIDPlumbedFromRequest(t *testing.T) {
 
 	writeTemplate(t, "wi", "# polecat\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -934,7 +932,7 @@ func TestHandleSpawnPolecat_WorkItemIDEmptyWhenNoId(t *testing.T) {
 
 	writeTemplate(t, "noid", "# polecat\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -963,7 +961,7 @@ func TestHandleSpawnPolecat_WorkItemIDEmptyWhenNoId(t *testing.T) {
 // process is a harmless `cat` regardless of which provider is resolved.
 func providerTestRegistry(t *testing.T, tmpHome string) *Registry {
 	t.Helper()
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}

--- a/internal/agent/attach_proto_test.go
+++ b/internal/agent/attach_proto_test.go
@@ -3,27 +3,12 @@ package agent
 import (
 	"encoding/binary"
 	"net"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/creack/pty"
 )
-
-// shortSocketDir returns a tempdir with a path short enough to fit inside
-// AF_UNIX's sun_path limit (≈104 bytes on macOS). t.TempDir() on darwin
-// returns paths under /var/folders/... which routinely exceed that.
-func shortSocketDir(t *testing.T) string {
-	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", "pogo-attach-")
-	if err != nil {
-		t.Fatalf("MkdirTemp: %v", err)
-	}
-	t.Cleanup(func() { os.RemoveAll(dir) })
-	return filepath.Join(dir, "s")
-}
 
 // waitForPTYSize polls pty.Getsize on master until cols/rows match the wanted
 // values or the deadline elapses. Returns the last observed size on timeout.

--- a/internal/agent/autostart_test.go
+++ b/internal/agent/autostart_test.go
@@ -37,7 +37,7 @@ func TestAutoStartAgents_StartsOnlyFlaggedPrompts(t *testing.T) {
 	writePrompt(t, CrewPromptDir(), "lurker", "+++\nauto_start = false\n+++\n# lurker\n")
 	writePrompt(t, TemplateDir(), "polecat", "+++\nauto_start = true\n+++\n# polecat template\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestAutoStartAgents_Idempotent(t *testing.T) {
 	}
 	writePrompt(t, PromptDir(), "mayor", "+++\nauto_start = true\n+++\n# mayor\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestAutoStartAgents_SkipsParked(t *testing.T) {
 		t.Fatalf("writeParkState: %v", err)
 	}
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -152,7 +152,7 @@ func TestAutoStartAgents_NoPromptDir(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestAutoStartAgents_AlphabeticalOrder(t *testing.T) {
 	writePrompt(t, CrewPromptDir(), "alpha", "+++\nauto_start = true\n+++\n")
 	writePrompt(t, PromptDir(), "mayor", "+++\nauto_start = true\n+++\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestAutoStartAgents_NoFrontmatterDoesNotStart(t *testing.T) {
 	}
 	writePrompt(t, PromptDir(), "mayor", "# mayor with no frontmatter\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -226,7 +226,7 @@ func TestStartCrewAgentCoordinatorRename(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}

--- a/internal/agent/diagnose_test.go
+++ b/internal/agent/diagnose_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"path/filepath"
 	"testing"
 	"time"
 )
@@ -16,8 +15,7 @@ func TestStallThresholdFor(t *testing.T) {
 }
 
 func TestDiagnoseHealthy(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -55,8 +53,7 @@ func TestDiagnoseHealthy(t *testing.T) {
 }
 
 func TestDiagnoseExited(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -349,8 +346,7 @@ func (f *fakeScheduleProvider) CronWindowsForAgent(agentIdentity string) []CronW
 }
 
 func TestRegistryDiagnoseUsesScheduleProvider(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -378,8 +374,7 @@ func TestRegistryDiagnoseUsesScheduleProvider(t *testing.T) {
 }
 
 func TestDiagnoseRecentOutputTail(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}

--- a/internal/agent/events_test.go
+++ b/internal/agent/events_test.go
@@ -73,8 +73,7 @@ func waitForEvent(t *testing.T, path, eventType, agent string, timeout time.Dura
 
 func TestEmitsAgentSpawned(t *testing.T) {
 	path := useTempEventLog(t)
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,8 +115,7 @@ func TestEmitsAgentSpawned(t *testing.T) {
 
 func TestEmitsAgentStoppedOnCleanExit(t *testing.T) {
 	path := useTempEventLog(t)
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,8 +149,7 @@ func TestEmitsAgentStoppedOnCleanExit(t *testing.T) {
 
 func TestEmitsAgentStoppedOnRequestedStop(t *testing.T) {
 	path := useTempEventLog(t)
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,8 +179,7 @@ func TestEmitsAgentStoppedOnRequestedStop(t *testing.T) {
 
 func TestEmitsAgentCrashedOnNonZeroExit(t *testing.T) {
 	path := useTempEventLog(t)
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,8 +211,7 @@ func TestEmitsAgentCrashedOnNonZeroExit(t *testing.T) {
 
 func TestEmitsAgentRestartedOnRespawn(t *testing.T) {
 	path := useTempEventLog(t)
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,8 +253,7 @@ func TestEmitsAgentRestartedOnRespawn(t *testing.T) {
 
 func TestEmitsNudgeSent(t *testing.T) {
 	path := useTempEventLog(t)
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -301,8 +295,7 @@ func TestEmitsNudgeSent(t *testing.T) {
 // timestamp (RFC3339Nano UTC), event_type, agent, and details.
 func TestEventEnvelope(t *testing.T) {
 	path := useTempEventLog(t)
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/getbyworkitem_test.go
+++ b/internal/agent/getbyworkitem_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"path/filepath"
 	"testing"
 )
 
@@ -10,7 +9,7 @@ import (
 // the full work-item id (WorkItemID) an authored MR carries, while a plain Get
 // only matches the registry key.
 func TestGetByWorkItemOrName(t *testing.T) {
-	reg, err := NewRegistry(filepath.Join(t.TempDir(), "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}

--- a/internal/agent/integration_test.go
+++ b/internal/agent/integration_test.go
@@ -418,16 +418,20 @@ func TestPolecatCleanupOnExit(t *testing.T) {
 // exited agent is cleaned up regardless of type. This mirrors the production
 // onExit logic in cmd/pogod/main.go.
 func TestRestartOnCrashFlagDrivesBranching(t *testing.T) {
+	// agent is spelled out per case rather than derived from name: a name over
+	// config.MaxAgentNameLen is refused at spawn (mg-ef80), and these subtest
+	// names are far longer than that.
 	cases := []struct {
 		name           string
+		agent          string
 		typ            AgentType
 		restartOnCrash bool
 		wantRestart    bool
 	}{
-		{"crew with restart=true is respawned", TypeCrew, true, true},
-		{"crew with restart=false stays down", TypeCrew, false, false},
-		{"polecat with restart=true is respawned", TypePolecat, true, true},
-		{"polecat with restart=false stays down (default)", TypePolecat, false, false},
+		{"crew with restart=true is respawned", "roc-crew-on", TypeCrew, true, true},
+		{"crew with restart=false stays down", "roc-crew-off", TypeCrew, false, false},
+		{"polecat with restart=true is respawned", "roc-cat-on", TypePolecat, true, true},
+		{"polecat with restart=false stays down (default)", "roc-cat-off", TypePolecat, false, false},
 	}
 
 	for _, tc := range cases {
@@ -462,7 +466,7 @@ func TestRestartOnCrashFlagDrivesBranching(t *testing.T) {
 			})
 
 			a, err := reg.Spawn(SpawnRequest{
-				Name:           "roc-" + strings.ReplaceAll(tc.name, " ", "-"),
+				Name:           tc.agent,
 				Type:           tc.typ,
 				Command:        []string{"true"},
 				RestartOnCrash: tc.restartOnCrash,

--- a/internal/agent/mailcheck_test.go
+++ b/internal/agent/mailcheck_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -43,7 +42,7 @@ func TestSpawnPolecatRegistersMailCheck(t *testing.T) {
 
 	writeTemplate(t, "plainpc", "# plain polecat\nbody {{.Id}}\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -87,7 +86,7 @@ func TestSpawnPolecatMailCheckFallsBackToName(t *testing.T) {
 
 	writeTemplate(t, "noidpc", "# polecat no id\nbody\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -125,7 +124,7 @@ func TestSpawnPolecatMailCheckFailureNonFatal(t *testing.T) {
 
 	writeTemplate(t, "errpc", "# polecat\nbody {{.Id}}\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -155,7 +154,7 @@ func TestSpawnPolecatNoMailCheckRegistrar(t *testing.T) {
 
 	writeTemplate(t, "bareepc", "# polecat\nbody {{.Id}}\n")
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}

--- a/internal/agent/name.go
+++ b/internal/agent/name.go
@@ -23,10 +23,13 @@ var ErrInvalidAgentName = errors.New("invalid agent name")
 // of the name alone: a name either works under every POGO_HOME or fails under
 // all of them. Enforcing it only where it actually overflows would make spawn
 // succeed or fail based on how deep the operator's root happens to be, which is
-// the surprise this check exists to remove. Spawn also treats a permanent bind
-// failure as fatal, so a name that passes here and still cannot bind — should
-// the reservation arithmetic ever drift from sun_path — fails the spawn instead
-// of silently losing attach (mg-ef80).
+// the surprise this check exists to remove.
+//
+// That equivalence rests on config.AgentSocketDir always reserving
+// MaxAgentNameLen bytes for the name, whatever the root or TMPDIR. Spawn also
+// treats a permanent bind failure as fatal, so a name that passes here and still
+// cannot bind — should the reservation arithmetic ever drift from sun_path —
+// fails the spawn instead of silently losing attach (mg-ef80).
 //
 // The comparison is on bytes, not runes: sun_path is a byte budget.
 func ValidateAgentName(name string) error {

--- a/internal/agent/name.go
+++ b/internal/agent/name.go
@@ -1,0 +1,41 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/drellem2/pogo/internal/config"
+)
+
+// ErrInvalidAgentName wraps every reason a name cannot be spawned. The API
+// handlers test for it with errors.Is and answer 400 rather than 409/500.
+var ErrInvalidAgentName = errors.New("invalid agent name")
+
+// ValidateAgentName rejects names pogod cannot fully serve.
+//
+// The length ceiling is config.MaxAgentNameLen. An agent's attach socket lives
+// at "<socket dir>/<name>.sock", and AgentSocketDir chooses that directory by
+// reserving exactly MaxAgentNameLen bytes for the name against the AF_UNIX
+// sun_path limit. A longer name overruns the reservation, bind fails, and the
+// agent runs with `pogo agent attach` permanently unavailable against it.
+//
+// Rejecting the name here rather than at bind time makes the ceiling a property
+// of the name alone: a name either works under every POGO_HOME or fails under
+// all of them. Enforcing it only where it actually overflows would make spawn
+// succeed or fail based on how deep the operator's root happens to be, which is
+// the surprise this check exists to remove. Spawn also treats a permanent bind
+// failure as fatal, so a name that passes here and still cannot bind — should
+// the reservation arithmetic ever drift from sun_path — fails the spawn instead
+// of silently losing attach (mg-ef80).
+//
+// The comparison is on bytes, not runes: sun_path is a byte budget.
+func ValidateAgentName(name string) error {
+	if name == "" {
+		return fmt.Errorf("%w: name is required", ErrInvalidAgentName)
+	}
+	if len(name) > config.MaxAgentNameLen {
+		return fmt.Errorf("%w: %q is %d bytes, over the %d-byte limit; the agent's attach socket path must fit the AF_UNIX sun_path limit",
+			ErrInvalidAgentName, name, len(name), config.MaxAgentNameLen)
+	}
+	return nil
+}

--- a/internal/agent/name_test.go
+++ b/internal/agent/name_test.go
@@ -1,0 +1,306 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drellem2/pogo/internal/config"
+)
+
+func TestValidateAgentName(t *testing.T) {
+	tests := []struct {
+		name    string
+		agent   string
+		wantErr bool
+	}{
+		{"empty", "", true},
+		{"short", "pm-pogo", false},
+		{"polecat work item", "ef80", false},
+		{"exactly at the limit", strings.Repeat("a", config.MaxAgentNameLen), false},
+		{"one byte over the limit", strings.Repeat("a", config.MaxAgentNameLen+1), true},
+		{"reviewer's 30-char repro", strings.Repeat("a", 30), true},
+		// sun_path is a byte budget, so the ceiling counts bytes, not runes:
+		// 13 three-byte runes are 39 bytes and must be refused even though
+		// they are well under MaxAgentNameLen runes.
+		{"multibyte over the byte limit", strings.Repeat("日", 13), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAgentName(tt.agent)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateAgentName(%d bytes) error = %v, wantErr %v", len(tt.agent), err, tt.wantErr)
+			}
+			if err != nil && !errors.Is(err, ErrInvalidAgentName) {
+				t.Errorf("error %v does not wrap ErrInvalidAgentName", err)
+			}
+		})
+	}
+}
+
+// TestSpawnRejectsOverlongName pins the headline fix of mg-ef80. Before it,
+// Spawn accepted any name and only the attach bind noticed — under a deep
+// enough POGO_HOME the agent ran with attach permanently unavailable while the
+// API reported success.
+func TestSpawnRejectsOverlongName(t *testing.T) {
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	name := strings.Repeat("a", config.MaxAgentNameLen+1)
+	a, err := reg.Spawn(SpawnRequest{Name: name, Type: TypePolecat, Command: []string{"cat"}})
+	if err == nil {
+		t.Fatal("Spawn accepted a name over MaxAgentNameLen")
+	}
+	if a != nil {
+		t.Errorf("Spawn returned an agent alongside its error: %+v", a)
+	}
+	if !errors.Is(err, ErrInvalidAgentName) {
+		t.Errorf("Spawn error %v does not wrap ErrInvalidAgentName", err)
+	}
+	if reg.Get(name) != nil {
+		t.Error("a rejected name left a registry entry behind")
+	}
+}
+
+// TestSpawnRejectsEmptyName guards the check Spawn never had: the handlers
+// rejected an empty name, but a direct Spawn would happily bind ".sock".
+func TestSpawnRejectsEmptyName(t *testing.T) {
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	if _, err := reg.Spawn(SpawnRequest{Name: "", Type: TypePolecat, Command: []string{"cat"}}); !errors.Is(err, ErrInvalidAgentName) {
+		t.Fatalf("Spawn(\"\") error = %v, want ErrInvalidAgentName", err)
+	}
+}
+
+// TestSpawnAcceptsNameAtLimit is the other half of the boundary: the byte
+// budget AgentSocketDir reserves is a promise, so a name of exactly
+// MaxAgentNameLen must still spawn.
+func TestSpawnAcceptsNameAtLimit(t *testing.T) {
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	name := strings.Repeat("a", config.MaxAgentNameLen)
+	if _, err := reg.Spawn(SpawnRequest{Name: name, Type: TypePolecat, Command: []string{"cat"}}); err != nil {
+		t.Fatalf("Spawn(%d-byte name at the limit): %v", len(name), err)
+	}
+	if reg.Get(name) == nil {
+		t.Error("a name at the limit did not register")
+	}
+}
+
+// TestHandleStartRejectsOverlongName pins the API contract: 400, not the 201
+// that used to lie.
+func TestHandleStartRejectsOverlongName(t *testing.T) {
+	// Hermetic HOME: the name must be refused before the prompt lookup, so a
+	// regression that moved the check later would otherwise fail against the
+	// developer's real ~/.pogo with a confusing 404.
+	t.Setenv("HOME", t.TempDir())
+
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+	reg.SetCommandConfig(catCommandConfig{})
+
+	name := strings.Repeat("a", config.MaxAgentNameLen+1)
+	body, _ := json.Marshal(StartAPIRequest{Name: name})
+	req := httptest.NewRequest("POST", "/agents/start", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	reg.handleStart(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("handleStart status = %d, want %d; body=%s", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	if reg.Get(name) != nil {
+		t.Error("a rejected name left a registry entry behind")
+	}
+}
+
+// TestHandleSpawnPolecatRejectsOverlongName also guards that the rejection
+// happens before any side effects: no worktree, no agent dir, no prompt file.
+func TestHandleSpawnPolecatRejectsOverlongName(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	if err := InitPromptDirs(); err != nil {
+		t.Fatalf("InitPromptDirs: %v", err)
+	}
+
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+	reg.SetCommandConfig(catCommandConfig{})
+
+	name := strings.Repeat("a", config.MaxAgentNameLen+1)
+	body, _ := json.Marshal(SpawnPolecatAPIRequest{Name: name, NoWorktree: true, Task: "t"})
+	req := httptest.NewRequest("POST", "/agents/spawn-polecat", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	reg.handleSpawnPolecat(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("handleSpawnPolecat status = %d, want %d; body=%s", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(PromptDir(), name)); !os.IsNotExist(err) {
+		t.Errorf("a rejected name left an agent dir behind (stat err = %v)", err)
+	}
+}
+
+// TestHandleAgentsPostRejectsOverlongName covers the generic POST /agents
+// path, which mapped every Spawn error to 409 before mg-ef80.
+func TestHandleAgentsPostRejectsOverlongName(t *testing.T) {
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	name := strings.Repeat("a", config.MaxAgentNameLen+1)
+	body, _ := json.Marshal(SpawnAPIRequest{Name: name, Type: TypePolecat, Command: []string{"cat"}})
+	req := httptest.NewRequest("POST", "/agents", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	reg.handleAgents(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("handleAgents POST status = %d, want %d; body=%s", rr.Code, http.StatusBadRequest, rr.Body.String())
+	}
+}
+
+// TestHandleAgentsPostStillConflictsOnDuplicate guards that routing the
+// invalid-name case to 400 did not steal the 409 the duplicate-name case
+// still owes its callers.
+func TestHandleAgentsPostStillConflictsOnDuplicate(t *testing.T) {
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	if _, err := reg.Spawn(SpawnRequest{Name: "dupe", Type: TypePolecat, Command: []string{"cat"}}); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	body, _ := json.Marshal(SpawnAPIRequest{Name: "dupe", Type: TypePolecat, Command: []string{"cat"}})
+	req := httptest.NewRequest("POST", "/agents", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	reg.handleAgents(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("handleAgents POST on a live duplicate = %d, want %d; body=%s", rr.Code, http.StatusConflict, rr.Body.String())
+	}
+}
+
+// socketDirOfLen returns a creatable directory path of exactly n bytes. It
+// builds from a short /tmp base rather than t.TempDir(), whose darwin path is
+// already longer than the lengths this helper's callers need to hit exactly.
+func socketDirOfLen(t *testing.T, n int) string {
+	t.Helper()
+	base, err := os.MkdirTemp("/tmp", "pogo-len-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(base) })
+
+	pad := n - len(base) - 1 // -1 for the separator filepath.Join adds
+	if pad < 1 || pad > 255 {
+		// A single path component cannot exceed NAME_MAX.
+		t.Fatalf("cannot build a %d-byte dir from a %d-byte base in one component", n, len(base))
+	}
+	dir := filepath.Join(base, strings.Repeat("s", pad))
+	if len(dir) != n {
+		t.Fatalf("test bug: built a %d-byte dir, want %d", len(dir), n)
+	}
+	return dir
+}
+
+// TestSpawnFailsWhenAttachSocketCannotBind is the mg-ef80 backstop. A name
+// within MaxAgentNameLen still overruns sun_path if the socket dir is deep
+// enough — which is what would happen should the byte budget in
+// internal/config ever drift from the real limit. The spawn must fail loudly
+// rather than return a running agent nobody can attach to.
+//
+// The test also proves the teardown reaps the process: Spawn kills and waits
+// for it before returning, so a Kill that did not land would hang here rather
+// than leak an orphan past the end of the run.
+func TestSpawnFailsWhenAttachSocketCannotBind(t *testing.T) {
+	// 120 bytes is past sun_path on every supported platform (104 on darwin,
+	// 108 on linux), so Go refuses the bind before it reaches the kernel.
+	const socketPathLen = 120
+	name := "unbindable"
+	dir := socketDirOfLen(t, socketPathLen-len("/"+name+".sock"))
+
+	reg, err := NewRegistry(dir)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	if err := ValidateAgentName(name); err != nil {
+		t.Fatalf("test bug: %q must be a legal name, got %v", name, err)
+	}
+
+	a, err := reg.Spawn(SpawnRequest{Name: name, Type: TypePolecat, Command: []string{"cat"}})
+	if err == nil {
+		t.Fatal("Spawn succeeded despite an attach socket that cannot bind")
+	}
+	if a != nil {
+		t.Errorf("Spawn returned an agent alongside its error: %+v", a)
+	}
+	if !errors.Is(err, ErrAttachSocketUnusable) {
+		t.Errorf("Spawn error %v does not wrap ErrAttachSocketUnusable", err)
+	}
+	if reg.Get(name) != nil {
+		t.Error("a failed spawn left a registry entry behind")
+	}
+	if got := len(reg.List()); got != 0 {
+		t.Errorf("registry holds %d agents after a failed spawn, want 0", got)
+	}
+}
+
+// TestSpawnSurvivesTransientBindFailure guards the mg-d216 contract that
+// mg-ef80's fatal-bind path must not swallow: a bind failure that may clear on
+// its own keeps the agent alive, and the supervisor rebinds later. Here the
+// socket path is occupied by a non-empty directory, so the pre-bind unlink
+// fails and net.Listen reports EADDRINUSE — recoverable, not fatal.
+func TestSpawnSurvivesTransientBindFailure(t *testing.T) {
+	dir := shortSocketDir(t)
+	reg, err := NewRegistry(dir)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	name := "blocked"
+	blocker := filepath.Join(dir, name+".sock")
+	if err := os.MkdirAll(filepath.Join(blocker, "child"), 0700); err != nil {
+		t.Fatalf("mkdir blocker: %v", err)
+	}
+
+	a, err := reg.Spawn(SpawnRequest{Name: name, Type: TypePolecat, Command: []string{"cat"}})
+	if err != nil {
+		t.Fatalf("Spawn must survive a recoverable bind failure, got: %v", err)
+	}
+	if a == nil || reg.Get(name) == nil {
+		t.Fatal("a recoverable bind failure lost the agent")
+	}
+	if !a.alive() {
+		t.Error("agent process is not running after a recoverable bind failure")
+	}
+}

--- a/internal/agent/nudge_test.go
+++ b/internal/agent/nudge_test.go
@@ -3,15 +3,13 @@ package agent
 import (
 	"context"
 	"errors"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
 
 func TestIsIdle(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -58,8 +56,7 @@ func TestIsIdleNoOutput(t *testing.T) {
 }
 
 func TestNudgeWithModeImmediate(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -88,8 +85,7 @@ func TestNudgeWithModeImmediate(t *testing.T) {
 }
 
 func TestNudgeWithModeWaitIdle(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -136,8 +132,7 @@ func TestNudgeWithModeWaitIdle(t *testing.T) {
 // callers can distinguish "agent busy" from other failures, and the message
 // must name the busy/stuck condition for operator triage.
 func TestNudgeWithModeWaitIdleTimeoutOnBusy(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -256,8 +251,7 @@ func TestWaitForReadySentinelSeenButNeverIdle(t *testing.T) {
 // harness emits the prompt-ready sentinel and goes quiet, a wait-ready nudge
 // delivers.
 func TestNudgeWaitReadyDeliversOnSentinel(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -290,8 +284,7 @@ func TestNudgeWaitReadyDeliversOnSentinel(t *testing.T) {
 // degrading to no-worse-than the old wait-idle behavior rather than dropping
 // the initial nudge.
 func TestNudgeWaitReadyBestEffortAfterTimeout(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -335,8 +328,7 @@ func TestNudgeWaitReadyBestEffortAfterTimeout(t *testing.T) {
 // prompt-ready sentinel (e.g. Codex) gets pure wait-idle delivery from
 // wait-ready mode: the nudge fires on quiescence alone, with no sentinel gate.
 func TestNudgeWaitReadyFallsBackToWaitIdle(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -370,8 +362,7 @@ func TestNudgeWaitReadyFallsBackToWaitIdle(t *testing.T) {
 }
 
 func TestNudgeExitedAgent(t *testing.T) {
-	tmpDir := t.TempDir()
-	reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}

--- a/internal/agent/onexit_abnormal_test.go
+++ b/internal/agent/onexit_abnormal_test.go
@@ -79,8 +79,7 @@ func TestOnExitWorktreeCleanupOnAbnormalExit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sourceRepo, worktreeDir := makeWorktreeRepo(t, tc.name)
 
-			tmpDir := t.TempDir()
-			reg, err := NewRegistry(filepath.Join(tmpDir, "sockets"))
+			reg, err := NewRegistry(shortSocketDir(t))
 			if err != nil {
 				t.Fatalf("NewRegistry: %v", err)
 			}

--- a/internal/agent/park_test.go
+++ b/internal/agent/park_test.go
@@ -37,7 +37,7 @@ func newParkTestRegistry(t *testing.T) *Registry {
 	if err := InitPromptDirs(); err != nil {
 		t.Fatalf("InitPromptDirs: %v", err)
 	}
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -2802,7 +2802,7 @@ func TestStartCrewAgentResolvesExtendsDirective(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reg, err := NewRegistry(filepath.Join(tmpHome, "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}

--- a/internal/agent/provider_resolution_test.go
+++ b/internal/agent/provider_resolution_test.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 	"time"
 )
@@ -46,7 +45,7 @@ func testProvider(id string, idle time.Duration) *Provider {
 // registered (distinct nudge thresholds: claude 1s, codex 9s).
 func newResolutionRegistry(t *testing.T) (reg *Registry, claudeP, codexP *Provider) {
 	t.Helper()
-	reg, err := NewRegistry(filepath.Join(t.TempDir(), "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -185,7 +184,7 @@ func TestResolveProviderUnknownFrontmatterFallsBack(t *testing.T) {
 // registered resolves to a nil provider — the degenerate unit-test path that
 // lets Spawn fall back to pogo's built-in nudge/PTY defaults.
 func TestResolveProviderBareRegistry(t *testing.T) {
-	reg, err := NewRegistry(filepath.Join(t.TempDir(), "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -278,7 +277,7 @@ func TestSpawnRunsResolvedProviderHooks(t *testing.T) {
 // provider (bare registry) falls back to pogo's built-in nudge defaults —
 // preserving pre-mg-b31b behavior for unit-test registries.
 func TestSpawnNilProviderUsesBuiltinDefaults(t *testing.T) {
-	reg, err := NewRegistry(filepath.Join(t.TempDir(), "sockets"))
+	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}

--- a/internal/agent/testsupport_test.go
+++ b/internal/agent/testsupport_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// shortSocketDir returns a directory path short enough that "<dir>/<name>.sock"
+// fits inside AF_UNIX's sun_path limit (104 bytes on darwin, 108 on linux) for
+// any name within config.MaxAgentNameLen.
+//
+// Every Registry a test builds must be rooted here. t.TempDir() on darwin
+// returns paths under /var/folders/... that routinely exceed sun_path on their
+// own, so a registry rooted there cannot bind an attach socket for *any* agent
+// name. That used to pass unnoticed — the failed bind was only a log line — and
+// it meant most of this package's spawn tests silently never exercised attach.
+// Since mg-ef80 a bind that can never succeed fails the spawn, so a test on a
+// long temp path now fails loudly, which is the point.
+//
+// Production never has this problem: pogod takes its socket dir from
+// config.AgentSocketDir, which falls back to a short hashed path under
+// os.TempDir when POGO_HOME is too deep.
+func shortSocketDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "pogo-test-sock-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, "s")
+}

--- a/internal/config/agent_socket_test.go
+++ b/internal/config/agent_socket_test.go
@@ -293,3 +293,117 @@ func TestAgentSocketDirLegacyHomeNormalized(t *testing.T) {
 		t.Errorf("AgentSocketDir() with POGO_HOME=$HOME = %q, want %q", dir, want)
 	}
 }
+
+// tmpDirOfLen returns an existing directory of exactly n bytes, for sitting
+// TMPDIR on a chosen side of the socket-dir budget.
+func tmpDirOfLen(t *testing.T, n int) string {
+	t.Helper()
+	base := shortHome(t)
+	pad := n - len(base) - 1 // -1 for the separator
+	if pad < 1 || pad > 255 {
+		t.Fatalf("cannot build a %d-byte TMPDIR from a %d-byte base in one component", n, len(base))
+	}
+	dir := filepath.Join(base, strings.Repeat("t", pad))
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if len(dir) != n {
+		t.Fatalf("built TMPDIR %q is %d bytes, want %d", dir, len(dir), n)
+	}
+	return dir
+}
+
+// TestAgentSocketDirAlwaysFits is the invariant MaxAgentNameLen's promise rests
+// on: whatever the root and whatever TMPDIR, the directory AgentSocketDir hands
+// back leaves room for the reserved "/<name>.sock" leaf. Without it, a name
+// inside the 24-byte ceiling can still fail to bind — which agent.Spawn treats
+// as fatal — so the ceiling would be a ceiling again and not a promise.
+//
+// The long-TMPDIR rows are the regression: the fallback used to derive from
+// os.TempDir() unchecked, so a TMPDIR past ~52 bytes produced a socket dir in
+// which no legal agent name could bind (mg-ef80, review round 1 blocking 1).
+func TestAgentSocketDirAlwaysFits(t *testing.T) {
+	// bindable is false for "/": its socket dir fits, but only root can create
+	// /agents/sockets, so that row asserts the budget without binding.
+	roots := map[string]struct {
+		mk       func(*testing.T) string
+		bindable bool
+	}{
+		"shallow root": {shortHome, true},
+		"deep root":    {deepHome, true},
+		"root is /":    {func(*testing.T) string { return "/" }, false},
+	}
+	tmpdirs := map[string]func(*testing.T) string{
+		"short TMPDIR": func(t *testing.T) string { return tmpDirOfLen(t, 20) },
+		"TMPDIR at the budget limit": func(t *testing.T) string {
+			return tmpDirOfLen(t, maxUnixSocketPathLen-agentSocketLeafBudget-len("/pogo-agents-abcdef01"))
+		},
+		"TMPDIR one byte past the budget": func(t *testing.T) string {
+			return tmpDirOfLen(t, maxUnixSocketPathLen-agentSocketLeafBudget-len("/pogo-agents-abcdef01")+1)
+		},
+		"pathologically long TMPDIR": func(t *testing.T) string { return tmpDirOfLen(t, 90) },
+	}
+
+	for rootName, root := range roots {
+		for tmpName, mkTmp := range tmpdirs {
+			t.Run(rootName+"/"+tmpName, func(t *testing.T) {
+				t.Setenv("POGO_HOME", root.mk(t))
+				t.Setenv("TMPDIR", mkTmp(t))
+
+				dir, _ := AgentSocketDir()
+				if !agentSocketDirFits(dir) {
+					t.Fatalf("AgentSocketDir() = %q (%d bytes): no room for the %d-byte leaf under the %d-byte sun_path limit",
+						dir, len(dir), agentSocketLeafBudget, maxUnixSocketPathLen)
+				}
+				if !root.bindable {
+					return
+				}
+				// The budget is only meaningful if the longest promised name
+				// actually binds there.
+				sock := filepath.Join(dir, strings.Repeat("a", MaxAgentNameLen)+".sock")
+				if err := bindOK(t, sock); err != nil {
+					t.Fatalf("a %d-byte name must bind under %q, got: %v", MaxAgentNameLen, dir, err)
+				}
+			})
+		}
+	}
+}
+
+// TestAgentSocketDirPrefersTempDirWhenItFits pins that the /tmp last resort is a
+// degradation, not the default: a TMPDIR with room keeps the sockets under it,
+// preserving the per-user $TMPDIR isolation darwin gives us.
+func TestAgentSocketDirPrefersTempDirWhenItFits(t *testing.T) {
+	tmp := tmpDirOfLen(t, 20)
+	t.Setenv("POGO_HOME", deepHome(t))
+	t.Setenv("TMPDIR", tmp)
+
+	dir, inside := AgentSocketDir()
+	if inside {
+		t.Fatalf("a deep root must fall back, got %q inside POGO_HOME", dir)
+	}
+	if filepath.Dir(dir) != tmp {
+		t.Errorf("AgentSocketDir() = %q, want it under the fitting TMPDIR %q", dir, tmp)
+	}
+}
+
+// TestAgentSocketDirFallsBackToTmpWhenTempDirTooLong is the other side: an
+// unusable TMPDIR degrades to /tmp rather than to a directory nothing can bind
+// in. Distinctness per root must survive that degradation.
+func TestAgentSocketDirFallsBackToTmpWhenTempDirTooLong(t *testing.T) {
+	t.Setenv("TMPDIR", tmpDirOfLen(t, 90))
+
+	t.Setenv("POGO_HOME", deepHome(t))
+	first, inside := AgentSocketDir()
+	if inside {
+		t.Fatalf("a deep root must fall back, got %q inside POGO_HOME", first)
+	}
+	if filepath.Dir(first) != "/tmp" {
+		t.Errorf("AgentSocketDir() = %q, want it directly under /tmp", first)
+	}
+
+	t.Setenv("POGO_HOME", deepHome(t))
+	second, _ := AgentSocketDir()
+	if first == second {
+		t.Errorf("two distinct roots share the degraded socket dir %q — the per-root distinctness guarantee is lost", first)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -634,11 +634,15 @@ const maxUnixSocketPathLen = 103
 //
 // The reservation is a fixed constant rather than a function of the agent being
 // bound: every agent under one POGO_HOME must agree on one socket dir, so the
-// dir cannot depend on which agent binds first. That makes this a ceiling, not a
-// promise — a name longer than this under a root deep enough to consume the
-// headroom will fail to bind, and the agent runs with attach unavailable (pogod
-// logs "attach listener failed"). Nothing enforces the ceiling at spawn today;
-// see mg-8532 advisory 2 and its follow-up.
+// dir cannot depend on which agent binds first.
+//
+// agent.ValidateAgentName enforces this at spawn, so it is a promise and not
+// merely a ceiling: a longer name is refused (HTTP 400) under every POGO_HOME,
+// shallow or deep, rather than spawning an agent that runs fine but can never be
+// attached to. Enforcing it unconditionally is the point — a name's fate must
+// not depend on how deep the operator's root happens to be. Should this
+// arithmetic ever drift from the real sun_path limit, agent.Spawn also treats a
+// permanent bind failure as fatal, so the failure is loud either way (mg-ef80).
 const MaxAgentNameLen = 24
 
 // agentSocketLeafBudget reserves room for the "/<agent name>.sock" leaf that

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -640,9 +640,13 @@ const maxUnixSocketPathLen = 103
 // merely a ceiling: a longer name is refused (HTTP 400) under every POGO_HOME,
 // shallow or deep, rather than spawning an agent that runs fine but can never be
 // attached to. Enforcing it unconditionally is the point — a name's fate must
-// not depend on how deep the operator's root happens to be. Should this
-// arithmetic ever drift from the real sun_path limit, agent.Spawn also treats a
-// permanent bind failure as fatal, so the failure is loud either way (mg-ef80).
+// not depend on how deep the operator's root happens to be.
+//
+// The promise holds only because AgentSocketDir never returns a directory with
+// less than agentSocketLeafBudget bytes of headroom, on any root and any TMPDIR;
+// TestAgentSocketDirAlwaysFits pins that. Should this arithmetic ever drift from
+// the real sun_path limit anyway, agent.Spawn treats a permanent bind failure as
+// fatal, so the failure is loud rather than silent either way (mg-ef80).
 const MaxAgentNameLen = 24
 
 // agentSocketLeafBudget reserves room for the "/<agent name>.sock" leaf that
@@ -669,16 +673,31 @@ const agentSocketLeafBudget = len("/") + MaxAgentNameLen + len(".sock")
 // The sun_path limit forces one wrinkle. A sufficiently deep POGO_HOME (a
 // t.TempDir() under /var/folders on darwin, say) leaves no room for the socket
 // leaf, and bind would fail with EINVAL. Such a root falls back to a short
-// directory under os.TempDir() named for a hash of the root — so the per-root
-// distinctness this function exists to guarantee survives the fallback. The hash
-// is taken over the cleaned root so that "/a/b" and "/a/b/" — which the lockfile
-// already treats as one daemon — agree on one socket dir too.
+// directory named for a hash of the root — so the per-root distinctness this
+// function exists to guarantee survives the fallback. The hash is taken over the
+// cleaned root so that "/a/b" and "/a/b/" — which the lockfile already treats as
+// one daemon — agree on one socket dir too.
+//
+// The returned directory always leaves room for the reserved MaxAgentNameLen
+// leaf; every caller, and MaxAgentNameLen's promise to agent.ValidateAgentName,
+// depends on that. The fallback therefore prefers os.TempDir() — per-user on
+// darwin, and where these sockets already live — but only when it fits, because
+// TMPDIR is itself unbounded: a TMPDIR over ~52 bytes leaves a directory in which
+// no legal agent name could bind, which agent.Spawn treats as a fatal error
+// rather than the silent attach loss it used to be. "/tmp" is the last resort;
+// at 4 bytes it fits under any budget these constants could grow to. If it is
+// not writable, NewRegistry's MkdirAll fails and pogod exits loudly at startup,
+// which is the honest outcome (mg-ef80).
 func AgentSocketDir() (dir string, insidePogoHome bool) {
 	if dir := filepath.Join(PogoHome(), "agents", "sockets"); agentSocketDirFits(dir) {
 		return dir, true
 	}
 	sum := sha256.Sum256([]byte(filepath.Clean(PogoHome())))
-	return filepath.Join(os.TempDir(), "pogo-agents-"+hex.EncodeToString(sum[:4])), false
+	leaf := "pogo-agents-" + hex.EncodeToString(sum[:4])
+	if dir := filepath.Join(os.TempDir(), leaf); agentSocketDirFits(dir) {
+		return dir, false
+	}
+	return filepath.Join("/tmp", leaf), false
 }
 
 // agentSocketDirFits reports whether dir leaves room to bind an agent socket


### PR DESCRIPTION
## What

`internal/config.MaxAgentNameLen` (24) is the byte budget `AgentSocketDir()` reserves for the `"/<name>.sock"` leaf when choosing the attach socket directory — but nothing enforced it. Under a `POGO_HOME` deep enough to consume the remaining headroom, a longer agent name pushed the socket path past `sun_path`: the bind failed, pogod logged `attach listener failed`, and `POST /agents/start` **still returned 201** for an agent that could never be attached to.

Implements the ticket's recommended fix, **option (c) — both halves**:

**(a) Reject the name at spawn.** `ValidateAgentName` refuses an empty or over-long name, wired into `Registry.Spawn` (the choke point all three spawn paths funnel through) and into each handler, so a rejected polecat name never gets as far as creating a worktree, agent dir, or expanded prompt. The check is **unconditional**, not conditional on the root's depth: a name that works on a shallow root and silently loses attach on a deep one is worse than one refused everywhere.

**(b) Make an unbindable socket fatal to the spawn.** As the ticket notes, (a) alone still lets a deep root + long name fail if the budget arithmetic ever drifts. So a bind failure that no retry can clear now fails the spawn instead of logging. The listener binds *before* the PTY plumbing goroutines start and before the agent enters the registry, so the teardown is just a kill.

The fatal set is deliberately narrow — `EINVAL`/`ENAMETOOLONG`, the sun_path-overflow class. A **transient** failure (`EMFILE` under fd exhaustion) still keeps the agent alive and lets the mg-d216 supervisor rebind once fds free up; a false positive here would cost an agent that would otherwise have recovered. `TestSpawnSurvivesTransientBindFailure` pins that contract.

Spawn errors now map to **400** (bad name) and **500** (unbindable socket); the legacy catch-all **409** stays for genuine registry conflicts.

## Verification

Driven end-to-end against a sandboxed pogod on the reviewer's exact geometry (58-byte `POGO_HOME` → 73-byte socket dir, so a 24-char name lands on exactly 103 bytes and a 30-char name overruns at 109):

- 30-char name → `400`, message names the limit; no agent dir, no socket, no registry entry. Same on `POST /agents`, `/agents/start`, and `/agents/spawn-polecat`.
- 24-char name at the budget limit → `201`, and its 103-byte socket path is bound and **accepts connections**; no `attach listener failed` in the log.

Each new test was confirmed to **fail without the fix** (checked by neutering the length check and the errno classifier). `./build.sh` green; `go test -race ./internal/agent/` clean.

## Note on the test-file churn

Making an unbindable socket fatal surfaced that **90 of this package's 311 tests had never bound an attach socket.** They root their `Registry` at `t.TempDir()`, which on darwin returns a `/var/folders/...` path already longer than `sun_path` — so the bind failed, the failure was only a log line, and the tests passed while silently never exercising attach. (A handful of tests that *did* care already worked around this with a short `/tmp` dir, with a comment saying why.)

So the second commit promotes that workaround to the package default: `shortSocketDir` moves to `testsupport_test.go` and every test registry roots there. Those 90 tests now genuinely exercise attach binding. **Production was never affected** — pogod takes its socket dir from `config.AgentSocketDir`, which falls back to a short hashed path when `POGO_HOME` is too deep.

## Behavior change (API-visible, as the ticket anticipated)

A crew agent whose **configured** name exceeds 24 bytes will now fail to start, auto-start, or wake, with an explicit error — where it previously started without a working `pogo agent attach`. Recorded in `CHANGELOG.md` under an operator note. The default `~/.pogo` root has room for a 64-byte name, so no default deployment could reach the old failure.

## Out of scope (noted, not fixed)

- `ValidateAgentName` does not reject path separators, so a name like `../x` still escapes `filepath.Join(socketDir, name+".sock")` and `filepath.Join(PromptDir(), name)`. Pre-existing, unrelated to this ticket's recommendation, and worth its own review.
- `Respawn` still logs (rather than fails) on a fatal bind error. Unreachable in practice: the name and socket dir are fixed at registry creation, so a respawn cannot newly overflow a path that bound at spawn.

## Provenance

There is **no originating GitHub issue** for this work item — it came from advisory 2 (non-blocking) of the mg-8532 review by reviewer 473a on #71, which is merged. Nothing to `Resolves`.

Xref: #71, mg-8532, mg-d216.
Work item: mg-ef80