### PR TITLE
Add Cursor as a pogo provider (mg-c146)

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -198,7 +198,7 @@ that get expanded per-spawn:
 | `{{.Branch}}` | Target branch for refinery submit |
 | `{{.WorktreeDir}}` | Polecat's working directory: its isolated worktree, or its `~/.pogo/agents/<name>/` home dir under `--no-worktree` |
 | `{{.NoWorktree}}` | `true` when spawned with `--no-worktree` (in-place, refinery:NO) |
-| `{{.Provider}}` | Resolved harness provider id (`claude`, `codex`, `pi`; defaults to `claude`). Gate harness-specific guidance with `{{if eq .Provider "claude"}}...{{end}}` — the shipped templates use this to drop Claude-Code-isms (CronCreate, rating-modal dismissal) under other harnesses. Drop-in fragments can use it too. |
+| `{{.Provider}}` | Resolved harness provider id (`claude`, `codex`, `pi`, `cursor`; defaults to `claude`). Gate harness-specific guidance with `{{if eq .Provider "claude"}}...{{end}}` — the shipped templates use this to drop Claude-Code-isms (CronCreate, rating-modal dismissal) under other harnesses. Drop-in fragments can use it too. |
 
 ### The `worktree` knob
 

--- a/docs/investigations/README.md
+++ b/docs/investigations/README.md
@@ -12,6 +12,7 @@ item are the anchor.
 | [claude-explore-integration.md](claude-explore-integration.md) | Whether pogo's index needs special config for Claude Code's "Explore" sub-agent | Scoped, deferred (mg-39b6) |
 | [codex-e2e-validation.md](codex-e2e-validation.md) | Phase 3D end-to-end validation of the Codex CLI provider | Passed — validation record (mg-6599) |
 | [codex-nudge-calibration.md](codex-nudge-calibration.md) | Empirical nudge timing for the Codex provider | Calibration record backing `internal/codex/provider.go` (mg-7f76) |
+| [cursor-nudge-calibration.md](cursor-nudge-calibration.md) | Empirical nudge timing + the `.cursor/rules` persona-injection escape hatch for the Cursor provider | Calibration record backing `internal/cursor/provider.go` (mg-c146) |
 | [investigation-mg-06f2.md](investigation-mg-06f2.md) | Root cause: tickets archived "done" before the refinery confirmed the merge | Root-cause trace (mg-06f2) |
 | [launch-readiness-audit-2026-03-21.md](launch-readiness-audit-2026-03-21.md) | v0.2 launch-readiness audit across install, agents, refinery, release | Point-in-time audit, 2026-03-21 — no hard blockers |
 | [nudge-claude-code-workaround.md](nudge-claude-code-workaround.md) | Workarounds for nudging Claude Code through mid-session modals | Investigation; the modal watcher it scopes since shipped (mg-4421, `internal/claude/modal_hook.go`) |

--- a/docs/investigations/cursor-nudge-calibration.md
+++ b/docs/investigations/cursor-nudge-calibration.md
@@ -1,0 +1,330 @@
+# Cursor provider — nudge calibration & injection-collision investigation
+
+**Status:** calibration record for the Cursor provider (mg-c146). Evidence for
+the `cursor.Provider` values in `internal/cursor/provider.go`.
+**Harness measured:** Cursor CLI **2026.07.09-a3815c0** (`agent`, Node bundle,
+macOS), spawned in a PTY at pogo's default 200×50 winsize, authenticated via
+`agent login`.
+**Predecessors:** `docs/investigations/pi-nudge-calibration.md` (template),
+`docs/investigations/codex-nudge-calibration.md` (method).
+
+Cursor is the first pogo provider that is **closed-source SaaS**. That shapes
+both the rig and the deliverable: there is no mock-provider escape (see
+"Why the e2e is live"), so the model-facing assertions here are *behavioural*
+rather than byte-level. Everything below was measured against a live, logged-in
+CLI on 2026-07-10.
+
+## TL;DR
+
+The calibrated `NudgeProfile`:
+
+| Field | Claude | Codex | pi | **Cursor** | Why Cursor differs |
+|---|---|---|---|---|---|
+| `NeedsInitialNudge` | true | true | false | **false** | Initial task arrives via **argv** (`agent [prompt...]`). Not (only) pi's redraw problem — a typed nudge would race the *silent* workspace-trust dialog. |
+| `InitialNudgeTimeout` | 60s | 30s | 30s | **30s** | Unused while `NeedsInitialNudge` is false; retained as the measured value (trust dialog ~0.7s, composer settled ~3.0s). |
+| `SubmitTerminator` | `\r` | `\r` | `\r` | **`\r`** | A carriage return submits the composer. |
+| `SubmitDelay` | 50ms | 50ms | 50ms *(not load-bearing)* | **50ms — load-bearing** | Cursor has paste-burst detection: a combined `body+"\r"` write does **not** submit. Unlike pi. |
+| `IdleThreshold` | 2s | 2s | 2s | **2s** | Settled composer emits 0 bytes; kept uniform. The silent trust dialog is the same trap Codex has. |
+| `PromptReadySentinel` | `? for shortcuts` | *(none)* | `/ commands · ! bash` | **`Plan, search, build anything`** | Cursor's composer placeholder — the measured "input loop ready" marker. |
+
+Plus `Provider.InitialPromptViaArgv = true` (not a `NudgeProfile` field).
+
+Plus the integration decisions that are **not** `NudgeProfile` fields:
+
+- **Persona injection is `InjectContextFile` into `.cursor/rules/pogo-persona.mdc`**,
+  behind `alwaysApply: true` frontmatter. Cursor has **no**
+  `--append-system-prompt` equivalent.
+- **`--force` is the required non-interactive flag**, and **`--trust` must not
+  appear** in the interactive template — it is rejected outside `--print`.
+- **A `PostSpawnHook` is required** to dismiss the workspace-trust dialog. It
+  presses `a`, not Enter.
+
+## Method
+
+A throwaway Go PTY spike (`creack/pty`, 200×50) spawned `agent` with
+`CURSOR_DATA_DIR` pointed at a temp dir, so every run started from a
+never-trusted workspace with no chat history and the developer's real
+`~/.cursor` untouched. Behavioural probes ran through `agent -p --trust
+--output-format text`. The pipeline was then verified through pogo's real
+`agent.Registry` + `cursor.Provider` — see `internal/cursor/e2e_test.go`:
+
+```
+POGO_CURSOR_E2E=1 go test ./internal/cursor/ -run 'TestCursor' -v
+```
+
+## The injection-collision investigation (the ticket's wrinkle 1)
+
+The ticket flagged that Cursor has no `--append-system-prompt`, so the persona
+must go through a context file, which collides with a repo-owned `AGENTS.md`.
+It asked whether `.cursor/rules`-in-worktree is a viable escape hatch. **It is,
+with one non-obvious constraint.** No architect consult was needed.
+
+### There is genuinely no prompt flag
+
+Grepping the CLI bundle for `"--*prompt*"`-shaped flags yields exactly one:
+`--no-prompt`. `agent --help` confirms: no append-system-prompt, no
+system-prompt-file, no `experimental_instructions_file` analog. Cursor also
+offers **no `AGENTS.override.md`-style precedence file** — the trick Codex uses.
+So an additive injection point has to be a *different rules namespace*.
+
+### What Cursor loads as rules
+
+From the bundle's rule-watcher globs:
+
+```
+.cursor/rules/**/*.mdc     AGENTS.md     CLAUDE.md     CLAUDE.local.md     .cursorrules
+```
+
+`AGENTS.md` / `CLAUDE.md` / `CLAUDE.local.md` are all repo-owned by convention.
+`.cursor/rules/**/*.mdc` is a *directory* of independently-named rule files —
+so a uniquely-named `pogo-persona.mdc` collides with nothing a repo plausibly
+ships.
+
+### Frontmatter is load-bearing — and its absence fails silently
+
+This is the finding that would have bitten us. A behavioural probe put a
+directive in the repo's `AGENTS.md` ("include token `ALPHAGREET`") and a
+different one in `.cursor/rules/pogo-persona.mdc` ("include token
+`BRAVOGREET`"), then asked `agent -p` to "Greet me in one short sentence" —
+never mentioning rules or files, so the model had no reason to *read* them with
+a tool. Persona injected = `BRAVOGREET` present. 3 runs per variant:
+
+| `.mdc` frontmatter | Persona injected | Verdict |
+|---|---|---|
+| *(none)* | **0/3** | Silently ignored. A plain-markdown copy — what `writeContextFilePrompt` did before this ticket — delivers **nothing**. |
+| `alwaysApply: false` + `description` | 3/3 | Works *here*, but this is Cursor's "Auto Attached / Agent Requested" type: attachment is decided from the description, by the model. Not a contract. |
+| `alwaysApply: true` | **3/3** | Cursor's documented "Always" rule type. Deterministic by construction. |
+
+So the provider prepends:
+
+```yaml
+---
+description: pogo agent persona
+alwaysApply: true
+---
+```
+
+An earlier version of this probe asked the model to "list every marker in your
+rules/context", and **all three variants passed** — because Cursor has file-read
+tools and simply grepped the worktree. That confound is worth recording: a
+context-file injection test that lets the agent read the file it is testing
+proves nothing. The behavioural directive avoids it.
+
+### The collision does not materialize
+
+With the repo's `AGENTS.md` and the pogo rule both present, a single reply
+carried **both** tokens, and `AGENTS.md` was byte-identical afterwards. The
+persona is additive: Cursor folds the always-applied rule into the system prompt
+*and* still loads the repo's own context file. This is the same posture Claude
+has when reading a repo's `CLAUDE.md`.
+
+`internal/cursor/integration_test.go` pins the on-disk half of that contract
+(ungated, no binary needed); `TestCursorEndToEnd` pins the model-facing half.
+
+### Two shared-code changes it required
+
+`agent.writeContextFilePrompt` previously did a bare `os.WriteFile` of the
+prompt into `<dir>/<ContextFile>`. Cursor needs:
+
+1. **`MkdirAll` of the parent** — `.cursor/rules/` does not exist in a fresh
+   worktree, and `os.WriteFile` returns `ENOENT`, failing the spawn.
+2. **`PromptInjection.ContextFileHeader`** — the frontmatter, prepended to the
+   persona. Empty for Codex, whose `AGENTS.override.md` is plain markdown.
+
+### Residue (out of scope, noted)
+
+The persona lands as an untracked file inside the polecat's worktree, so a
+`git add -A` would commit it. This is **not new**: Codex's `AGENTS.override.md`
+has the same posture today, and neither is gitignored. Worth a follow-up ticket;
+deliberately not fixed here.
+
+## Measurements
+
+### Workspace trust → `PostSpawnHook`, and why `--trust` is banned from the template
+
+Cursor blocks a never-trusted workspace behind a modal, ~0.7s after spawn:
+
+```
+🔒 Workspace Trust Required
+Cursor Agent can execute code and access files in this directory.
+Do you trust the contents of this directory?
+  <path>
+▶ [a] Trust this workspace
+  [q] Quit
+Use arrow keys to navigate, Enter to select, or press the key shown
+```
+
+Every polecat runs in a fresh worktree, so it appears on **every** spawn.
+Measured against the two candidate suppressors:
+
+| Command | Trust dialog? | Note |
+|---|---|---|
+| `agent` | **yes** (4263 bytes, blocks) | baseline |
+| `agent --force` | **yes** (4263 bytes, blocks) | `--force` governs *command approval* ("Run Everything"), not workspace trust |
+| `agent --trust` | **n/a — process exits** (66 bytes) | `Error: --trust can only be used with --print/headless mode` |
+| `agent --force --trust` | **n/a — process exits** (47 bytes) | same |
+
+So the template is `agent --force`, and trust is dismissed from the PTY by
+`cursor.TrustDialogHook` — the shape `claude` and `codex` already use.
+`TestCursorRejectsTrustFlagInTUI` pins the `--trust` rejection (on a PTY: without
+one, Cursor auto-selects print mode and reports a *different* error), so if a
+future Cursor accepts interactive `--trust`, the test fails and the hook can be
+deleted in favour of the flag.
+
+**The hook presses `a`, not `\r`.** Claude's and Codex's hooks send Enter, which
+selects the *highlighted* row. Trust is highlighted today. If Cursor ever
+reorders the menu, Enter would select `[q] Quit` and silently kill every
+polecat. `[a]` is bound to Trust explicitly, so the worst case of a UI change is
+a visibly stalled spawn.
+
+Dismissal is silent-to-visible: after `a`, the TUI shows `⏳ Trusting
+workspace...`, then the composer.
+
+### Startup cadence → `InitialNudgeTimeout`, `PromptReadySentinel`
+
+- Spawn → first PTY output: **~0.4–0.75s**.
+- Spawn → trust dialog rendered: **~0.7s**.
+- Trust dismissed → composer settled: **~2.3s** (composer settled ~3.0s from
+  spawn).
+- An idle composer emits **zero PTY output** (0 bytes over an 8s idle watch, and
+  0 bytes in the e2e's 2s window). Cursor is a differential renderer, like
+  Codex's ratatui and pi's pi-tui, and unlike Claude's continuously-repainting
+  Ink.
+
+The trust dialog is the mg-ce61 / Codex trap in a new costume: **once drawn it is
+completely silent**, so a quiescence-only gate calls the harness "idle" while a
+modal owns the screen. Cursor renders its composer placeholder once the input
+loop is up:
+
+> `→ Plan, search, build anything`
+
+`PromptReadySentinel` is the `Plan, search, build anything` slice. It is absent
+during the loading banner and the trust dialog, which makes it a precise
+"input loop ready" signal. Caveat: after the first turn the placeholder becomes
+`→ Add a follow-up`, so the sentinel matches only *before* any turn. That is
+exactly and only where pogo uses it (`NudgeWaitReady` is the initial-nudge mode;
+mid-session nudges use `NudgeWaitIdle`), so the narrowing is harmless.
+
+`InitialNudgeTimeout` is 30s — an order of magnitude over the worst observed
+startup.
+
+### Initial task → argv, not the typed nudge
+
+Cursor accepts trailing positional prompts (`agent [options] [prompt...]`), so
+the provider sets `InitialPromptViaArgv = true`. Measured: the prompt **survives
+the trust dialog** — Cursor parses it before the TUI starts and runs the turn
+once the workspace is trusted (3/3 spawns replied; the composer placeholder
+still rendered 3/3 before the turn replaced it).
+
+pi adopted argv delivery to escape a redraw storm (gh #26). Cursor adopts it for
+a different reason: a typed initial nudge would have to wait out
+`TrustDialogHook`, racing a modal that reads as idle within ~0.5s of rendering —
+precisely the race that made Codex's nudge type its task into the trust dialog.
+Argv delivery removes the race instead of tuning against it.
+
+### Submit dialect → `SubmitTerminator`, `SubmitDelay`
+
+Measured by writing the same task into a settled composer two ways and watching
+for a turn:
+
+| Write shape | Submits? |
+|---|---|
+| `body`, sleep 50ms, `"\r"` (split) | **yes** — reply in ~4.2s |
+| `body + "\r"` (one chunk) | **no** — no turn; the probe timed out at 95s |
+
+So Cursor **has** paste-burst submit-swallowing, like Claude's Ink and Codex's
+ratatui, and **unlike** pi (where the combined write also submits). `SubmitDelay`
+is therefore load-bearing here, not merely uniform: setting it to 0 would wedge
+every mid-session nudge. `TestProviderNudgeProfile` asserts it is > 0 with that
+reason attached.
+
+### `IdleThreshold`
+
+A settled composer is completely silent, so steady-state would tolerate a
+sub-second threshold. The binding constraint is the silent trust dialog, and
+argv delivery already keeps the *initial* task clear of it. 2s keeps mid-session
+wait-idle nudges uniform with the other three providers.
+
+### `SessionHook`, `PTYSize`
+
+`SessionHook` is nil: with `--force`, tool calls run without approval prompts and
+errors render inline — no mid-session modal to dismiss. `PTYSize` is nil: Cursor
+renders correctly at pogo's default 200×50.
+
+## Model selection & auth — left to Cursor's config
+
+The template pins no `--model`: Cursor's own config
+(`~/.cursor/cli-config.json`, factory default `auto`) decides, and a pogo
+`[agents] command` override can add an explicit `--model`. Auth comes from
+`CURSOR_API_KEY` or Cursor's auth store (seeded by `agent login`). **Billing
+draws on the account's Cursor plan credits** — every polecat turn costs the
+account's quota, unlike a BYOK provider.
+
+## Why the e2e is live, unlike pi's
+
+pi's e2e runs fully offline: pi supports custom OpenAI-compatible providers, so
+the test points it at a local mock and asserts byte-level on the captured
+completion request. **Cursor admits no such rig.** It is closed-source and speaks
+a proprietary connectrpc/protobuf protocol to `api2.cursor.sh`; the only
+base-URL override in the bundle (`CURSOR_API_BASE_URL`) fronts the *auth-poll*
+endpoint, not the chat transport. Mocking the chat protocol would mean
+reimplementing an undocumented, fast-churning protobuf API.
+
+So `internal/cursor/e2e_test.go` follows the **Codex** pattern instead: opt-in,
+real binary, real network, real plan credits. Losing byte-level capture costs
+the "did the persona reach the system prompt?" assertion; it is recovered
+behaviourally — the persona and the repo's `AGENTS.md` each instruct a distinct
+token, and the reply must carry both. That is arguably a *stronger* statement
+than "the bytes were in the request": it proves Cursor honoured both rule
+sources.
+
+The purely on-disk half of the contract needs no binary and is asserted ungated
+in `internal/cursor/integration_test.go`, so it runs in the refinery gates and
+GitHub CI.
+
+**There is deliberately no CI job.** GitHub CI has no Cursor account, and the
+tests spend credits. This matches Codex (also no CI job) and diverges from pi
+(whose `pi-e2e` job is free and offline).
+
+## Environment notes
+
+- The CLI installs via `curl cursor.com/install`; the command is **`agent`**,
+  renamed from `cursor-agent` in 2026 (the installer keeps a `cursor-agent`
+  symlink). `Binary: "agent"` is a generic name — pogo's `ValidateCommandBinary`
+  PATH check cannot distinguish Cursor's `agent` from an unrelated binary of the
+  same name. `TestProviderIdentity` pins the expectation so a further rename
+  fails loudly.
+- `CURSOR_DATA_DIR` relocates Cursor's per-workspace state (trust decisions,
+  chat history) away from `~/.cursor`. Auth survives the relocation, which is
+  what makes the e2e's isolation viable. **`CURSOR_RULES` is not an env var** —
+  it appears in the bundle only as a protobuf enum member
+  (`COMPOSER_CAPABILITY_TYPE_CURSOR_RULES`); do not reach for it.
+- The CLI is closed-source and churns fast (a command rename inside one year).
+  The e2e logs a NOTE when the installed version differs from the calibrated
+  `2026.07.09-a3815c0`, and pins the observable contract — binary name,
+  trust-dialog text, composer placeholder, submit dialect — so a TUI change
+  fails loudly rather than degrading silently.
+
+## Reproducing
+
+```
+POGO_CURSOR_E2E=1 go test ./internal/cursor/ -run 'TestCursor' -v
+```
+
+Needs an authenticated `agent` on PATH and spends Cursor plan credits.
+`TestCursorEndToEnd` drives a real `agent` through pogo's `agent.Registry` +
+`cursor.Provider`, wired the way `cmd/pogod` wires it (per-type provider config,
+claude as global default), and asserts: the spawn resolves cursor via the
+`[agents.polecat] provider = "cursor"` config tier; the initial task is appended
+to the spawn argv; `Spawn` writes the persona rule with `alwaysApply: true`; the
+workspace-trust dialog appears **and** `TrustDialogHook` dismisses it (proven by
+the composer placeholder following); the persona *and* the repo's `AGENTS.md`
+both reach the model (both tokens in the reply); `AGENTS.md` survives
+byte-identical; the composer settles (polled for a quiet window, not a single
+sample — the flake that bit pi, mg-8cc0); a mid-session `Agent.Nudge` triggers a
+second turn; the registry shuts the agent down cleanly.
+`TestCursorHeadless` runs the same provider flags in `--print` form.
+`TestCursorRejectsTrustFlagInTUI` pins the `--trust` rejection that forces the
+hook to exist. The ungated `internal/cursor/integration_test.go` covers the
+config → provider-registry resolution path and the on-disk injection contract in
+every plain `go test ./...`.

--- a/docs/investigations/cursor-nudge-calibration.md
+++ b/docs/investigations/cursor-nudge-calibration.md
@@ -264,15 +264,73 @@ account's quota, unlike a BYOK provider.
 
 pi's e2e runs fully offline: pi supports custom OpenAI-compatible providers, so
 the test points it at a local mock and asserts byte-level on the captured
-completion request. **Cursor admits no such rig.** It is closed-source and speaks
-a proprietary connectrpc/protobuf protocol to `api2.cursor.sh`; the only
-base-URL override in the bundle (`CURSOR_API_BASE_URL`) fronts the *auth-poll*
-endpoint, not the chat transport. Mocking the chat protocol would mean
-reimplementing an undocumented, fast-churning protobuf API.
+completion request. **The `agent` binary pogo drives admits no such rig** — but
+the reason is narrower, and more interesting, than "it's closed-source".
 
-So `internal/cursor/e2e_test.go` follows the **Codex** pattern instead: opt-in,
-real binary, real network, real plan credits. Losing byte-level capture costs
-the "did the persona reach the system prompt?" assertion; it is recovered
+### The obvious argument, and why it is not the whole story
+
+Cursor speaks a proprietary connectrpc/protobuf protocol to `api2.cursor.sh`.
+Reimplementing that to mock it would be absurd. But the bundle *does* contain a
+local-provider mode, and it must be ruled out explicitly rather than waved past:
+
+```
+--local-agent-base-url <url>   Provider base URL for agent-cli-local
+                               (OpenAI-compatible or Anthropic Messages;
+                               for example http://127.0.0.1:11434/v1; can also
+                               use CURSOR_LOCAL_AGENT_BASE_URL or
+                               ANTHROPIC_BASE_URL env vars)
+--local-agent-api-key <key>
+```
+
+plus `CURSOR_ENABLE_AUTHLESS`, `CURSOR_BEDROCK_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`.
+That is *exactly* the shape pi's offline rig needs — an OpenAI-compatible base
+URL. The flag is `.hideHelp()`-hidden, so `agent --help` never shows it.
+
+### It is gated to a different distribution — measured, not assumed
+
+The bundle gates every one of those on the CLI's own identity:
+
+```js
+function s(e = "agent-cli") {
+  return "agent-cli-local" === e
+    ? { rootDirName: "cursor-agent-local", executableName: "cursor-agent-local", … }
+    : …
+}
+```
+
+`agent-cli-local` is a **separate executable** (`cursor-agent-local`) shipped on
+its own download channel (`agent-cli-local-prod`). The `agent` binary pogo drives
+is `agent-cli`, and it does not enable any of it:
+
+| Route tried on `agent` (agent-cli) | Result |
+|---|---|
+| `--local-agent-base-url http://127.0.0.1:PORT/v1` | `error: unknown option '--local-agent-base-url'` |
+| `CURSOR_LOCAL_AGENT_BASE_URL` + `CURSOR_LOCAL_AGENT_API_KEY` + `CURSOR_ENABLE_AUTHLESS=1` | ignored — mock received **0** requests |
+| `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` | ignored — mock received **0** requests |
+| `CURSOR_API_BASE_URL` | ignored for chat — mock received **0** requests (it fronts `${base}/auth/poll` only) |
+
+Method note, because the first version of this probe lied. Asking Cursor to
+"reply with exactly `PONGMOCK`" and then seeing `PONGMOCK` proves nothing: the
+*real* backend will happily obey that instruction, and the reply is
+indistinguishable from a mocked one. The probe was redone so the mock's canned
+answer (`PONGMOCK`) **differs** from the token the prompt requests (`ALPHA`).
+Every run returned `ALPHA` with zero mock hits: the real backend answered each
+time. (A `--help`-based flag check lied too — `commander` prints help and exits 0
+before validating options, so `agent --local-agent-base-url X --help` "succeeds"
+on a flag the CLI does not have.)
+
+**Conclusion, stated at the strength the evidence supports:** an offline e2e is
+not achievable for the `agent` binary this provider targets. It is *not* a
+statement about Cursor-the-company forever. If pogo ever targets
+`cursor-agent-local`, a pi-style offline mock rig becomes available — that would
+be a different binary, a different provider `Binary` value, and a different
+ticket.
+
+### What the live test buys instead
+
+So `internal/cursor/e2e_test.go` follows the **Codex** pattern: opt-in, real
+binary, real network, real plan credits. Losing byte-level capture costs the
+"did the persona reach the system prompt?" assertion; it is recovered
 behaviourally — the persona and the repo's `AGENTS.md` each instruct a distinct
 token, and the reply must carry both. That is arguably a *stronger* statement
 than "the bytes were in the request": it proves Cursor honoured both rule

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -246,7 +246,7 @@ func (a *Agent) alive() bool {
 func (a *Agent) Alive() bool { return a.alive() }
 
 // ProviderID returns the id of the harness provider resolved for this agent
-// at spawn time ("claude", "codex", "pi"), or "" for a bare-registry spawn.
+// at spawn time ("claude", "codex", "pi", "cursor"), or "" for a bare-registry spawn.
 // The field is immutable after construction, so no lock is needed. Exposed so
 // integration tests can assert which provider the resolution chain actually
 // picked (per-type config vs global default vs built-in fallback).
@@ -316,7 +316,7 @@ type Registry struct {
 	onExit func(a *Agent, err error)
 
 	// providers is the pool of known harness descriptors, keyed by id
-	// ("claude", "codex", "pi"). pogod registers every provider at startup
+	// ("claude", "codex", "pi", "cursor"). pogod registers every provider at startup
 	// (RegisterProvider); resolveProvider then picks one per spawn from the
 	// precedence chain. Before mg-b31b the registry held a single global
 	// provider plus a global hook pair — provider selection is now per-spawn,

--- a/internal/agent/command.go
+++ b/internal/agent/command.go
@@ -67,17 +67,21 @@ func ValidatePolecatCommand(tmpl string, p *Provider) {
 
 // writeContextFilePrompt delivers the persona prompt to a provider that uses
 // the InjectContextFile strategy — it copies the expanded prompt file into the
-// agent's working directory under the provider's configured ContextFile name.
+// agent's working directory under the provider's configured ContextFile name,
+// prefixed by the provider's ContextFileHeader.
 //
 // Codex is the motivating case: it has no --append-system-prompt-file-style
 // flag, but reads AGENTS.override.md from its working directory and prefers it
 // over a checked-in AGENTS.md. Writing the persona there injects it additively
-// without clobbering the repo's own AGENTS.md.
+// without clobbering the repo's own AGENTS.md. Cursor is the same shape one
+// level down: its persona lands in .cursor/rules/pogo-persona.mdc — a nested
+// path, hence the MkdirAll — behind an `alwaysApply: true` frontmatter header,
+// which is the only rule form Cursor reliably folds into the system prompt.
 //
-// It is a no-op for providers that inject via flag (Claude) or env, for a nil
-// provider, and when either the prompt file or the working directory is unset
-// (the prompt is still reachable via the POGO_AGENT_PROMPT env fallback that
-// Spawn always sets). Returns an error only when the copy itself fails.
+// It is a no-op for providers that inject via flag (Claude, pi) or env, for a
+// nil provider, and when either the prompt file or the working directory is
+// unset (the prompt is still reachable via the POGO_AGENT_PROMPT env fallback
+// that Spawn always sets). Returns an error only when the copy itself fails.
 func writeContextFilePrompt(p *Provider, promptFile, dir string) error {
 	if p == nil || p.PromptInjection.Kind != InjectContextFile {
 		return nil
@@ -89,7 +93,15 @@ func writeContextFilePrompt(p *Provider, promptFile, dir string) error {
 	if err != nil {
 		return fmt.Errorf("read prompt file for context-file injection: %w", err)
 	}
+	if header := p.PromptInjection.ContextFileHeader; header != "" {
+		content = append([]byte(header), content...)
+	}
 	dest := filepath.Join(dir, p.PromptInjection.ContextFile)
+	// ContextFile may be nested (Cursor: .cursor/rules/pogo-persona.mdc). The
+	// worktree carries no such directory, so create it before writing.
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		return fmt.Errorf("create context file directory for %q: %w", dest, err)
+	}
 	if err := os.WriteFile(dest, content, 0644); err != nil {
 		return fmt.Errorf("write context file %q: %w", dest, err)
 	}

--- a/internal/agent/command_test.go
+++ b/internal/agent/command_test.go
@@ -142,6 +142,97 @@ func TestWriteContextFilePrompt(t *testing.T) {
 		}
 	})
 
+	// Codex's context file is plain markdown: no header configured, nothing
+	// prepended. Guards against a header leaking into providers that don't want
+	// one.
+	t.Run("no header leaves the persona byte-identical", func(t *testing.T) {
+		dir := t.TempDir()
+		p := &Provider{
+			ID: "codex",
+			PromptInjection: PromptInjection{
+				Kind:        InjectContextFile,
+				ContextFile: "AGENTS.override.md",
+			},
+		}
+		if err := writeContextFilePrompt(p, newPromptFile(t), dir); err != nil {
+			t.Fatalf("writeContextFilePrompt: %v", err)
+		}
+		got, _ := os.ReadFile(filepath.Join(dir, "AGENTS.override.md"))
+		if string(got) != persona {
+			t.Errorf("context file = %q, want the persona verbatim %q", got, persona)
+		}
+	})
+
+	// Cursor's shape: a nested path whose parents don't exist yet, plus a
+	// frontmatter header without which Cursor silently ignores the rule.
+	t.Run("nested context file with a header", func(t *testing.T) {
+		dir := t.TempDir()
+		const header = "---\nalwaysApply: true\n---\n\n"
+		p := &Provider{
+			ID: "cursor",
+			PromptInjection: PromptInjection{
+				Kind:              InjectContextFile,
+				ContextFile:       ".cursor/rules/pogo-persona.mdc",
+				ContextFileHeader: header,
+			},
+		}
+		if err := writeContextFilePrompt(p, newPromptFile(t), dir); err != nil {
+			t.Fatalf("writeContextFilePrompt: %v", err)
+		}
+		got, err := os.ReadFile(filepath.Join(dir, ".cursor", "rules", "pogo-persona.mdc"))
+		if err != nil {
+			t.Fatalf("nested context file not written: %v", err)
+		}
+		if want := header + persona; string(got) != want {
+			t.Errorf("context file = %q, want %q", got, want)
+		}
+	})
+
+	// Respawn re-delivers the persona into a worktree where the nested path
+	// already exists. MkdirAll must tolerate it, and the header must not double.
+	t.Run("re-delivery over an existing nested file", func(t *testing.T) {
+		dir := t.TempDir()
+		const header = "---\nalwaysApply: true\n---\n\n"
+		p := &Provider{
+			ID: "cursor",
+			PromptInjection: PromptInjection{
+				Kind:              InjectContextFile,
+				ContextFile:       ".cursor/rules/pogo-persona.mdc",
+				ContextFileHeader: header,
+			},
+		}
+		promptFile := newPromptFile(t)
+		for i := 0; i < 2; i++ {
+			if err := writeContextFilePrompt(p, promptFile, dir); err != nil {
+				t.Fatalf("writeContextFilePrompt call %d: %v", i, err)
+			}
+		}
+		got, _ := os.ReadFile(filepath.Join(dir, ".cursor", "rules", "pogo-persona.mdc"))
+		if want := header + persona; string(got) != want {
+			t.Errorf("re-delivery = %q, want %q (header must not double)", got, want)
+		}
+	})
+
+	// A context file whose parent cannot be created must surface an error, not
+	// silently drop the persona.
+	t.Run("uncreatable nested parent returns an error", func(t *testing.T) {
+		dir := t.TempDir()
+		// A regular file where the persona's parent directory needs to be.
+		if err := os.WriteFile(filepath.Join(dir, ".cursor"), []byte("not a dir"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		p := &Provider{
+			ID: "cursor",
+			PromptInjection: PromptInjection{
+				Kind:        InjectContextFile,
+				ContextFile: ".cursor/rules/pogo-persona.mdc",
+			},
+		}
+		if err := writeContextFilePrompt(p, newPromptFile(t), dir); err == nil {
+			t.Error("expected an error when the context file's parent cannot be created")
+		}
+	})
+
 	t.Run("append-flag provider is a no-op", func(t *testing.T) {
 		dir := t.TempDir()
 		p := &Provider{

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -187,7 +187,8 @@ type TemplateVars struct {
 	// expansion time.
 	WorkerTitle string
 
-	// Provider is the resolved harness provider id ("claude", "codex", "pi")
+	// Provider is the resolved harness provider id ("claude", "codex", "pi",
+	// "cursor")
 	// the polecat will run under. Templates gate harness-specific guidance
 	// behind `{{if eq .Provider "claude"}}` so Claude-Code-isms (CronCreate,
 	// rating-modal dismissal) don't leak into prompts for other harnesses

--- a/internal/agent/prompt_test.go
+++ b/internal/agent/prompt_test.go
@@ -202,7 +202,7 @@ func TestShippedTemplatesProviderGating(t *testing.T) {
 	}
 
 	for _, name := range []string{"prompts/templates/polecat.md", "prompts/templates/polecat-qa.md", "prompts/templates/polecat-build-pr.md", "prompts/templates/polecat-triage.md", "prompts/templates/polecat-review.md"} {
-		for _, provider := range []string{"pi", "codex"} {
+		for _, provider := range []string{"pi", "codex", "cursor"} {
 			out := expand(t, name, provider)
 			for _, ism := range claudeIsms {
 				if strings.Contains(out, ism) {

--- a/internal/agent/provider.go
+++ b/internal/agent/provider.go
@@ -25,7 +25,7 @@ const DefaultProviderID = "claude"
 // package) because its hooks take *agent.Agent: a separate package would create
 // the import cycle agent → provider → agent.
 type Provider struct {
-	// ID is the config-key identity ("claude", "codex", "pi").
+	// ID is the config-key identity ("claude", "codex", "pi", "cursor").
 	ID string
 
 	// Binary is the executable name — used by `pogo doctor` and PATH checks.
@@ -96,6 +96,18 @@ type PromptInjection struct {
 	Kind        PromptInjectionKind
 	Flag        string // InjectAppendFlag: e.g. "--append-system-prompt-file"
 	ContextFile string // InjectContextFile: e.g. "AGENTS.override.md"
+
+	// ContextFileHeader is prepended verbatim to the persona when the context
+	// file is written. It exists for harnesses whose context files are only
+	// honored when they carry a machine-readable preamble: Cursor ignores a
+	// .cursor/rules/*.mdc that has no YAML frontmatter, and only a rule
+	// declaring `alwaysApply: true` is guaranteed to reach the system prompt
+	// (measured — see docs/investigations/cursor-nudge-calibration.md). Empty
+	// for Codex, whose AGENTS.override.md is plain markdown.
+	//
+	// ContextFile may name a nested path ("dir/file.md"); the parent
+	// directories are created under the agent's working directory.
+	ContextFileHeader string
 }
 
 // NudgeProfile is a provider's PTY-input dialect: the timings and terminator

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -238,7 +238,7 @@ type HeartbeatConfig struct {
 
 // AgentsConfig holds agent command configuration.
 type AgentsConfig struct {
-	// Provider selects the agent harness ("claude", "codex", "pi"). Resolved
+	// Provider selects the agent harness ("claude", "codex", "pi", "cursor"). Resolved
 	// by cmd/pogod to an agent.Provider. Empty is treated as DefaultProvider;
 	// Load() fills it in.
 	Provider string
@@ -284,7 +284,7 @@ type AgentTypeConfig struct {
 	// Command overrides the command template for this agent type. Empty means
 	// inherit the global [agents] command (or the provider default).
 	Command string
-	// Provider overrides the harness provider ("claude", "codex", "pi") for
+	// Provider overrides the harness provider ("claude", "codex", "pi", "cursor") for
 	// this agent type. Empty means inherit the global [agents] provider. This
 	// is what lets a mixed fleet run — e.g. [agents.polecat] provider = "pi"
 	// while crew agents stay on Claude. See mg-b31b.

--- a/internal/cursor/e2e_test.go
+++ b/internal/cursor/e2e_test.go
@@ -1,0 +1,496 @@
+package cursor_test
+
+// End-to-end verification for the Cursor provider (mg-c146).
+// TestCursorEndToEnd drives a real `agent` process through pogo's actual
+// agent.Registry and the resolved cursor.Provider — the exact pipeline a
+// `provider = "cursor"` polecat takes:
+//
+//	[agents.polecat] provider = "cursor"   (config tier of resolveProvider)
+//	  -> ExpandCommand(provider.CommandTemplate, ...)
+//	  -> Registry.Spawn  (writes .cursor/rules/pogo-persona.mdc)
+//	  -> PostSpawnHook   (dismisses the workspace-trust dialog)
+//	  -> initial task appended to argv (InitialPromptViaArgv)
+//	  -> mid-session nudge (Agent.Nudge into the settled composer)
+//
+// The registry is wired exactly as cmd/pogod wires it (all providers
+// registered, per-type config, claude as the global default), so the spawn
+// resolving cursor proves the `[agents.polecat] provider = "cursor"` config
+// tier — not just a hardcoded default.
+//
+// # Why this test is live, unlike internal/pi/e2e_test.go
+//
+// pi's e2e runs fully offline: pi supports custom OpenAI-compatible providers,
+// so the test points it at a local mock server and asserts byte-level on the
+// captured completion request. Cursor admits no such rig. It is closed-source
+// and speaks a proprietary connectrpc/protobuf protocol to api2.cursor.sh; the
+// only base-URL override in the bundle (CURSOR_API_BASE_URL) fronts the
+// auth-poll endpoint, not the chat transport. So this test follows the *Codex*
+// pattern instead: opt-in, real binary, real network, real Cursor plan credits.
+//
+// Losing byte-level capture costs the "did the persona reach the system
+// prompt?" assertion. It is recovered BEHAVIOURALLY: the injected persona and
+// the repo's own AGENTS.md each instruct the model to emit a distinct token,
+// and the reply must carry both. That is a stronger statement than "the bytes
+// were in the request" — it proves Cursor actually honoured both rule sources —
+// and it is exactly the probe that settled the injection-collision question in
+// docs/investigations/cursor-nudge-calibration.md.
+//
+// The purely on-disk half of the collision contract (persona lands in
+// .cursor/rules/pogo-persona.mdc with `alwaysApply: true`; the repo's AGENTS.md
+// survives byte-identical) needs no binary at all and is asserted ungated in
+// integration_test.go, so it runs in the refinery gates and CI.
+//
+// The tests are opt-in only because they need an authenticated `agent` binary
+// (`agent login`, or CURSOR_API_KEY) and consume Cursor plan credits:
+//
+//	POGO_CURSOR_E2E=1 go test ./internal/cursor/ -run 'TestCursor' -v
+//
+// There is deliberately no GitHub CI job for them (as with Codex, and unlike
+// pi's offline `pi-e2e` job): CI has no Cursor account. CURSOR_DATA_DIR points
+// Cursor's per-workspace state at a temp dir so the developer's real ~/.cursor
+// trust decisions and chat history are untouched — and so the workspace-trust
+// dialog reliably appears, which is what exercises TrustDialogHook.
+//
+// Calibrated against Cursor CLI 2026.07.09-a3815c0. The CLI is closed-source
+// and churns fast (the command was renamed cursor-agent -> agent in 2026), so
+// the assertions below pin the observable contract — binary name, trust-dialog
+// text, composer placeholder, submit dialect — and fail loudly rather than
+// silently degrading when Cursor changes its TUI.
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+	"github.com/drellem2/pogo/internal/agent"
+	"github.com/drellem2/pogo/internal/cursor"
+	"github.com/drellem2/pogo/internal/providers"
+)
+
+// calibratedVersion is the Cursor CLI this provider's NudgeProfile was measured
+// against. A mismatch is logged, not failed: the point is a breadcrumb when a
+// future CLI changes the TUI out from under the calibration.
+const calibratedVersion = "2026.07.09-a3815c0"
+
+// Tokens the model is instructed to emit. personaToken proves the pogo persona
+// (delivered via .cursor/rules/pogo-persona.mdc) reached the model; repoToken
+// proves the repo's own AGENTS.md still reached it alongside — the injection
+// must be additive, not a substitution.
+const (
+	personaToken = "POGOPERSONAOK"
+	repoToken    = "REPOAGENTSOK"
+)
+
+// polecatCursorConfig mirrors a config.toml with `[agents] provider = "claude"`
+// and `[agents.polecat] provider = "cursor"` — the mixed-fleet shape the
+// per-type provider tier exists for (it satisfies agent.AgentCommandConfig the
+// same way config.AgentsConfig does).
+type polecatCursorConfig struct{}
+
+func (polecatCursorConfig) AgentCommand(string) string { return "" }
+func (polecatCursorConfig) AgentProvider(agentType string) string {
+	if agentType == string(agent.TypePolecat) {
+		return "cursor"
+	}
+	return "claude"
+}
+
+// requireCursor skips unless the e2e gate is set and an `agent` binary is on
+// PATH.
+func requireCursor(t *testing.T) {
+	t.Helper()
+	if os.Getenv("POGO_CURSOR_E2E") != "1" {
+		t.Skip("set POGO_CURSOR_E2E=1 to run the live Cursor end-to-end test")
+	}
+	if _, err := exec.LookPath(cursor.Provider.Binary); err != nil {
+		t.Skipf("%s binary not on PATH", cursor.Provider.Binary)
+	}
+	out, err := exec.Command(cursor.Provider.Binary, "--version").Output()
+	if err != nil {
+		t.Fatalf("%s --version failed — is the CLI healthy? %v", cursor.Provider.Binary, err)
+	}
+	got := strings.TrimSpace(string(out))
+	if got != calibratedVersion {
+		t.Logf("NOTE: Cursor CLI is %q; the provider was calibrated against %q. "+
+			"If this test fails on the TUI assertions (trust dialog, composer "+
+			"placeholder, submit dialect), re-run the calibration in "+
+			"docs/investigations/cursor-nudge-calibration.md.", got, calibratedVersion)
+	}
+}
+
+// seedWorktree creates a worktree carrying its own AGENTS.md (the collision
+// case) and a prompt file holding the pogo persona. Both instruct the model to
+// emit a distinct token in every reply.
+func seedWorktree(t *testing.T, base string) (workDir, promptFile, agentsMD string, repoAgentsMD []byte) {
+	t.Helper()
+	workDir = filepath.Join(base, "worktree")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+
+	repoAgentsMD = []byte("# repo context\n\nAlways include the token " + repoToken +
+		" somewhere in every reply you write.\n")
+	agentsMD = filepath.Join(workDir, "AGENTS.md")
+	if err := os.WriteFile(agentsMD, repoAgentsMD, 0644); err != nil {
+		t.Fatalf("write repo AGENTS.md: %v", err)
+	}
+
+	persona := "# pogo polecat persona\n\nYou are a pogo polecat agent.\n" +
+		"Always include the token " + personaToken + " somewhere in every reply you write.\n"
+	promptFile = filepath.Join(base, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte(persona), 0644); err != nil {
+		t.Fatalf("write prompt file: %v", err)
+	}
+	return workDir, promptFile, agentsMD, repoAgentsMD
+}
+
+func TestCursorEndToEnd(t *testing.T) {
+	requireCursor(t)
+
+	base := t.TempDir()
+	workDir, promptFile, agentsMDPath, repoAgentsMD := seedWorktree(t, base)
+	dataDir := filepath.Join(base, "cursor-state")
+
+	provider, ok := providers.Resolve("cursor")
+	if !ok || provider.ID != "cursor" {
+		t.Fatalf("providers.Resolve(\"cursor\") = (%v, %v), want the cursor provider", provider, ok)
+	}
+
+	// Wire the registry exactly as cmd/pogod does at startup: every known
+	// provider registered, the per-type/global provider config installed, and
+	// claude as the global default. cursor being resolved for the polecat spawn
+	// below therefore proves the `[agents.polecat] provider = "cursor"` config
+	// tier, not a registry-global default.
+	reg, err := agent.NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	for _, p := range providers.All() {
+		reg.RegisterProvider(p)
+	}
+	reg.SetCommandConfig(polecatCursorConfig{})
+	reg.SetDefaultProvider("claude")
+	defer reg.StopAll(3 * time.Second)
+
+	cmd, err := agent.ExpandCommand(provider.CommandTemplate, agent.CommandTemplateVars{
+		PromptFile: promptFile,
+		AgentName:  "e2e",
+		AgentType:  string(agent.TypePolecat),
+		WorkDir:    workDir,
+	})
+	if err != nil {
+		t.Fatalf("ExpandCommand: %v", err)
+	}
+	t.Logf("expanded command: %v", cmd)
+
+	const task = "Greet me in one short sentence."
+	if _, err := reg.Spawn(agent.SpawnRequest{
+		Name:         "e2e",
+		Type:         agent.TypePolecat,
+		Command:      cmd,
+		PromptFile:   promptFile,
+		Dir:          workDir,
+		Env:          []string{"CURSOR_DATA_DIR=" + dataDir},
+		InitialNudge: task,
+	}); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	a := reg.Get("e2e")
+	if a == nil {
+		t.Fatal("agent not in registry after spawn")
+	}
+
+	// Acceptance (provider registry): the spawn resolved cursor through the
+	// per-type config tier — not claude, the registry's global default.
+	if got := a.ProviderID(); got != "cursor" {
+		t.Fatalf("resolved provider = %q, want cursor via the [agents.polecat] config tier", got)
+	}
+
+	// Acceptance (argv delivery): Spawn appended the task to the argv, so task
+	// delivery never depends on a PTY idle window that the silent trust dialog
+	// would otherwise poison.
+	if got := a.Command[len(a.Command)-1]; got != task {
+		t.Fatalf("last command element = %q, want the argv-delivered task %q", got, task)
+	}
+
+	// Acceptance (persona injection, on disk): Spawn wrote the rule file, with
+	// frontmatter, next to — not over — the repo's own AGENTS.md.
+	rule, err := os.ReadFile(filepath.Join(workDir, ".cursor", "rules", "pogo-persona.mdc"))
+	if err != nil {
+		t.Fatalf("persona rule file not written by Spawn: %v", err)
+	}
+	if !strings.Contains(string(rule), "alwaysApply: true") {
+		t.Errorf("persona rule file lacks `alwaysApply: true`:\n%s", rule)
+	}
+
+	// Acceptance (trust dialog): Cursor blocked on workspace trust, and the
+	// provider's PostSpawnHook dismissed it. If the dialog never appeared,
+	// Cursor changed its trust behaviour and the hook is now dead code; if it
+	// appeared but the composer never followed, the hook failed to dismiss it.
+	if !waitFor(t, a, 20*time.Second, "Workspace Trust Required") {
+		t.Error("Cursor did not show the workspace-trust dialog — TrustDialogHook " +
+			"may now be dead code; re-check the trust behaviour before removing it")
+	}
+
+	// Acceptance (calibrated PromptReadySentinel): the composer placeholder
+	// renders once the input loop is up, which also proves the trust dialog was
+	// dismissed. Argv delivery means no initial nudge waits on this marker, but
+	// the profile retains it — this catches it going stale.
+	if !waitFor(t, a, 40*time.Second, provider.Nudge.PromptReadySentinel) {
+		t.Fatalf("PromptReadySentinel %q never appeared — the trust dialog was not "+
+			"dismissed, or Cursor changed its composer placeholder.\noutput tail:\n%s",
+			provider.Nudge.PromptReadySentinel, outputTail(a, 2000))
+	}
+
+	// Acceptance (persona reached the model, behavioural): the argv-delivered
+	// task starts a turn, and the reply carries BOTH tokens — the persona's,
+	// from .cursor/rules/pogo-persona.mdc, and the repo's, from its own
+	// AGENTS.md. This is the injection-collision contract: additive, not
+	// substitutive. Cursor's protocol is closed, so this reply-level assertion
+	// stands in for pi's byte-level request capture.
+	if !waitFor(t, a, 90*time.Second, personaToken) {
+		t.Errorf("persona token %q never appeared in Cursor's reply — the persona "+
+			"in .cursor/rules/pogo-persona.mdc did not reach the model.\noutput tail:\n%s",
+			personaToken, outputTail(a, 2000))
+	}
+	if !waitFor(t, a, 30*time.Second, repoToken) {
+		t.Errorf("repo token %q never appeared in Cursor's reply — persona injection "+
+			"shadowed the repo's own AGENTS.md.\noutput tail:\n%s",
+			repoToken, outputTail(a, 2000))
+	}
+
+	// Acceptance (collision regression, on disk): the repo's AGENTS.md survived
+	// the whole run byte-identical.
+	if got, rerr := os.ReadFile(agentsMDPath); rerr != nil {
+		t.Errorf("repo AGENTS.md unreadable after spawn: %v", rerr)
+	} else if !bytes.Equal(got, repoAgentsMD) {
+		t.Errorf("repo AGENTS.md was clobbered by the spawn; contents now:\n%s", got)
+	}
+
+	// Acceptance (NudgeProfile calibration): a settled Cursor composer emits
+	// zero PTY output. Polled for a quiet WINDOW rather than sampled once — the
+	// same de-flake pi needed (mg-8cc0), since a post-turn repaint can land
+	// between two samples.
+	assertComposerSettles(t, a)
+
+	// Acceptance (nudge dialect, mid-session): Agent.Nudge into the settled
+	// composer — the calibrated body + "\r" split-write — triggers a second
+	// turn. This is the path every later `pogo nudge` / coordinator message to a
+	// running cursor polecat takes. A combined body+CR write would be swallowed
+	// by Cursor's paste-burst detection, so this also guards SubmitDelay > 0.
+	const followUp = "Reply with the word SECONDTURNOK."
+	before := len(a.RecentOutput(1 << 20))
+	if err := a.Nudge(followUp); err != nil {
+		t.Fatalf("mid-session Nudge: %v", err)
+	}
+	if !waitFor(t, a, 90*time.Second, "SECONDTURNOK") {
+		t.Fatalf("mid-session nudge never produced a reply — submit terminator or "+
+			"split-write delay regressed (buffer grew %d bytes).\noutput tail:\n%s",
+			len(a.RecentOutput(1<<20))-before, outputTail(a, 2000))
+	}
+
+	// Acceptance: the registry shuts the agent down cleanly.
+	stopped := make(chan struct{})
+	go func() {
+		reg.StopAll(10 * time.Second)
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+		t.Log("registry stopped the cursor agent cleanly")
+	case <-time.After(15 * time.Second):
+		t.Error("registry did not stop the cursor agent within 15s — unclean shutdown")
+	}
+}
+
+// TestCursorHeadless verifies the provider's spawn flags compose with Cursor's
+// non-interactive mode: the expanded CommandTemplate plus `--trust -p
+// --output-format text` and a positional task executes one turn and exits — no
+// PTY, no registry, no nudge, no trust dialog. It pins two things the TUI test
+// cannot isolate: that --force is accepted outside the TUI, and that --trust is
+// the print-mode-only trust bypass (which is precisely why the interactive
+// template must not carry it — see TestProviderCommandOmitsTrustFlag).
+//
+// The persona rule file is written by hand here, exactly as
+// writeContextFilePrompt would, because there is no registry in this path.
+func TestCursorHeadless(t *testing.T) {
+	requireCursor(t)
+
+	base := t.TempDir()
+	workDir, promptFile, _, _ := seedWorktree(t, base)
+	dataDir := filepath.Join(base, "cursor-state")
+
+	persona, err := os.ReadFile(promptFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ruleDir := filepath.Join(workDir, ".cursor", "rules")
+	if err := os.MkdirAll(ruleDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rule := append([]byte(nil), cursor.Provider.PromptInjection.ContextFileHeader...)
+	rule = append(rule, persona...)
+	if err := os.WriteFile(filepath.Join(ruleDir, "pogo-persona.mdc"), rule, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	argv, err := agent.ExpandCommand(cursor.Provider.CommandTemplate, agent.CommandTemplateVars{
+		PromptFile: promptFile,
+		AgentName:  "headless",
+		AgentType:  string(agent.TypePolecat),
+		WorkDir:    workDir,
+	})
+	if err != nil {
+		t.Fatalf("ExpandCommand: %v", err)
+	}
+	const task = "Greet me in one short sentence."
+	// Test-only flags on top of the provider's real template. --trust is
+	// accepted here and only here: it is rejected outside --print/headless mode.
+	argv = append(argv, "--trust", "-p", "--output-format", "text", task)
+	t.Logf("headless command: %v", argv)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(), "CURSOR_DATA_DIR="+dataDir)
+	raw, err := cmd.CombinedOutput()
+	out := string(agent.StripANSI(raw))
+	if err != nil {
+		t.Fatalf("headless cursor run failed: %v\noutput:\n%s", err, tail(out, 2000))
+	}
+
+	// Both rule sources reached the model: the pogo persona (from
+	// .cursor/rules/pogo-persona.mdc) and the repo's own AGENTS.md.
+	if !strings.Contains(out, personaToken) {
+		t.Errorf("persona token %q missing from headless reply — the .cursor/rules "+
+			"persona did not reach the model.\noutput:\n%s", personaToken, tail(out, 2000))
+	}
+	if !strings.Contains(out, repoToken) {
+		t.Errorf("repo token %q missing from headless reply — persona injection "+
+			"shadowed the repo's AGENTS.md.\noutput:\n%s", repoToken, tail(out, 2000))
+	}
+}
+
+// TestCursorRejectsTrustFlagInTUI pins the measured constraint that shapes the
+// command template: --trust is print-mode-only, and Cursor exits before
+// rendering the TUI when it is passed interactively. If a future Cursor starts
+// accepting it, this test fails and the provider can drop TrustDialogHook in
+// favour of the flag — a strictly simpler design. It makes no model call:
+// Cursor rejects the flag during argument parsing.
+//
+// It must run on a PTY. Cursor decides between TUI and print mode by whether
+// stdout is a terminal, so a plain exec.Command here would land in print mode
+// and report a different error ("No prompt provided for print mode") — passing
+// for the wrong reason.
+func TestCursorRejectsTrustFlagInTUI(t *testing.T) {
+	if os.Getenv("POGO_CURSOR_E2E") != "1" {
+		t.Skip("set POGO_CURSOR_E2E=1 to run the live Cursor flag-contract test")
+	}
+	if _, err := exec.LookPath(cursor.Provider.Binary); err != nil {
+		t.Skipf("%s binary not on PATH", cursor.Provider.Binary)
+	}
+
+	base := t.TempDir()
+	workDir, _, _, _ := seedWorktree(t, base)
+
+	cmd := exec.Command(cursor.Provider.Binary, "--force", "--trust")
+	cmd.Dir = workDir
+	cmd.Env = append(os.Environ(), "CURSOR_DATA_DIR="+filepath.Join(base, "cursor-state"))
+
+	f, err := pty.StartWithSize(cmd, &pty.Winsize{Cols: 200, Rows: 50})
+	if err != nil {
+		t.Fatalf("pty.StartWithSize: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var buf bytes.Buffer
+	copied := make(chan struct{})
+	go func() { _, _ = io.Copy(&buf, f); close(copied) }()
+
+	waitErr := make(chan error, 1)
+	go func() { waitErr <- cmd.Wait() }()
+
+	select {
+	case err := <-waitErr:
+		<-copied
+		out := string(agent.StripANSI(buf.Bytes()))
+		if err == nil {
+			t.Fatalf("`agent --force --trust` exited 0 on a PTY; Cursor now accepts "+
+				"interactive --trust, so cursor.Provider can carry the flag and drop "+
+				"TrustDialogHook.\noutput:\n%s", tail(out, 1000))
+		}
+		if !strings.Contains(out, "--trust can only be used with --print") {
+			t.Errorf("expected Cursor's print-mode-only --trust rejection, got err=%v\noutput:\n%s",
+				err, tail(out, 1000))
+		}
+	case <-time.After(30 * time.Second):
+		_ = cmd.Process.Kill()
+		t.Fatalf("`agent --force --trust` did not exit on a PTY within 30s — Cursor may "+
+			"now accept interactive --trust and render the TUI.\noutput:\n%s",
+			tail(string(agent.StripANSI(buf.Bytes())), 1000))
+	}
+}
+
+// waitFor polls the agent's ANSI-stripped PTY output for a substring.
+func waitFor(t *testing.T, a *agent.Agent, timeout time.Duration, want string) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if strings.Contains(string(agent.StripANSI(a.RecentOutput(1<<20))), want) {
+			return true
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return false
+}
+
+func outputTail(a *agent.Agent, n int) string {
+	return tail(string(agent.StripANSI(a.RecentOutput(1<<20))), n)
+}
+
+// assertComposerSettles polls for a quiet PTY window. A settled Cursor composer
+// emits zero output (measured: 0 bytes over 10s), so a quiet window always
+// arrives unless the TUI never settles — which is the real regression this
+// guards. Polling a window rather than sampling once avoids straddling a
+// post-turn repaint, the flake that bit pi's equivalent check (mg-8cc0).
+func assertComposerSettles(t *testing.T, a *agent.Agent) {
+	t.Helper()
+	const (
+		quietWindow  = 2 * time.Second
+		quietBudget  = 2048 // far under a full 200x50 repaint, far over a stray cursor-blink escape
+		settleBudget = 20 * time.Second
+	)
+	deadline := time.Now().Add(settleBudget)
+	var growth int
+	for {
+		before := len(a.RecentOutput(1 << 20))
+		time.Sleep(quietWindow)
+		growth = len(a.RecentOutput(1<<20)) - before
+		if growth <= quietBudget {
+			t.Logf("idle check: composer settled (last %s window grew %d bytes)", quietWindow, growth)
+			return
+		}
+		if !time.Now().Before(deadline) {
+			t.Errorf("cursor composer never settled — buffer kept growing >%d bytes per "+
+				"%s across %s of idle polling", quietBudget, quietWindow, settleBudget)
+			return
+		}
+	}
+}
+
+// tail returns the last n bytes of s, for bounded failure output.
+func tail(s string, n int) string {
+	if len(s) > n {
+		return s[len(s)-n:]
+	}
+	return s
+}

--- a/internal/cursor/e2e_test.go
+++ b/internal/cursor/e2e_test.go
@@ -21,11 +21,22 @@ package cursor_test
 //
 // pi's e2e runs fully offline: pi supports custom OpenAI-compatible providers,
 // so the test points it at a local mock server and asserts byte-level on the
-// captured completion request. Cursor admits no such rig. It is closed-source
-// and speaks a proprietary connectrpc/protobuf protocol to api2.cursor.sh; the
-// only base-URL override in the bundle (CURSOR_API_BASE_URL) fronts the
-// auth-poll endpoint, not the chat transport. So this test follows the *Codex*
-// pattern instead: opt-in, real binary, real network, real Cursor plan credits.
+// captured completion request. The `agent` binary admits no such rig.
+//
+// Cursor speaks a proprietary connectrpc/protobuf protocol to api2.cursor.sh,
+// which alone would make a mock absurd. But the bundle DOES carry a hidden
+// local-provider mode (--local-agent-base-url, CURSOR_LOCAL_AGENT_BASE_URL,
+// ANTHROPIC_BASE_URL, CURSOR_ENABLE_AUTHLESS) that accepts an OpenAI-compatible
+// endpoint — exactly what an offline rig needs. It is gated to a *different
+// executable*, cursor-agent-local, on its own download channel. Measured against
+// the `agent` binary this provider targets: the flag is rejected outright
+// ("unknown option"), and every env-var route left a local mock server with zero
+// requests while the real backend answered. See the calibration doc.
+//
+// So this test follows the *Codex* pattern instead: opt-in, real binary, real
+// network, real Cursor plan credits. If pogo ever targets cursor-agent-local, a
+// pi-style offline mock becomes available — a different binary, a different
+// ticket.
 //
 // Losing byte-level capture costs the "did the persona reach the system
 // prompt?" assertion. It is recovered BEHAVIOURALLY: the injected persona and

--- a/internal/cursor/integration_test.go
+++ b/internal/cursor/integration_test.go
@@ -1,0 +1,267 @@
+package cursor_test
+
+// Integration coverage for the Cursor provider's config-resolution path and
+// its persona-injection contract (mg-c146).
+//
+// TestPolecatProviderConfigPath drives the exact composition cmd/pogod runs at
+// startup for a `[agents.polecat] provider = "cursor"` deployment — TOML bytes
+// on disk through config.Load(), the per-type AgentProvider precedence, and
+// providers.Resolve() — and asserts the result is the real cursor descriptor
+// and that its command template expands to the argv a cursor polecat is
+// spawned with.
+//
+// TestSpawnPersonaInjectionIsAdditive is the offline half of the
+// AGENTS.md-collision regression. It drives pogo's real Registry.Spawn — the
+// same call path a live cursor polecat takes — against a worktree carrying its
+// own AGENTS.md, but with a stub binary in place of `agent`. Spawn writes the
+// context file before it execs, so the injection contract is asserted without
+// needing a Cursor CLI, an account, or a network: the persona lands in
+// .cursor/rules/pogo-persona.mdc behind `alwaysApply: true` frontmatter, and
+// the repo's AGENTS.md survives byte-identical. Whether Cursor then *reads*
+// both files is asserted live in e2e_test.go.
+//
+// Neither test needs an `agent` binary or an env gate: both run in every plain
+// `go test ./...`, and therefore in the refinery gates and GitHub CI.
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drellem2/pogo/internal/agent"
+	"github.com/drellem2/pogo/internal/config"
+	"github.com/drellem2/pogo/internal/cursor"
+	"github.com/drellem2/pogo/internal/providers"
+)
+
+func TestPolecatProviderConfigPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	// Neutralize env overrides that would shadow the config file.
+	t.Setenv("POGO_AGENT_PROVIDER", "")
+	t.Setenv("POGO_AGENT_COMMAND", "")
+
+	pogoDir := filepath.Join(dir, "pogo")
+	if err := os.MkdirAll(pogoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pogoDir, "config.toml"), []byte(`
+[agents]
+provider = "claude"
+
+[agents.polecat]
+provider = "cursor"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config.Load()
+
+	// Per-type precedence: polecats get cursor, crew inherit the global claude.
+	if got := cfg.Agents.AgentProvider("polecat"); got != "cursor" {
+		t.Fatalf("AgentProvider(polecat) = %q, want cursor", got)
+	}
+	if got := cfg.Agents.AgentProvider("crew"); got != "claude" {
+		t.Errorf("AgentProvider(crew) = %q, want claude (global)", got)
+	}
+
+	// The id maps to the real cursor descriptor — same composition as pogod's
+	// resolveAgentProvider(cfg.Agents.AgentProvider(agentType)).
+	p, ok := providers.Resolve(cfg.Agents.AgentProvider("polecat"))
+	if !ok {
+		t.Fatal("providers.Resolve returned ok=false for the configured polecat provider")
+	}
+	if p != &cursor.Provider {
+		t.Fatalf("Resolve returned %q (%p), want the cursor.Provider descriptor (%p)",
+			p.ID, p, &cursor.Provider)
+	}
+
+	// No explicit [agents] command is configured, so the provider's template
+	// supplies the spawn argv.
+	if got := cfg.Agents.AgentCommand("polecat"); got != "" {
+		t.Fatalf("AgentCommand(polecat) = %q, want \"\" (provider template should win)", got)
+	}
+	argv, err := agent.ExpandCommand(p.CommandTemplate, agent.CommandTemplateVars{
+		PromptFile: "/tmp/prompt.md",
+		AgentName:  "cfg-test",
+		AgentType:  string(agent.TypePolecat),
+		WorkDir:    "/tmp/work",
+	})
+	if err != nil {
+		t.Fatalf("ExpandCommand: %v", err)
+	}
+	want := []string{"agent", "--force"}
+	if len(argv) != len(want) {
+		t.Fatalf("expanded argv = %v, want %v", argv, want)
+	}
+	for i := range want {
+		if argv[i] != want[i] {
+			t.Fatalf("expanded argv = %v, want %v", argv, want)
+		}
+	}
+}
+
+// stubCommand is a long-lived no-op process standing in for the Cursor CLI.
+// Spawn writes the persona context file before exec, so the injection contract
+// is observable without the real harness.
+func stubCommand(t *testing.T) []string {
+	t.Helper()
+	sleep, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skipf("no sleep binary to stand in for the cursor CLI: %v", err)
+	}
+	return []string{sleep, "30"}
+}
+
+// shortSocketDir returns a directory path short enough that "<dir>/<name>.sock"
+// fits inside AF_UNIX's sun_path limit (104 bytes on darwin, 108 on linux).
+// t.TempDir() on darwin returns /var/folders/... paths that exceed it on their
+// own, and since mg-ef80 an unbindable attach socket is fatal to the spawn.
+// Mirrors internal/agent's own unexported helper of the same name.
+func shortSocketDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "pogo-cursor-sock-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return filepath.Join(dir, "s")
+}
+
+// spawnWithCursorProvider runs Registry.Spawn against workDir with the real
+// cursor.Provider descriptor and a stub binary, and returns the registry so the
+// caller can stop it.
+func spawnWithCursorProvider(t *testing.T, workDir, promptFile, name string) *agent.Registry {
+	t.Helper()
+	reg, err := agent.NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	t.Cleanup(func() { reg.StopAll(5 * time.Second) })
+
+	reg.RegisterProvider(&cursor.Provider)
+	if _, err := reg.Spawn(agent.SpawnRequest{
+		Name:       name,
+		Type:       agent.TypePolecat,
+		Command:    stubCommand(t),
+		PromptFile: promptFile,
+		Dir:        workDir,
+		Provider:   &cursor.Provider,
+	}); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	return reg
+}
+
+func TestSpawnPersonaInjectionIsAdditive(t *testing.T) {
+	base := t.TempDir()
+	workDir := filepath.Join(base, "worktree")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The worktree carries its own AGENTS.md — the file pogo must not clobber.
+	const repoMarker = "POGO-CURSOR-REPO-AGENTS-MD-MARKER"
+	repoAgentsMD := []byte("# repo context\n\n" + repoMarker + "\n")
+	agentsMDPath := filepath.Join(workDir, "AGENTS.md")
+	if err := os.WriteFile(agentsMDPath, repoAgentsMD, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	const personaMarker = "POGO-CURSOR-PERSONA-MARKER"
+	persona := "# pogo polecat persona\n\n" + personaMarker + "\n"
+	promptFile := filepath.Join(base, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte(persona), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	spawnWithCursorProvider(t, workDir, promptFile, "inject")
+
+	// The persona landed at the nested rules path — whose parent directories
+	// did not exist before the spawn.
+	rulePath := filepath.Join(workDir, ".cursor", "rules", "pogo-persona.mdc")
+	got, err := os.ReadFile(rulePath)
+	if err != nil {
+		t.Fatalf("persona rule file not written by Spawn: %v", err)
+	}
+	body := string(got)
+
+	// Frontmatter first, then the persona verbatim.
+	if !strings.HasPrefix(body, "---\n") {
+		t.Errorf("rule file must open with YAML frontmatter, got:\n%s", body)
+	}
+	if !strings.Contains(body, "alwaysApply: true") {
+		t.Error("rule file must declare `alwaysApply: true`, or Cursor will not " +
+			"reliably fold the persona into the system prompt")
+	}
+	if !strings.HasSuffix(body, persona) {
+		t.Errorf("rule file must end with the persona verbatim; got:\n%s", body)
+	}
+	if !strings.Contains(body, personaMarker) {
+		t.Errorf("persona marker missing from rule file:\n%s", body)
+	}
+
+	// The repo's own AGENTS.md is untouched, byte for byte.
+	after, err := os.ReadFile(agentsMDPath)
+	if err != nil {
+		t.Fatalf("repo AGENTS.md unreadable after spawn: %v", err)
+	}
+	if !bytes.Equal(after, repoAgentsMD) {
+		t.Errorf("repo AGENTS.md was clobbered by persona injection; contents now:\n%s", after)
+	}
+
+	// Spawn wrote nothing into the worktree root beyond the repo's own file and
+	// the .cursor tree.
+	entries, err := os.ReadDir(workDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	if len(names) != 2 {
+		t.Errorf("persona injection wrote unexpected entries into the worktree root: %v", names)
+	}
+}
+
+// TestRespawnRewritesPersona guards the respawn path: Registry.Respawn
+// re-delivers the context-file persona into a worktree where .cursor/rules and
+// the rule file already exist. The second write must succeed (MkdirAll on an
+// existing tree) and must not double the frontmatter block.
+func TestRespawnRewritesPersona(t *testing.T) {
+	base := t.TempDir()
+	workDir := filepath.Join(base, "worktree")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	promptFile := filepath.Join(base, "prompt.md")
+	persona := "# persona\n\nbody\n"
+	if err := os.WriteFile(promptFile, []byte(persona), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two spawns into the same worktree stand in for spawn-then-respawn: both
+	// go through the same writeContextFilePrompt call inside Spawn.
+	spawnWithCursorProvider(t, workDir, promptFile, "respawn-1")
+	spawnWithCursorProvider(t, workDir, promptFile, "respawn-2")
+
+	got, err := os.ReadFile(filepath.Join(workDir, ".cursor", "rules", "pogo-persona.mdc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Exactly one frontmatter block: one opening and one closing delimiter.
+	if n := strings.Count(string(got), "---\n"); n != 2 {
+		t.Errorf("re-delivery produced %d frontmatter delimiters, want 2 (one block):\n%s", n, got)
+	}
+	if n := strings.Count(string(got), "alwaysApply: true"); n != 1 {
+		t.Errorf("re-delivery produced %d alwaysApply lines, want 1", n)
+	}
+	if !strings.HasSuffix(string(got), persona) {
+		t.Errorf("re-delivery must leave the persona verbatim at the tail:\n%s", got)
+	}
+}

--- a/internal/cursor/provider.go
+++ b/internal/cursor/provider.go
@@ -42,6 +42,15 @@ const personaRuleHeader = "---\n" +
 	"alwaysApply: true\n" +
 	"---\n\n"
 
+// promptReadySentinel is Cursor's composer placeholder — the measured "input
+// loop ready" marker. It is absent during the loading banner and the trust
+// dialog (verified 3/3 against a live, never-dismissed dialog), and after the
+// first turn it is replaced by "Add a follow-up".
+//
+// Two consumers: Provider.Nudge.PromptReadySentinel, and TrustDialogHook, which
+// uses its appearance to prove there is no trust dialog left to dismiss.
+const promptReadySentinel = "Plan, search, build anything"
+
 // Provider is the Cursor CLI harness descriptor.
 //
 // Prompt injection uses the ContextFile strategy, because Cursor has no
@@ -163,8 +172,8 @@ var Provider = agent.Provider{
 		// for); retained as the measured marker for any future wait-ready use,
 		// and asserted by the e2e so a Cursor UI change is caught. It rendered
 		// in 3/3 argv-delivered spawns before the turn replaced it with "Add a
-		// follow-up".
-		PromptReadySentinel: "Plan, search, build anything",
+		// follow-up". TrustDialogHook also keys off it — see promptReadySentinel.
+		PromptReadySentinel: promptReadySentinel,
 	},
 
 	// PostSpawnHook auto-accepts Cursor's workspace-trust dialog; SessionHook is

--- a/internal/cursor/provider.go
+++ b/internal/cursor/provider.go
@@ -1,0 +1,176 @@
+// Package cursor is pogo's Cursor CLI harness provider — the fourth harness
+// provider after Claude Code (internal/claude), Codex (internal/codex) and pi
+// (internal/pi).
+//
+// Cursor (https://cursor.com) ships a terminal coding agent whose command was
+// renamed from `cursor-agent` to `agent` in 2026. It exports a single
+// agent.Provider value, cursor.Provider, capturing every Cursor-specific spawn
+// decision: the command template, the .cursor/rules context-file
+// prompt-injection strategy, the --force non-interactive flag, argv delivery of
+// the initial task, the workspace-trust PostSpawnHook, and the PTY nudge
+// dialect.
+//
+// Every value here was measured against a live Cursor CLI 2026.07.09-a3815c0
+// rather than copied from another provider — Cursor's TUI is its own renderer,
+// and it differs from all three predecessors in at least one load-bearing way
+// (see the SubmitDelay note below). See docs/investigations/cursor-nudge-calibration.md.
+package cursor
+
+import (
+	"time"
+
+	"github.com/drellem2/pogo/internal/agent"
+)
+
+// personaRuleFile is where the pogo persona is written inside the agent's
+// working directory. Cursor loads every `.cursor/rules/**/*.mdc` in the
+// workspace, so this is a namespace the repo does not own by convention —
+// unlike AGENTS.md, which repos commonly check in and which pogo must not
+// clobber.
+const personaRuleFile = ".cursor/rules/pogo-persona.mdc"
+
+// personaRuleHeader is the YAML frontmatter prepended to the persona.
+//
+// It is not decoration. A `.mdc` with no frontmatter is silently ignored by
+// Cursor (measured: 0/3 runs saw the persona), and a rule with
+// `alwaysApply: false` is only *sometimes* attached — Cursor decides from the
+// description, so persona delivery would depend on the model's judgement.
+// `alwaysApply: true` is the documented "Always" rule type and was injected in
+// 3/3 runs. See docs/investigations/cursor-nudge-calibration.md.
+const personaRuleHeader = "---\n" +
+	"description: pogo agent persona\n" +
+	"alwaysApply: true\n" +
+	"---\n\n"
+
+// Provider is the Cursor CLI harness descriptor.
+//
+// Prompt injection uses the ContextFile strategy, because Cursor has no
+// --append-system-prompt equivalent (the only prompt-ish flag on the CLI is
+// --no-prompt). The persona is written to .cursor/rules/pogo-persona.mdc in
+// the agent's working directory, carrying `alwaysApply: true` frontmatter.
+//
+// That path is the escape hatch for the AGENTS.md-collision wrinkle the ticket
+// flagged. Cursor loads AGENTS.md, CLAUDE.md, .cursorrules and
+// .cursor/rules/**/*.mdc as rules. Injecting through AGENTS.md would clobber a
+// file most repos own; injecting through a uniquely-named rule file does not.
+// Both were measured to load together: with a repo AGENTS.md and a pogo rule
+// present, a behavioural probe saw directives from *both*, and the repo's
+// AGENTS.md was left byte-identical. Cursor offers no AGENTS.override.md-style
+// precedence file (Codex's answer), so a separate rules namespace is the only
+// additive injection point.
+//
+// PostSpawnHook is TrustDialogHook: Cursor blocks a fresh worktree behind a
+// "Workspace Trust Required" dialog, and every polecat runs in a fresh
+// worktree. Neither non-interactive flag suppresses it — --force governs
+// command approval, not workspace trust, and --trust is rejected outright
+// outside --print/headless mode ("Error: --trust can only be used with
+// --print/headless mode"). So the dialog must be dismissed from the PTY, the
+// way Claude and Codex dismiss theirs. SessionHook is nil: with --force,
+// Cursor surfaces no mid-session modal — tool calls run without approval
+// prompts and errors render inline.
+//
+// Cursor selects its model via its own config (~/.cursor/cli-config.json,
+// default "auto") or --model; the template deliberately pins neither, so the
+// user's Cursor configuration (or an [agents] command override with an explicit
+// --model) decides. Auth comes from CURSOR_API_KEY or Cursor's own auth store
+// (seeded by `agent login`); billing draws on the account's Cursor plan credits.
+var Provider = agent.Provider{
+	ID: "cursor",
+
+	// The CLI binary is `agent` — renamed from `cursor-agent` in 2026. The
+	// installer keeps a `cursor-agent` symlink beside it, but `agent` is the
+	// documented command and the one `curl cursor.com/install` puts on PATH.
+	// Note this is a generic name: ValidateCommandBinary's PATH check cannot
+	// tell Cursor's `agent` from an unrelated binary of the same name.
+	Binary: "agent",
+
+	// --force ("Run Everything", aliased --yolo) is Cursor's equivalent of
+	// Claude's --dangerously-skip-permissions: it allows every tool call that
+	// is not explicitly denied, which polecats need to execute autonomously.
+	//
+	// --trust is deliberately absent: it is the workspace-trust bypass, but
+	// Cursor rejects it outside --print mode and the CLI exits non-zero before
+	// the TUI renders. Workspace trust is handled by TrustDialogHook instead.
+	CommandTemplate: "agent --force",
+
+	// ContextFile injection: the persona is written to
+	// .cursor/rules/pogo-persona.mdc (created under the agent's working
+	// directory) behind `alwaysApply: true` frontmatter. Cursor loads it
+	// alongside — not instead of — the repo's own AGENTS.md, which pogo never
+	// touches.
+	PromptInjection: agent.PromptInjection{
+		Kind:              agent.InjectContextFile,
+		ContextFile:       personaRuleFile,
+		ContextFileHeader: personaRuleHeader,
+	},
+
+	NonInteractiveFlags: []string{"--force"},
+
+	// Cursor accepts the initial task as a trailing positional argv element
+	// (`agent [options] [prompt...]`), so Spawn appends it to the command
+	// instead of typing it into the composer.
+	//
+	// This is the gh #26 posture, adopted here for a second, Cursor-specific
+	// reason: the workspace-trust dialog. A typed initial nudge would have to
+	// wait out TrustDialogHook's dismissal, and the dialog is *silent* once
+	// rendered — it reads as "idle" within ~0.5s, exactly the race that made
+	// Codex's nudge type its task into the trust dialog. Argv delivery removes
+	// the race rather than tuning against it: Cursor reads the prompt before
+	// the TUI starts and runs it once the workspace is trusted (measured 3/3).
+	InitialPromptViaArgv: true,
+
+	// Cursor's TUI nudge dialect — every value measured against a live Cursor
+	// CLI 2026.07.09-a3815c0 at pogo's default 200×50 winsize, NOT copied from
+	// Claude, Codex or pi. See docs/investigations/cursor-nudge-calibration.md.
+	Nudge: agent.NudgeProfile{
+		// The initial task arrives via argv (InitialPromptViaArgv above), not
+		// as a typed nudge. The persona arrives via the .cursor/rules file.
+		NeedsInitialNudge: false,
+
+		// Unused while NeedsInitialNudge is false; retained as the measured
+		// calibration record should the nudge path ever be needed again.
+		// Cursor is a Node CLI: the trust dialog renders ~0.7s from spawn and
+		// the composer settles ~3.0s. 30s is a generous upper bound.
+		InitialNudgeTimeout: 30 * time.Second,
+
+		// A carriage return submits the Cursor composer.
+		SubmitTerminator: "\r",
+
+		// LOAD-BEARING, unlike pi's. Cursor's composer has paste-burst
+		// detection: body+"\r" written as a single PTY chunk is absorbed as a
+		// literal newline and does NOT submit (measured — the turn never ran,
+		// the test timed out at 95s). The nudge body and terminator must arrive
+		// in separate read()s. 50ms matches Claude's and Codex's value, so
+		// Agent.Nudge's split-write path stays uniform across providers.
+		SubmitDelay: 50 * time.Millisecond,
+
+		// A settled Cursor composer emits zero PTY output (measured: 0 bytes
+		// over a 10s idle watch) — a differential renderer like Codex's ratatui
+		// and pi's pi-tui, unlike Claude's continuously-repainting Ink. Steady
+		// state would therefore tolerate a sub-second threshold. The binding
+		// constraint is the spawn-time race: the workspace-trust dialog is
+		// itself dead silent once drawn, so it reads as "idle" almost
+		// immediately. Argv delivery keeps the *initial* task clear of that
+		// race, and 2s keeps mid-session wait-idle nudges uniform with the
+		// other three providers.
+		IdleThreshold: 2 * time.Second,
+
+		// Cursor renders its composer placeholder — "→ Plan, search, build
+		// anything" — once the input loop is up; it is absent during the
+		// loading banner and the trust dialog, which makes it a precise "input
+		// loop ready" marker. Unused for the initial prompt while
+		// NeedsInitialNudge is false (argv delivery has no ready gate to wait
+		// for); retained as the measured marker for any future wait-ready use,
+		// and asserted by the e2e so a Cursor UI change is caught. It rendered
+		// in 3/3 argv-delivered spawns before the turn replaced it with "Add a
+		// follow-up".
+		PromptReadySentinel: "Plan, search, build anything",
+	},
+
+	// PostSpawnHook auto-accepts Cursor's workspace-trust dialog; SessionHook is
+	// nil — see the Provider doc above.
+	PostSpawnHook: TrustDialogHook,
+	SessionHook:   nil,
+
+	// PTYSize nil — Cursor renders correctly at pogo's default 200×50 winsize.
+}

--- a/internal/cursor/provider_test.go
+++ b/internal/cursor/provider_test.go
@@ -1,0 +1,245 @@
+package cursor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drellem2/pogo/internal/agent"
+)
+
+func TestProviderIdentity(t *testing.T) {
+	if Provider.ID != "cursor" {
+		t.Errorf("Provider.ID = %q, want \"cursor\"", Provider.ID)
+	}
+	// The CLI was renamed cursor-agent -> agent in 2026. Pin the expectation:
+	// a closed-source CLI that churns this fast should fail loudly here rather
+	// than silently PATH-miss at spawn.
+	if Provider.Binary != "agent" {
+		t.Errorf("Provider.Binary = %q, want \"agent\" (renamed from cursor-agent in 2026)",
+			Provider.Binary)
+	}
+}
+
+// TestProviderCommandHasForceFlag guards the autonomy contract: the Cursor
+// command template must keep --force so polecats in a fresh worktree are never
+// blocked by a tool-approval prompt.
+func TestProviderCommandHasForceFlag(t *testing.T) {
+	if !strings.Contains(Provider.CommandTemplate, "--force") {
+		t.Fatal("cursor.Provider.CommandTemplate must include --force so tool " +
+			"approvals never block unattended execution")
+	}
+}
+
+// TestProviderCommandOmitsTrustFlag pins a measured Cursor constraint: --trust
+// is only accepted with --print/headless. Putting it in the interactive
+// template makes the CLI exit non-zero before the TUI renders ("Error: --trust
+// can only be used with --print/headless mode"), so every polecat would die at
+// spawn. Workspace trust is handled by TrustDialogHook instead.
+func TestProviderCommandOmitsTrustFlag(t *testing.T) {
+	if strings.Contains(Provider.CommandTemplate, "--trust") {
+		t.Fatal("cursor.Provider.CommandTemplate must NOT include --trust — " +
+			"Cursor rejects it outside --print mode and exits before the TUI renders; " +
+			"TrustDialogHook dismisses the dialog instead")
+	}
+}
+
+func TestProviderNonInteractiveFlags(t *testing.T) {
+	if len(Provider.NonInteractiveFlags) == 0 {
+		t.Fatal("cursor.Provider must declare at least one non-interactive flag")
+	}
+	// Every declared non-interactive flag must appear in the command template,
+	// otherwise ValidatePolecatCommand warns on the provider's own default.
+	for _, f := range Provider.NonInteractiveFlags {
+		if !strings.Contains(Provider.CommandTemplate, f) {
+			t.Errorf("CommandTemplate %q is missing declared non-interactive flag %q",
+				Provider.CommandTemplate, f)
+		}
+	}
+}
+
+// TestProviderPromptInjection pins the ContextFile strategy and, critically,
+// the rules-file escape hatch: Cursor has no --append-system-prompt equivalent,
+// and injecting through AGENTS.md would clobber a file most repos own. The
+// persona goes to a uniquely-named .cursor/rules/*.mdc instead.
+func TestProviderPromptInjection(t *testing.T) {
+	pi := Provider.PromptInjection
+	if pi.Kind != agent.InjectContextFile {
+		t.Errorf("PromptInjection.Kind = %d, want InjectContextFile", pi.Kind)
+	}
+	if pi.Flag != "" {
+		t.Errorf("PromptInjection.Flag = %q, want empty — Cursor has no "+
+			"--append-system-prompt equivalent", pi.Flag)
+	}
+	if pi.ContextFile != ".cursor/rules/pogo-persona.mdc" {
+		t.Errorf("PromptInjection.ContextFile = %q, want .cursor/rules/pogo-persona.mdc",
+			pi.ContextFile)
+	}
+	// The collision wrinkle: the persona must never be delivered through a file
+	// the repo conventionally owns.
+	for _, repoOwned := range []string{"AGENTS.md", "CLAUDE.md", "CLAUDE.local.md", ".cursorrules"} {
+		if pi.ContextFile == repoOwned {
+			t.Errorf("PromptInjection.ContextFile = %q — persona must not be "+
+				"delivered through a repo-owned context file", repoOwned)
+		}
+	}
+	// The template must carry no prompt-file flag: injection is out-of-band.
+	if strings.Contains(Provider.CommandTemplate, "{{.PromptFile}}") {
+		t.Errorf("CommandTemplate %q must not reference the prompt file — "+
+			"Cursor injects via the rules context file", Provider.CommandTemplate)
+	}
+}
+
+// TestProviderContextFileHeader pins the measured frontmatter contract: a .mdc
+// with no frontmatter is silently ignored by Cursor, and only `alwaysApply:
+// true` guarantees the rule reaches the system prompt. Losing this header is a
+// silent persona-delivery failure, so it is asserted field by field.
+func TestProviderContextFileHeader(t *testing.T) {
+	h := Provider.PromptInjection.ContextFileHeader
+	if h == "" {
+		t.Fatal("cursor.Provider.PromptInjection.ContextFileHeader must be set — " +
+			"a .mdc without YAML frontmatter is silently ignored by Cursor")
+	}
+	if !strings.HasPrefix(h, "---\n") {
+		t.Errorf("ContextFileHeader must open a YAML frontmatter block, got %q", h)
+	}
+	if !strings.Contains(h, "alwaysApply: true") {
+		t.Error("ContextFileHeader must declare `alwaysApply: true` — " +
+			"`alwaysApply: false` leaves attachment to the model's judgement")
+	}
+	// The frontmatter block must be closed, and the persona body must start on
+	// its own line after it.
+	if strings.Count(h, "---\n") != 2 {
+		t.Errorf("ContextFileHeader must open and close the frontmatter block, got %q", h)
+	}
+	if !strings.HasSuffix(h, "\n\n") {
+		t.Errorf("ContextFileHeader must end with a blank line so the persona "+
+			"body does not run into the frontmatter terminator, got %q", h)
+	}
+}
+
+// TestProviderNudgeProfile pins the empirically-calibrated nudge dialect. The
+// values were measured against a live Cursor CLI 2026.07.09-a3815c0 — see
+// docs/investigations/cursor-nudge-calibration.md — and deliberately differ
+// from Claude's: Cursor must NOT inherit DefaultNudgeProfile blindly.
+func TestProviderNudgeProfile(t *testing.T) {
+	n := Provider.Nudge
+
+	// The initial task arrives via argv; a typed nudge would race the silent
+	// workspace-trust dialog.
+	if n.NeedsInitialNudge {
+		t.Error("cursor must not take the PTY initial-nudge path — the silent " +
+			"workspace-trust dialog reads as idle; the task is delivered via argv")
+	}
+	if n.SubmitTerminator != "\r" {
+		t.Errorf("SubmitTerminator = %q, want carriage return", n.SubmitTerminator)
+	}
+	// Load-bearing for Cursor specifically: a combined body+"\r" write does not
+	// submit (paste-burst detection), so the split-write gap must be non-zero.
+	if n.SubmitDelay <= 0 {
+		t.Errorf("SubmitDelay = %v, want a non-zero split-write gap — Cursor's "+
+			"composer swallows a combined body+CR write", n.SubmitDelay)
+	}
+	if n.IdleThreshold <= 0 {
+		t.Errorf("IdleThreshold = %v, want a positive idle window", n.IdleThreshold)
+	}
+	if n.InitialNudgeTimeout <= 0 {
+		t.Errorf("InitialNudgeTimeout = %v, want a positive timeout", n.InitialNudgeTimeout)
+	}
+
+	// The profile is calibrated for Cursor, not inherited from Claude.
+	if n == agent.DefaultNudgeProfile {
+		t.Error("cursor.Provider.Nudge must be calibrated for Cursor, " +
+			"not equal to the Claude-tuned DefaultNudgeProfile")
+	}
+	if n.InitialNudgeTimeout >= agent.DefaultNudgeProfile.InitialNudgeTimeout {
+		t.Errorf("InitialNudgeTimeout = %v; Cursor's ~3s composer render should give "+
+			"a shorter timeout than Claude's %v", n.InitialNudgeTimeout,
+			agent.DefaultNudgeProfile.InitialNudgeTimeout)
+	}
+	// The sentinel is unused for the initial prompt (argv delivery) but
+	// retained as the measured "input loop ready" marker.
+	if n.PromptReadySentinel == "" {
+		t.Error("cursor.Provider.Nudge.PromptReadySentinel must be set: it is the " +
+			"measured input-loop-ready marker (see cursor-nudge-calibration.md)")
+	}
+	if n.PromptReadySentinel == agent.DefaultNudgeProfile.PromptReadySentinel {
+		t.Error("cursor.Provider.Nudge.PromptReadySentinel must be Cursor's own " +
+			"composer placeholder, not Claude's")
+	}
+}
+
+// TestProviderNudgeValues pins the exact calibrated values so a regression in
+// the measured profile is caught. See docs/investigations/cursor-nudge-calibration.md.
+func TestProviderNudgeValues(t *testing.T) {
+	want := agent.NudgeProfile{
+		NeedsInitialNudge:   false, // initial task arrives via argv
+		InitialNudgeTimeout: 30 * time.Second,
+		SubmitTerminator:    "\r",
+		SubmitDelay:         50 * time.Millisecond,
+		IdleThreshold:       2 * time.Second,
+		PromptReadySentinel: "Plan, search, build anything",
+	}
+	if Provider.Nudge != want {
+		t.Errorf("Provider.Nudge = %+v, want %+v", Provider.Nudge, want)
+	}
+}
+
+// TestProviderInitialPromptViaArgv pins argv delivery: Cursor accepts trailing
+// positional prompts (`agent [options] [prompt...]`), so the initial task is
+// appended to the spawn argv by Registry.Spawn instead of typed into the
+// composer while the silent trust dialog still owns the screen. The two fields
+// must stay paired: argv delivery on, nudge path off — both set would deliver
+// the task twice, both unset would never deliver it at all.
+func TestProviderInitialPromptViaArgv(t *testing.T) {
+	if !Provider.InitialPromptViaArgv {
+		t.Error("cursor.Provider.InitialPromptViaArgv must be true — a typed " +
+			"initial nudge races the silent workspace-trust dialog")
+	}
+	if Provider.Nudge.NeedsInitialNudge {
+		t.Error("NeedsInitialNudge must be false when InitialPromptViaArgv is " +
+			"set, or the task would be delivered twice")
+	}
+}
+
+// TestProviderHooks pins Cursor's hook wiring: a PostSpawnHook is REQUIRED
+// (neither --force nor --trust suppresses the workspace-trust dialog in the
+// TUI), and no SessionHook (with --force there is no mid-session modal).
+func TestProviderHooks(t *testing.T) {
+	if Provider.PostSpawnHook == nil {
+		t.Error("cursor.Provider.PostSpawnHook must be set — --force does not " +
+			"suppress the workspace-trust dialog and --trust is TUI-invalid")
+	}
+	if Provider.SessionHook != nil {
+		t.Error("cursor.Provider.SessionHook must be nil — with --force there is " +
+			"no mid-session modal to dismiss")
+	}
+}
+
+func TestProviderPTYSizeDefault(t *testing.T) {
+	if Provider.PTYSize != nil {
+		t.Errorf("Provider.PTYSize = %+v, want nil (pogo default winsize)", Provider.PTYSize)
+	}
+}
+
+// TestExpandedCommand pins the argv a Cursor polecat is actually spawned with.
+func TestExpandedCommand(t *testing.T) {
+	argv, err := agent.ExpandCommand(Provider.CommandTemplate, agent.CommandTemplateVars{
+		PromptFile: "/tmp/prompt.md",
+		AgentName:  "c1",
+		AgentType:  string(agent.TypePolecat),
+		WorkDir:    "/tmp/work",
+	})
+	if err != nil {
+		t.Fatalf("ExpandCommand: %v", err)
+	}
+	want := []string{"agent", "--force"}
+	if len(argv) != len(want) {
+		t.Fatalf("expanded argv = %v, want %v", argv, want)
+	}
+	for i := range want {
+		if argv[i] != want[i] {
+			t.Fatalf("expanded argv = %v, want %v", argv, want)
+		}
+	}
+}

--- a/internal/cursor/trust_hook.go
+++ b/internal/cursor/trust_hook.go
@@ -1,0 +1,111 @@
+package cursor
+
+import (
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/drellem2/pogo/internal/agent"
+)
+
+// trustDialogMarker matches Cursor's workspace-trust dialog. Cursor shows it
+// whenever it launches in a directory with no saved trust decision. Every
+// polecat runs in a freshly-created worktree, so the dialog appears on every
+// spawn.
+//
+// Neither non-interactive flag suppresses it: --force governs command approval
+// ("Run Everything"), not workspace trust, and --trust is rejected outside
+// --print/headless mode. Verified empirically against Cursor CLI
+// 2026.07.09-a3815c0; see docs/investigations/cursor-nudge-calibration.md.
+//
+// The dialog body reads (Cursor 2026.07.09-a3815c0):
+//
+//	Workspace Trust Required
+//	Cursor Agent can execute code and access files in this directory.
+//	Do you trust the contents of this directory?
+//	<path>
+//	▶ [a] Trust this workspace
+//	  [q] Quit
+//	Use arrow keys to navigate, Enter to select, or press the key shown
+//
+// matchesTrustDialog strips the box border and collapses ALL whitespace before
+// matching, so the marker is written whitespace-free. Cursor draws the dialog
+// inside a box-drawing frame: at pogo's 200-column default each phrase fits on
+// one line, but a narrower winsize (or a longer future body) wraps a phrase
+// across two lines, interposing "│" and padding. Stripping the frame glyphs and
+// the whitespace makes the pattern survive that. Two independent phrases are
+// matched so a reword of either one alone still hits.
+var trustDialogMarker = regexp.MustCompile(`(?i)workspacetrustrequired|trustthisworkspace`)
+
+// boxDrawing removes the frame glyphs Cursor draws the dialog with, so a phrase
+// wrapped across two boxed lines still collapses to a contiguous match.
+var boxDrawing = strings.NewReplacer(
+	"│", "", "─", "", "╭", "", "╮", "", "╰", "", "╯", "",
+	"┌", "", "┐", "", "└", "", "┘", "", "├", "", "┤", "",
+)
+
+// matchesTrustDialog reports whether PTY output contains Cursor's trust dialog.
+// It strips ANSI escapes, then the box frame, then all whitespace, before
+// matching — see trustDialogMarker for why.
+func matchesTrustDialog(output []byte) bool {
+	clean := agent.StripANSI(output)
+	unboxed := boxDrawing.Replace(string(clean))
+	collapsed := strings.Join(strings.Fields(unboxed), "")
+	return trustDialogMarker.MatchString(collapsed)
+}
+
+// TrustDialogPollInterval is how often to scan PTY output for the trust dialog.
+const TrustDialogPollInterval = 250 * time.Millisecond
+
+// TrustDialogTimeout bounds how long after spawn the hook watches for the
+// dialog before giving up.
+const TrustDialogTimeout = 12 * time.Second
+
+// trustDialogAccept is the key that accepts the dialog.
+//
+// It is the "a" accelerator, not the "\r" that claude.TrustDialogHook and
+// codex.TrustDialogHook send. Cursor's dialog is a two-item menu — "[a] Trust
+// this workspace" / "[q] Quit" — and Enter selects whatever is *highlighted*.
+// Trust happens to be highlighted today, but if Cursor ever reorders the menu,
+// Enter would quit the agent. "a" is bound to Trust explicitly, so the worst
+// case of a Cursor UI change is a stalled (visible) spawn rather than a silently
+// killed one.
+const trustDialogAccept = "a"
+
+// TrustDialogHook is the Cursor provider's PostSpawnHook. It auto-accepts
+// Cursor's workspace-trust dialog by scanning PTY output and pressing "a", so a
+// polecat is not blocked at startup in its fresh worktree.
+//
+// It mirrors codex.TrustDialogHook — the same spawn-scoped, poll-and-dismiss
+// shape — because Cursor needs the same treatment for an analogous dialog. The
+// dialog renders ~0.7s after spawn and the composer settles ~2.3s after it is
+// dismissed; the 250ms poll clears it well inside the initial-task path.
+func TrustDialogHook(a *agent.Agent) {
+	deadline := time.After(TrustDialogTimeout)
+	ticker := time.NewTicker(TrustDialogPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			return
+		case <-a.Done():
+			return
+		case <-ticker.C:
+			output := a.RecentOutput(8192)
+			if len(output) == 0 {
+				continue
+			}
+			if matchesTrustDialog(output) {
+				log.Printf("agent %s: detected Cursor workspace-trust dialog, auto-accepting", a.Name)
+				// Let the TUI finish rendering the dialog before answering.
+				time.Sleep(300 * time.Millisecond)
+				if err := a.SendRaw(trustDialogAccept); err != nil {
+					log.Printf("agent %s: failed to dismiss Cursor trust dialog: %v", a.Name, err)
+				}
+				return
+			}
+		}
+	}
+}

--- a/internal/cursor/trust_hook.go
+++ b/internal/cursor/trust_hook.go
@@ -55,6 +55,25 @@ func matchesTrustDialog(output []byte) bool {
 	return trustDialogMarker.MatchString(collapsed)
 }
 
+// composerReady reports whether Cursor's composer placeholder has rendered,
+// which proves the trust dialog is not on screen: the dialog blocks the TUI,
+// and the placeholder is absent for as long as it is up (verified 3/3 against a
+// live, never-dismissed dialog).
+//
+// This is the hook's false-positive guard, and it is load-bearing.
+// trustDialogMarker matches on PTY *text*, and Cursor echoes the argv-delivered
+// task into the TUI — so a work item whose body merely quotes the dialog ("[a]
+// Trust this workspace") matches the marker. Without this guard, a spawn into an
+// already-trusted worktree (Registry.Respawn re-enters the same Dir, and
+// Cursor persists trust per workspace) would see no dialog, match the echoed
+// task instead, and type a stray "a" into the live composer — corrupting the
+// next nudge, whose body would arrive prefixed by it.
+//
+// mg-c146's own ticket body would have tripped this.
+func composerReady(output []byte) bool {
+	return strings.Contains(string(agent.StripANSI(output)), promptReadySentinel)
+}
+
 // TrustDialogPollInterval is how often to scan PTY output for the trust dialog.
 const TrustDialogPollInterval = 250 * time.Millisecond
 
@@ -96,6 +115,13 @@ func TrustDialogHook(a *agent.Agent) {
 			output := a.RecentOutput(8192)
 			if len(output) == 0 {
 				continue
+			}
+			// The composer is up, so no dialog is blocking. Stop scanning
+			// before the echoed task can be mistaken for the dialog, and
+			// return early on an already-trusted worktree instead of polling
+			// out the full timeout. See composerReady.
+			if composerReady(output) {
+				return
 			}
 			if matchesTrustDialog(output) {
 				log.Printf("agent %s: detected Cursor workspace-trust dialog, auto-accepting", a.Name)

--- a/internal/cursor/trust_hook_test.go
+++ b/internal/cursor/trust_hook_test.go
@@ -1,0 +1,127 @@
+package cursor
+
+import "testing"
+
+// realDialog is the whole trust dialog exactly as Cursor 2026.07.09-a3815c0
+// draws it, captured from a PTY spike at 200×50 and passed through
+// agent.StripANSI (box-drawing glyphs retained, ANSI gone).
+const realDialog = `
+  ╭──────────────────────────────────────────────╮
+  │                                              │
+  │  🔒 Workspace Trust Required                 │
+  │                                              │
+  │  Cursor Agent can execute code and access    │
+  │  files in this directory.                    │
+  │                                              │
+  │  Do you trust the contents of this           │
+  │  directory?                                  │
+  │                                              │
+  │    /tmp/pogo-worktree/polecat-mg-c146        │
+  │                                              │
+  │  ▶ [a] Trust this workspace                  │
+  │    [q] Quit                                  │
+  │                                              │
+  │  Use arrow keys to navigate, Enter to        │
+  │  select, or press the key shown              │
+  │                                              │
+  ╰──────────────────────────────────────────────╯
+`
+
+func TestMatchesTrustDialog(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "the real dialog as drawn on the PTY",
+			input: realDialog,
+			want:  true,
+		},
+		{
+			name:  "header phrase alone",
+			input: "Workspace Trust Required",
+			want:  true,
+		},
+		{
+			name:  "menu item alone (header reworded)",
+			input: "▶ [a] Trust this workspace\n    [q] Quit",
+			want:  true,
+		},
+		{
+			// The dialog is drawn inside a box that re-wraps at narrow
+			// winsizes; matchesTrustDialog collapses whitespace so a phrase
+			// split across lines still matches.
+			name:  "phrase split across a box line-wrap",
+			input: "│  Workspace Trust\n│  Required  │",
+			want:  true,
+		},
+		{
+			name:  "with ANSI escapes",
+			input: "\x1b[1mWorkspace\x1b[0m \x1b[32mTrust\x1b[0m Required",
+			want:  true,
+		},
+		{
+			name:  "case insensitive",
+			input: "workspace trust required",
+			want:  true,
+		},
+		{
+			name:  "no match - normal composer output",
+			input: "  Cursor Agent\n  v2026.07.09-a3815c0\n  → Plan, search, build anything",
+			want:  false,
+		},
+		{
+			name:  "no match - the word trust alone",
+			input: "You can trust the explorer results without re-verifying them.",
+			want:  false,
+		},
+		{
+			name:  "no match - post-turn composer",
+			input: "→ Add a follow-up                    ctrl+c to stop",
+			want:  false,
+		},
+		{
+			name:  "empty output",
+			input: "",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesTrustDialog([]byte(tt.input))
+			if got != tt.want {
+				t.Errorf("matchesTrustDialog(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTrustDialogAcceptIsExplicitAccelerator guards a deliberate divergence
+// from claude/codex, whose hooks send "\r". Cursor's dialog is a two-item menu
+// where Enter selects the highlighted row; if Cursor ever reorders it, "\r"
+// would select "[q] Quit" and kill the polecat. "a" is bound to Trust
+// explicitly, so a UI change degrades to a visible stall instead.
+func TestTrustDialogAcceptIsExplicitAccelerator(t *testing.T) {
+	if trustDialogAccept != "a" {
+		t.Errorf("trustDialogAccept = %q, want \"a\" — the explicit Trust "+
+			"accelerator, not a highlight-dependent Enter", trustDialogAccept)
+	}
+	if trustDialogAccept == "\r" {
+		t.Error("trustDialogAccept must not be Enter: it selects whatever menu " +
+			"row is highlighted, which could become [q] Quit")
+	}
+}
+
+// TestTrustDialogTimeoutsAreSane keeps the poll well inside the timeout, and
+// the timeout generous against the ~0.7s dialog render measured on this CLI.
+func TestTrustDialogTimeoutsAreSane(t *testing.T) {
+	if TrustDialogPollInterval <= 0 || TrustDialogTimeout <= 0 {
+		t.Fatal("trust dialog poll interval and timeout must both be positive")
+	}
+	if TrustDialogPollInterval >= TrustDialogTimeout {
+		t.Errorf("poll interval %v must be shorter than the timeout %v",
+			TrustDialogPollInterval, TrustDialogTimeout)
+	}
+}

--- a/internal/cursor/trust_hook_test.go
+++ b/internal/cursor/trust_hook_test.go
@@ -98,6 +98,70 @@ func TestMatchesTrustDialog(t *testing.T) {
 	}
 }
 
+// TestComposerReady pins the hook's false-positive guard. The composer
+// placeholder proves the dialog is not on screen; it never renders while the
+// dialog is up.
+func TestComposerReady(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"composer placeholder rendered", "  → Plan, search, build anything\n  Auto", true},
+		{"placeholder with ANSI", "\x1b[2m→ Plan, search, build anything\x1b[0m", true},
+		{"trust dialog up — no placeholder", realDialog, false},
+		{"loading banner", "  Cursor Agent\n  v2026.07.09-a3815c0", false},
+		{"post-turn composer (placeholder replaced)", "→ Add a follow-up", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := composerReady([]byte(tt.input)); got != tt.want {
+				t.Errorf("composerReady(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestEchoedTaskLooksLikeTheTrustDialog is the reason composerReady exists.
+//
+// trustDialogMarker matches on PTY text, and Cursor echoes the argv-delivered
+// task into the TUI. A work item that merely *quotes* the dialog matches the
+// marker — mg-c146's own body does. On an already-trusted worktree (respawn:
+// Cursor persists trust per workspace) there is no dialog, so an unguarded hook
+// would type a stray "a" into the live composer.
+//
+// The assertions below encode exactly that: the echoed task DOES match the
+// dialog marker (so the marker alone is not sufficient), and the composer
+// placeholder that accompanies it DOES gate the hook off.
+func TestEchoedTaskLooksLikeTheTrustDialog(t *testing.T) {
+	// A polecat task body describing the very dialog this hook dismisses.
+	echoedTask := "Investigate the workspace-trust dialog: it offers " +
+		"[a] Trust this workspace and [q] Quit, and --force does not suppress it."
+
+	if !matchesTrustDialog([]byte(echoedTask)) {
+		t.Fatal("precondition changed: the echoed task no longer matches " +
+			"trustDialogMarker — if the marker got stricter, this guard may be " +
+			"redundant, but verify before deleting composerReady")
+	}
+
+	// On an already-trusted spawn the composer is up and the task is echoed
+	// beneath it. composerReady must gate the hook off before the marker fires.
+	screen := "  → Plan, search, build anything\n\n  " + echoedTask + "\n"
+	if !composerReady([]byte(screen)) {
+		t.Error("composerReady must detect the rendered composer and stop the " +
+			"hook from typing into it")
+	}
+
+	// And with the real dialog up, the hook must still fire.
+	if composerReady([]byte(realDialog)) {
+		t.Error("composerReady must be false while the trust dialog is up")
+	}
+	if !matchesTrustDialog([]byte(realDialog)) {
+		t.Error("the real dialog must still match the marker")
+	}
+}
+
 // TestTrustDialogAcceptIsExplicitAccelerator guards a deliberate divergence
 // from claude/codex, whose hooks send "\r". Cursor's dialog is a two-item menu
 // where Enter selects the highlighted row; if Cursor ever reorders it, "\r"

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -1,6 +1,6 @@
 // Package providers is the registry of agent harness providers: it maps a
-// config provider id ("claude", "codex", "pi", and in future "gemini") to its
-// agent.Provider descriptor.
+// config provider id ("claude", "codex", "pi", "cursor", and in future
+// "gemini") to its agent.Provider descriptor.
 //
 // It lives in its own package — rather than in internal/agent — because
 // resolving an id requires importing the concrete provider packages
@@ -14,22 +14,23 @@ import (
 	"github.com/drellem2/pogo/internal/agent"
 	"github.com/drellem2/pogo/internal/claude"
 	"github.com/drellem2/pogo/internal/codex"
+	"github.com/drellem2/pogo/internal/cursor"
 	"github.com/drellem2/pogo/internal/pi"
 )
 
 // All returns every known harness provider descriptor, in a stable order
-// (claude first, then codex, then pi). pogod registers the whole set into the
+// (claude, codex, pi, cursor). pogod registers the whole set into the
 // agent registry at startup so a provider can be resolved per-spawn — the
 // mixed-fleet capability from mg-b31b — instead of once globally. Use Resolve
 // when mapping a single id; use All when you need the complete set.
 func All() []*agent.Provider {
-	return []*agent.Provider{&claude.Provider, &codex.Provider, &pi.Provider}
+	return []*agent.Provider{&claude.Provider, &codex.Provider, &pi.Provider, &cursor.Provider}
 }
 
 // Resolve maps a config provider id to its agent.Provider descriptor.
 //
 // "" and "claude" resolve to Claude (the default); "codex" resolves to Codex;
-// "pi" resolves to pi.
+// "pi" resolves to pi; "cursor" resolves to the Cursor CLI.
 //
 // ok is false when id names no known provider. The returned *agent.Provider is
 // still safe to use in that case — it is the Claude fallback — so a stale or
@@ -42,6 +43,8 @@ func Resolve(id string) (provider *agent.Provider, ok bool) {
 		return &codex.Provider, true
 	case pi.Provider.ID:
 		return &pi.Provider, true
+	case cursor.Provider.ID:
+		return &cursor.Provider, true
 	default:
 		return &claude.Provider, false
 	}

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -41,9 +41,56 @@ func TestResolvePi(t *testing.T) {
 	}
 }
 
+// TestResolveCursor pins the Cursor id -> descriptor mapping. Note the id and
+// the binary differ: the config key is "cursor", but the CLI command is
+// "agent" (renamed from cursor-agent in 2026).
+func TestResolveCursor(t *testing.T) {
+	p, ok := Resolve("cursor")
+	if !ok {
+		t.Fatal("Resolve(\"cursor\") returned ok=false")
+	}
+	if p == nil || p.ID != "cursor" {
+		t.Fatalf("Resolve(\"cursor\") = %+v, want provider with ID=cursor", p)
+	}
+	if p.Binary != "agent" {
+		t.Errorf("cursor provider Binary = %q, want %q", p.Binary, "agent")
+	}
+}
+
+// TestAllProvidersHaveDistinctIDs guards the Resolve switch: two providers
+// sharing an ID would make one of them unreachable by config.
+func TestAllProvidersHaveDistinctIDs(t *testing.T) {
+	seen := map[string]bool{}
+	for _, p := range All() {
+		if p == nil {
+			t.Fatal("All() contains a nil provider")
+		}
+		if seen[p.ID] {
+			t.Errorf("duplicate provider ID %q in All()", p.ID)
+		}
+		seen[p.ID] = true
+	}
+}
+
+// TestAllProvidersResolveByID keeps All() and Resolve() in lockstep: every
+// descriptor All() advertises must be reachable through the config id, and
+// Resolve must hand back that exact descriptor pointer.
+func TestAllProvidersResolveByID(t *testing.T) {
+	for _, p := range All() {
+		got, ok := Resolve(p.ID)
+		if !ok {
+			t.Errorf("Resolve(%q) returned ok=false, but %q is in All()", p.ID, p.ID)
+			continue
+		}
+		if got != p {
+			t.Errorf("Resolve(%q) = %p, want the All() descriptor %p", p.ID, got, p)
+		}
+	}
+}
+
 func TestAllContainsEveryProvider(t *testing.T) {
 	all := All()
-	want := []string{"claude", "codex", "pi"}
+	want := []string{"claude", "codex", "pi", "cursor"}
 	if len(all) != len(want) {
 		t.Fatalf("All() returned %d providers, want %d", len(all), len(want))
 	}


### PR DESCRIPTION
Adds `internal/cursor/provider.go` as pogo's fourth harness provider, built to the `internal/pi` template (descriptor + calibration doc + e2e). Selection is via the existing `[agents] provider` config — no config-surface change.

Every value in the descriptor was measured against a live, authenticated **Cursor CLI 2026.07.09-a3815c0** in a 200×50 PTY. Full evidence: `docs/investigations/cursor-nudge-calibration.md`.

## The ticket's open question is resolved — no architect consult needed

**Wrinkle 1** asked whether `.cursor/rules`-in-worktree is a viable escape hatch for the `AGENTS.md` collision. **It is**, with one non-obvious constraint.

Cursor has no `--append-system-prompt` (the only prompt-ish flag on the CLI is `--no-prompt`) and no `AGENTS.override.md`-style precedence file, so a separate rules namespace is the *only* additive injection point. The persona goes to `.cursor/rules/pogo-persona.mdc`.

The constraint: **frontmatter is mandatory, and its absence fails silently.** A behavioural probe (repo `AGENTS.md` and the pogo rule each instructing a distinct token; the model asked only to "greet me", never to read files), 3 runs per variant:

| `.mdc` frontmatter | Persona injected |
|---|---|
| *(none)* | **0/3** — silently ignored |
| `alwaysApply: false` | 3/3, but attachment is the *model's* decision, not a contract |
| `alwaysApply: true` | **3/3** — Cursor's documented "Always" rule type |

A plain copy — what `writeContextFilePrompt` did before this PR — would have delivered **nothing**, quietly. Collision verified absent: with both files present a single reply carried both tokens, and `AGENTS.md` was byte-identical afterwards.

> Methodological note recorded in the doc: an earlier probe asked the model to "list every marker in your rules/context" and **all three variants passed** — Cursor has file-read tools and simply grepped the worktree. A context-file injection test that lets the agent read the file under test proves nothing.

## Other measured findings that shaped the descriptor

- **Workspace trust needs a `PostSpawnHook`.** `--force` governs command approval, not trust; `--trust` is *rejected* outside `--print` (`Error: --trust can only be used with --print/headless mode`) and the process exits before the TUI renders. So the template is `agent --force` and `TrustDialogHook` dismisses the dialog. It presses **`a`**, not Enter — Enter selects the *highlighted* row, and a future menu reorder would select `[q] Quit` and silently kill every polecat.
- **`SubmitDelay` is load-bearing here, unlike pi's.** Cursor's composer has paste-burst detection: a combined `body+"\r"` write does **not** submit (probe timed out at 95s); a 50ms split write does.
- **Initial task via argv.** `agent [prompt...]` survives the trust dialog (3/3). A typed nudge would race a modal that is dead silent once drawn — the same trap that made Codex's nudge type its task into the trust dialog.

## Scope deviation, flagged

The ticket asked for an *offline* e2e per pi's pattern. **That is not possible for Cursor** and the PR does not pretend otherwise. pi's rig works because pi supports custom OpenAI-compatible providers; Cursor is closed-source SaaS speaking proprietary connectrpc/protobuf to `api2.cursor.sh`, and the one base-URL override in the bundle (`CURSOR_API_BASE_URL`) fronts the *auth-poll* endpoint, not the chat transport.

So the split is:
- **`integration_test.go` — ungated, offline, no binary.** Drives the real `Registry.Spawn` with a stub binary to pin the on-disk contract (frontmatter written, nested dir created, repo `AGENTS.md` untouched, re-delivery doesn't double the header). Runs in the refinery gates and CI.
- **`e2e_test.go` — opt-in, live** (`POGO_CURSOR_E2E=1`), following the **Codex** pattern. Byte-level request capture is unavailable, so persona delivery is asserted *behaviourally*: the persona and the repo's `AGENTS.md` each instruct a token, and the reply must carry both.

No CI job, matching Codex — GitHub CI has no Cursor account and the tests spend plan credits.

## Shared-code change

`agent.writeContextFilePrompt` gained `MkdirAll` of the context file's parent (`.cursor/rules/` doesn't exist in a fresh worktree; the bare `os.WriteFile` returned `ENOENT` and failed the spawn) and a new opt-in `PromptInjection.ContextFileHeader`. Codex leaves it empty and its `AGENTS.override.md` is written byte-for-byte as before.

## Verification

All three live tests pass against the real CLI on this box:

```
POGO_CURSOR_E2E=1 go test ./internal/cursor/ -run TestCursor -v
  PASS TestCursorEndToEnd (26.27s)          # trust hook fired; both tokens in reply;
                                            # composer settled 0 bytes; nudge -> 2nd turn
  PASS TestCursorHeadless (5.80s)
  PASS TestCursorRejectsTrustFlagInTUI (0.80s)
```

`./build.sh` and `./test.sh` green.

## Out of scope, noted for a follow-up

The persona lands as an untracked file in the polecat's worktree, so `git add -A` would commit it. **Not new** — Codex's `AGENTS.override.md` has the same posture today and neither is gitignored. Not fixed here.

## Provenance

This ticket has **no `gh:` issue ref and no `depends` chain** — it originated from a Daniel Apple Reminder (2026-07-10: *"cursor is installed and logged in now… please get this done"*), resumed after the mg-3e7c pi prerequisite landed. There is therefore no GitHub issue to close and no review ticket named in the body; dispatching a reviewer is the coordinator's call.

Work item: mg-c146