### PR TITLE
build: polecat mail-check auto-register hardening

### DIFF
--- a/cmd/pogod/mailcheck_test.go
+++ b/cmd/pogod/mailcheck_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -65,5 +66,63 @@ func TestMailCheckRegistrar_RegisterAndReap(t *testing.T) {
 	}
 	if got := len(s.List("")); got != 0 {
 		t.Fatalf("%d schedules left after reap, want 0", got)
+	}
+}
+
+// TestMailCheckRegistrar_HappyPathNoEscalation verifies the verify-after-register
+// success path (mg-6fe0): a registration that persists and verifies present
+// returns nil and does NOT escalate to the mayor.
+func TestMailCheckRegistrar_HappyPathNoEscalation(t *testing.T) {
+	s, err := scheduler.New(filepath.Join(t.TempDir(), "schedules.json"), nil)
+	if err != nil {
+		t.Fatalf("scheduler.New: %v", err)
+	}
+	var escalated int
+	m := mailCheckRegistrar{sched: s, escalate: func(string, string) { escalated++ }}
+
+	if err := m.RegisterMailCheck("pc-ok", "wi-ok", "*/10 * * * *", "check your mail"); err != nil {
+		t.Fatalf("RegisterMailCheck: %v", err)
+	}
+	if escalated != 0 {
+		t.Errorf("escalate called %d times on the happy path, want 0", escalated)
+	}
+	if _, ok := s.Get("pc-ok", scheduler.MailCheckIDPrefix+"wi-ok"); !ok {
+		t.Errorf("entry not present after a successful RegisterMailCheck")
+	}
+}
+
+// TestMailCheckRegistrar_PersistentFailureEscalates verifies the persistent
+// post-retry path (mg-6fe0): when the scheduler cannot persist (its state dir is
+// read-only, so every Add fails), RegisterMailCheck retries once, then escalates
+// to the mayor and returns the error — a live polecat left with no reachability
+// channel must be loud, not silent.
+func TestMailCheckRegistrar_PersistentFailureEscalates(t *testing.T) {
+	dir := t.TempDir()
+	s, err := scheduler.New(filepath.Join(dir, "schedules.json"), nil)
+	if err != nil {
+		t.Fatalf("scheduler.New: %v", err)
+	}
+
+	// Make the state dir read-only so the store's temp-file+rename save fails on
+	// every Add. Restore perms on cleanup so t.TempDir can remove it.
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	var escalations []string
+	m := mailCheckRegistrar{sched: s, escalate: func(agentName, scheduleID string) {
+		escalations = append(escalations, agentName+"/"+scheduleID)
+	}}
+
+	err = m.RegisterMailCheck("pc-dark", "wi-dark", "*/10 * * * *", "check your mail")
+	if err == nil {
+		t.Fatal("RegisterMailCheck returned nil, want a persistent-failure error")
+	}
+	if len(escalations) != 1 {
+		t.Fatalf("escalate called %d times, want exactly 1: %v", len(escalations), escalations)
+	}
+	if want := "pc-dark/" + scheduler.MailCheckIDPrefix + "wi-dark"; escalations[0] != want {
+		t.Errorf("escalation = %q, want %q", escalations[0], want)
 	}
 }

--- a/cmd/pogod/main.go
+++ b/cmd/pogod/main.go
@@ -145,21 +145,81 @@ func (p schedulePauser) RestoreForAgent(entries []json.RawMessage) (int, error) 
 // (RemoveMailChecksForAgent) matches on exit — with a mail-check-<id> schedule
 // id so the scheduler's stale-entry sweep leaves it alone (mg-8e5d). Replay
 // policy "once" and nudge delivery mirror the crew-agent mail-check convention.
-type mailCheckRegistrar struct{ sched *scheduler.Scheduler }
+type mailCheckRegistrar struct {
+	sched *scheduler.Scheduler
+	// escalate, when set, nudges the mayor that a live polecat was left with no
+	// mail-check reachability channel after verify+retry both failed. nil
+	// disables escalation (tests). Called ONLY on the persistent post-retry
+	// path — never for the benign startup nil-registrar (mg-6fe0).
+	escalate func(agentName, scheduleID string)
+}
 
+// RegisterMailCheck adds the polecat's mail-check schedule, then VERIFIES it
+// actually persisted and retries ONCE if not. A mail-check loop is a polecat's
+// primary reachability channel, so "best-effort" is the wrong contract:
+// Scheduler.Add's persist is a disk write that can transiently fail, and a
+// silent drop leaves a live worker unreachable. The verify+retry recovers that
+// transient persist-IO suspect; on a persistent failure it escalates to the
+// mayor (a live polecat going dark) and returns the error so the agent layer
+// records schedule_register_failed telemetry. It CANNOT recover a nil
+// registrar — that path never reaches here, it is handled a layer up (mg-6fe0).
 func (m mailCheckRegistrar) RegisterMailCheck(agentName, workItemID, cron, message string) error {
 	if m.sched == nil {
 		return nil
 	}
-	_, err := m.sched.Add(scheduler.Entry{
+	scheduleID := scheduler.MailCheckIDPrefix + workItemID
+	entry := scheduler.Entry{
 		Agent:        agentName,
-		ID:           scheduler.MailCheckIDPrefix + workItemID,
+		ID:           scheduleID,
 		Cron:         cron,
 		ReplayPolicy: scheduler.ReplayOnce,
 		Delivery:     scheduler.DeliveryNudge,
 		Message:      message,
-	}, time.Now())
+	}
+
+	err := m.addAndVerify(entry, agentName, scheduleID)
+	if err == nil {
+		return nil
+	}
+	// Retry once — recovers a transient persist-IO failure (Add rolls its own
+	// memory state back on a persist error, so the retry re-adds cleanly).
+	if err = m.addAndVerify(entry, agentName, scheduleID); err == nil {
+		return nil
+	}
+
+	// Persistent after retry: a live polecat with no reachability channel.
+	// Escalate to the mayor so a human/coordinator can intervene.
+	if m.escalate != nil {
+		m.escalate(agentName, scheduleID)
+	}
 	return err
+}
+
+// addAndVerify performs one Add followed by a Get to confirm the entry is
+// actually present afterward (Add reports persist errors, but a defensive Get
+// also catches a lost write / concurrent reap). Returns nil only when the entry
+// is verified present.
+func (m mailCheckRegistrar) addAndVerify(entry scheduler.Entry, agentName, scheduleID string) error {
+	if _, err := m.sched.Add(entry, time.Now()); err != nil {
+		return err
+	}
+	if _, ok := m.sched.Get(agentName, scheduleID); !ok {
+		return fmt.Errorf("mail-check schedule %s for %s absent after Add", scheduleID, agentName)
+	}
+	return nil
+}
+
+// scheduleRegisterFailureReporter implements agent.ScheduleRegisterFailureReporter
+// by writing schedule_register_failed telemetry to the scheduler's own-root
+// events.log (logPath). It is wired EVEN WHEN scheduler.New fails — its whole
+// reason to exist is to make the startup nil-registrar drop loud — so it carries
+// the resolved own-root path directly rather than a *Scheduler (which may not
+// exist). Event-only: escalation to the mayor is the registrar adapter's job on
+// the persistent post-retry path, not this reporter's (mg-6fe0).
+type scheduleRegisterFailureReporter struct{ logPath string }
+
+func (r scheduleRegisterFailureReporter) ReportScheduleRegisterFailed(agentName, mailbox, reason string) {
+	scheduler.EmitScheduleRegisterFailedTo(r.logPath, agentName, scheduler.MailCheckIDPrefix+mailbox, reason)
 }
 
 // schedulerStallWindows implements agent.StallScheduleProvider against the
@@ -576,6 +636,34 @@ func newStallNudger(reg *agent.Registry, mail func(to, from, subject, body strin
 	}
 }
 
+// newMailCheckReachabilityEscalator builds the mayor-nudge fired when a
+// polecat's mail-check schedule could not be registered even after
+// verify+retry (mg-6fe0). A live polecat with no mail-check loop has no
+// proactive reachability channel — it will miss reviewer findings and
+// re-review requests that drive the modify<->review loop — so this is a
+// coordination alert, not a cosmetic one. Delivery mirrors newStallNudger:
+// wait-idle PTY nudge when the mayor is running (never interrupts a busy turn),
+// durable macguffin mail otherwise so the signal survives an offline mayor.
+func newMailCheckReachabilityEscalator(reg *agent.Registry, coordinator string) func(agentName, scheduleID string) {
+	return func(agentName, scheduleID string) {
+		msg := fmt.Sprintf(
+			"reachability alert: polecat %s could not register its mail-check schedule %s after verify+retry — "+
+				"it has NO proactive mail channel and may miss reviewer findings / re-review requests. "+
+				"Re-register it (`pogo schedule %s --cron \"*/10 * * * *\" --id %s ...`) or restart it.",
+			agentName, scheduleID, agentName, scheduleID)
+		if reg != nil {
+			if a := reg.Get(coordinator); a != nil && a.Status == agent.StatusRunning {
+				if err := a.NudgeWithMode(msg, agent.NudgeWaitIdle, agent.DefaultNudgeTimeout); err == nil {
+					return
+				}
+			}
+		}
+		if err := client.SendMGMail(coordinator, "pogod", "polecat reachability alert", msg); err != nil {
+			log.Printf("pogod: mail-check reachability escalation to %s failed: %v", coordinator, err)
+		}
+	}
+}
+
 // newStartVerifier builds the post-spawn start-verification query for the
 // auto-renudge watcher (mg-feb3). It reports a polecat as "started" once its mg
 // work item has left the available/ queue — the item's presence in available/
@@ -867,6 +955,15 @@ Flags:
 	if err != nil {
 		log.Printf("pogod: scheduler disabled (cannot resolve home dir): %v", err)
 	} else {
+		// Wire the schedule-register failure reporter FIRST, independent of
+		// whether the scheduler below actually loads. If scheduler.New fails, the
+		// mail-check registrar is never installed and every polecat spawn takes
+		// the nil-registrar path — the startup suspect this telemetry exists to
+		// surface (mg-6fe0). The reporter targets the scheduler's own-root
+		// events.log, resolvable from schedPath even without a live *Scheduler.
+		agentRegistry.SetScheduleRegisterFailureReporter(
+			scheduleRegisterFailureReporter{logPath: scheduler.EventLogPath(schedPath)})
+
 		deliverer := &scheduler.PogodDeliverer{
 			Registry: agentRegistry,
 			Mail:     client.SendMGMail,
@@ -888,7 +985,13 @@ Flags:
 			agentRegistry.SetSchedulePauser(schedulePauser{sched: s})
 			// Auto-register a polecat's mail-check loop at spawn so review
 			// loops round-trip without manual schedule registration (mg-e633).
-			agentRegistry.SetMailCheckRegistrar(mailCheckRegistrar{sched: s})
+			// On a persistent registration failure (verify+retry both failed),
+			// escalate to the mayor: a live polecat with no reachability channel
+			// is a coordination problem, not a cosmetic one (mg-6fe0).
+			agentRegistry.SetMailCheckRegistrar(mailCheckRegistrar{
+				sched:    s,
+				escalate: newMailCheckReachabilityEscalator(agentRegistry, coordinator),
+			})
 			log.Printf("pogod: scheduler loaded from %s", schedPath)
 		}
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -358,6 +358,13 @@ type Registry struct {
 	// scheduler disabled) makes spawn skip registration.
 	mailCheckRegistrar MailCheckRegistrar
 
+	// scheduleRegisterFailureReporter, when set, emits schedule_register_failed
+	// telemetry when a polecat's mail-check loop could not be registered —
+	// including when mailCheckRegistrar itself is nil (scheduler failed to load
+	// at startup). Wired independently of the registrar so the nil-registrar
+	// drop is still made loud (mg-6fe0). nil falls back to a log line.
+	scheduleRegisterFailureReporter ScheduleRegisterFailureReporter
+
 	// startVerifier, when set, reports whether a freshly spawned polecat has
 	// actually begun its work (claimed its mg work item) — the HARD
 	// started-signal the post-spawn auto-renudge watcher gates on (mg-feb3).

--- a/internal/agent/mailcheck.go
+++ b/internal/agent/mailcheck.go
@@ -52,6 +52,30 @@ type MailCheckRegistrar interface {
 	RegisterMailCheck(agentName, workItemID, cron, message string) error
 }
 
+// ScheduleRegisterFailureReporter emits structured schedule_register_failed
+// telemetry when a polecat's mail-check loop could not be registered. It is
+// deliberately SEPARATE from MailCheckRegistrar for one reason: the registrar
+// can itself be nil — pogod installs it only after its scheduler loads, so a
+// scheduler that fails to load at startup leaves every polecat spawn on the
+// nil-registrar path (mailcheck.go's `reg == nil`). That drop — a live polecat
+// with no reachability channel — is exactly the case that most needs a LOUD,
+// structured signal, yet the registrar that would carry it is absent. Wiring
+// the reporter independently of the registrar is what lets the failure still be
+// recorded when the registrar is gone.
+//
+// Event-ONLY: a nil registrar at startup is benign (bare registry in tests, or
+// a daemon with the scheduler disabled), so it must NOT escalate to a mayor
+// nudge — that noise is reserved for the persistent post-retry Add-failure
+// path, which the registrar adapter owns (mg-6fe0).
+type ScheduleRegisterFailureReporter interface {
+	// ReportScheduleRegisterFailed records that a polecat's mail-check schedule
+	// could not be registered. mailbox is the schedule-id key (the work item id,
+	// or the agent name when the spawn carried none); reason is a short,
+	// machine-stable cause so a reader can tell the two live suspects apart (a
+	// benign startup nil registrar vs. a transient persist-IO failure).
+	ReportScheduleRegisterFailed(agentName, mailbox, reason string)
+}
+
 // SetMailCheckRegistrar installs the scheduler adapter used by spawn-polecat to
 // auto-register a polecat's mail-check loop. Call once at startup before any
 // polecat is spawned. A nil registrar disables auto-registration.
@@ -67,21 +91,61 @@ func (r *Registry) getMailCheckRegistrar() MailCheckRegistrar {
 	return r.mailCheckRegistrar
 }
 
-// registerPolecatMailCheck best-effort registers the mail-check loop for a
-// freshly spawned polecat. workItemID falls back to the agent name when the
-// spawn carried no work item id, so every polecat gets a specific,
-// reap-matchable schedule id. Failure is logged, never fatal: the polecat is
-// already running and a missing mail-check only degrades proactive reachability.
-func (r *Registry) registerPolecatMailCheck(agentName, workItemID string) {
-	reg := r.getMailCheckRegistrar()
-	if reg == nil {
+// SetScheduleRegisterFailureReporter installs the reporter used to emit
+// schedule_register_failed telemetry. Call once at startup — critically, wire it
+// EVEN WHEN the scheduler (and therefore the mail-check registrar) fails to
+// load, so the startup nil-registrar drop still produces a structured signal.
+// A nil reporter falls back to a plain log line (see reportScheduleRegisterFailed).
+func (r *Registry) SetScheduleRegisterFailureReporter(rep ScheduleRegisterFailureReporter) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.scheduleRegisterFailureReporter = rep
+}
+
+func (r *Registry) reportScheduleRegisterFailed(agentName, mailbox, reason string) {
+	r.mu.RLock()
+	rep := r.scheduleRegisterFailureReporter
+	r.mu.RUnlock()
+	if rep == nil {
+		// No reporter wired (a unit test, or pogod could not even resolve the
+		// scheduler root): fall back to a log line so the drop is never fully
+		// silent — the whole point of mg-6fe0 is that this stops being invisible.
+		log.Printf("polecat %s: mail-check schedule registration failed (%s); no failure reporter wired", agentName, reason)
 		return
 	}
+	rep.ReportScheduleRegisterFailed(agentName, mailbox, reason)
+}
+
+// registerPolecatMailCheck registers the mail-check loop for a freshly spawned
+// polecat. workItemID falls back to the agent name when the spawn carried no
+// work item id, so every polecat gets a specific, reap-matchable schedule id.
+//
+// Registration stays NON-fatal to the spawn (the polecat is already running),
+// but it is no longer best-effort-and-silent: a mail-check loop is a polecat's
+// PRIMARY reachability channel — the modify<->review loop is driven by it — so a
+// drop is a reliability event, not a cosmetic one. Both failure paths are made
+// LOUD via schedule_register_failed telemetry (mg-6fe0):
+//
+//   - nil registrar: pogod's scheduler failed to load, so SetMailCheckRegistrar
+//     was never called. Event-only — this is a benign startup condition and the
+//     registrar is nil synchronously here, so there is nothing to retry and a
+//     mayor nudge would be pure noise.
+//   - RegisterMailCheck error: the adapter already ran verify-after-register +
+//     retry-once (recovering the transient persist-IO suspect) and escalated to
+//     the mayor before returning; a non-nil error here means the entry is
+//     genuinely absent after that. Record it so the telemetry is complete.
+func (r *Registry) registerPolecatMailCheck(agentName, workItemID string) {
 	mailbox := workItemID
 	if mailbox == "" {
 		mailbox = agentName
 	}
+	reg := r.getMailCheckRegistrar()
+	if reg == nil {
+		r.reportScheduleRegisterFailed(agentName, mailbox, "nil_registrar")
+		return
+	}
 	if err := reg.RegisterMailCheck(agentName, mailbox, PolecatMailCheckCron, PolecatMailCheckMessage(mailbox)); err != nil {
-		log.Printf("polecat %s: mail-check schedule registration failed: %v", agentName, err)
+		log.Printf("polecat %s: mail-check schedule registration failed after verify+retry: %v", agentName, err)
+		r.reportScheduleRegisterFailed(agentName, mailbox, "register_error: "+err.Error())
 	}
 }

--- a/internal/agent/mailcheck_test.go
+++ b/internal/agent/mailcheck_test.go
@@ -32,6 +32,30 @@ func (f *fakeMailCheckRegistrar) recorded() []mailCheckCall {
 	return append([]mailCheckCall(nil), f.calls...)
 }
 
+// fakeScheduleFailureReporter records ReportScheduleRegisterFailed calls so
+// tests can assert that a failed mail-check registration is made LOUD (mg-6fe0)
+// while the spawn itself stays non-fatal.
+type fakeScheduleFailureReporter struct {
+	mu    sync.Mutex
+	calls []scheduleFailure
+}
+
+type scheduleFailure struct {
+	agent, mailbox, reason string
+}
+
+func (f *fakeScheduleFailureReporter) ReportScheduleRegisterFailed(agentName, mailbox, reason string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, scheduleFailure{agentName, mailbox, reason})
+}
+
+func (f *fakeScheduleFailureReporter) recorded() []scheduleFailure {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]scheduleFailure(nil), f.calls...)
+}
+
 // TestSpawnPolecatRegistersMailCheck locks in the mg-e633 fix: spawning a
 // polecat auto-registers its mail-check loop, addressed to the polecat's bare
 // registry name (the identity pogod delivers nudges to and reaps under) with a
@@ -115,9 +139,10 @@ func TestSpawnPolecatMailCheckFallsBackToName(t *testing.T) {
 }
 
 // TestSpawnPolecatMailCheckFailureNonFatal verifies that a mail-check
-// registration error does not fail the spawn: the polecat is already running,
-// so a missing mail-check only degrades reachability, it must not kill the
-// worker.
+// registration error does not fail the spawn (the polecat is already running,
+// so a missing mail-check only degrades reachability) AND that it is no longer
+// silent: the failure is reported as schedule_register_failed telemetry —
+// louder, but still non-fatal (mg-6fe0).
 func TestSpawnPolecatMailCheckFailureNonFatal(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
@@ -132,6 +157,8 @@ func TestSpawnPolecatMailCheckFailureNonFatal(t *testing.T) {
 	reg.SetCommandConfig(catCommandConfig{})
 
 	reg.SetMailCheckRegistrar(&fakeMailCheckRegistrar{err: errRegistrarBoom})
+	reporter := &fakeScheduleFailureReporter{}
+	reg.SetScheduleRegisterFailureReporter(reporter)
 
 	// spawnPolecatViaAPI already asserts a 201; reaching here means the spawn
 	// succeeded despite the registrar error.
@@ -142,6 +169,69 @@ func TestSpawnPolecatMailCheckFailureNonFatal(t *testing.T) {
 	})
 	if a == nil {
 		t.Fatal("expected polecat to spawn despite mail-check registration failure")
+	}
+
+	// Louder: the registrar error must surface as a schedule_register_failed
+	// report keyed on the work item, carrying a register_error reason.
+	calls := reporter.recorded()
+	if len(calls) != 1 {
+		t.Fatalf("ReportScheduleRegisterFailed called %d times, want 1: %+v", len(calls), calls)
+	}
+	if calls[0].agent != "pc-err" {
+		t.Errorf("report agent = %q, want %q", calls[0].agent, "pc-err")
+	}
+	if calls[0].mailbox != "wi-err" {
+		t.Errorf("report mailbox = %q, want %q", calls[0].mailbox, "wi-err")
+	}
+	if !strings.HasPrefix(calls[0].reason, "register_error:") {
+		t.Errorf("report reason = %q, want a register_error: prefix", calls[0].reason)
+	}
+	if !strings.Contains(calls[0].reason, errRegistrarBoom.Error()) {
+		t.Errorf("report reason = %q, want it to carry the underlying error %q", calls[0].reason, errRegistrarBoom.Error())
+	}
+}
+
+// TestSpawnPolecatNilRegistrarReportsFailure locks in the load-bearing half of
+// mg-6fe0: when the mail-check registrar is nil (pogod's scheduler failed to
+// load at startup), spawn must not silently drop the mail-check loop — it emits
+// a schedule_register_failed report with reason "nil_registrar", event-only,
+// while the spawn stays non-fatal.
+func TestSpawnPolecatNilRegistrarReportsFailure(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	writeTemplate(t, "nilregpc", "# polecat\nbody {{.Id}}\n")
+
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+	reg.SetCommandConfig(catCommandConfig{})
+
+	// No SetMailCheckRegistrar — the registrar is nil, mirroring a pogod whose
+	// scheduler failed to load. The reporter IS wired (it is set independently).
+	reporter := &fakeScheduleFailureReporter{}
+	reg.SetScheduleRegisterFailureReporter(reporter)
+
+	a := spawnPolecatViaAPI(t, reg, SpawnPolecatAPIRequest{
+		Name:     "pc-nilreg",
+		Template: "nilregpc",
+		Id:       "wi-nilreg",
+	})
+	if a == nil {
+		t.Fatal("expected polecat to spawn with a nil mail-check registrar")
+	}
+
+	calls := reporter.recorded()
+	if len(calls) != 1 {
+		t.Fatalf("ReportScheduleRegisterFailed called %d times, want 1: %+v", len(calls), calls)
+	}
+	if calls[0].reason != "nil_registrar" {
+		t.Errorf("report reason = %q, want %q", calls[0].reason, "nil_registrar")
+	}
+	if calls[0].agent != "pc-nilreg" || calls[0].mailbox != "wi-nilreg" {
+		t.Errorf("report = %+v, want agent=pc-nilreg mailbox=wi-nilreg", calls[0])
 	}
 }
 

--- a/internal/scheduler/register_events_test.go
+++ b/internal/scheduler/register_events_test.go
@@ -1,0 +1,76 @@
+package scheduler
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEventLogPath pins the own-root derivation: events.log is the sibling of
+// the schedules.json state file, never a globally-resolved path (mg-e06d).
+func TestEventLogPath(t *testing.T) {
+	got := EventLogPath("/some/root/schedules.json")
+	if want := filepath.Join("/some/root", "events.log"); got != want {
+		t.Errorf("EventLogPath = %q, want %q", got, want)
+	}
+}
+
+// TestEmitScheduleRegisterFailedTo verifies the emitter writes a
+// schedule_register_failed event, with the agent/schedule-id/reason fields, to
+// the exact own-root log it is handed — the path a scheduler-less pogod
+// (scheduler.New failed) still uses to make the startup nil-registrar drop loud
+// (mg-6fe0).
+func TestEmitScheduleRegisterFailedTo(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "events.log")
+
+	EmitScheduleRegisterFailedTo(logPath, "pc-77", MailCheckIDPrefix+"wi-77", "nil_registrar")
+
+	ev := findScheduleRegisterFailed(t, logPath, MailCheckIDPrefix+"wi-77")
+	if ev == nil {
+		t.Fatalf("no schedule_register_failed event in %s", logPath)
+	}
+	d, _ := ev["details"].(map[string]any)
+	if d == nil {
+		t.Fatalf("event has no details: %+v", ev)
+	}
+	if d["agent"] != "pc-77" {
+		t.Errorf("details.agent = %v, want pc-77", d["agent"])
+	}
+	if d["reason"] != "nil_registrar" {
+		t.Errorf("details.reason = %v, want nil_registrar", d["reason"])
+	}
+	if ev["agent"] != "pogod" {
+		t.Errorf("event agent = %v, want pogod", ev["agent"])
+	}
+}
+
+func findScheduleRegisterFailed(t *testing.T, path, scheduleID string) map[string]any {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open events.log: %v", err)
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		var m map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if m["event_type"] != "schedule_register_failed" {
+			continue
+		}
+		d, _ := m["details"].(map[string]any)
+		if d != nil && d["schedule_id"] == scheduleID {
+			return m
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan events.log: %v", err)
+	}
+	return nil
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -268,7 +268,7 @@ func New(path string, deliverer Deliverer) (*Scheduler, error) {
 	s := &Scheduler{
 		store:     st,
 		deliverer: deliverer,
-		logPath:   filepath.Join(filepath.Dir(path), "events.log"),
+		logPath:   EventLogPath(path),
 		entries:   make(map[entryKey]*Entry, len(loaded)),
 	}
 	for _, e := range loaded {
@@ -765,5 +765,43 @@ func (s *Scheduler) emitSchedulerRemovalEvent(reason string, e Entry, removedAt 
 		EventType: "schedule_removed",
 		Agent:     "pogod",
 		Details:   details,
+	})
+}
+
+// EventLogPath returns the own-root events.log path for a scheduler whose state
+// file lives at schedulesPath (events.log is its sibling under POGO_HOME). New
+// derives s.logPath from this, and it is exported so a caller that holds the
+// scheduler root but not a live *Scheduler — pogod when scheduler.New failed to
+// load — can still address the same own-root log. Keeping the derivation in one
+// place is what stops a library from writing to the operator's global
+// ~/.pogo/events.log merely because of the caller it was linked into (mg-e06d).
+func EventLogPath(schedulesPath string) string {
+	return filepath.Join(filepath.Dir(schedulesPath), "events.log")
+}
+
+// EmitScheduleRegisterFailedTo writes a schedule_register_failed event to
+// logPath (an own-root events.log, see EventLogPath). It records that a
+// per-agent schedule could not be registered — a load-bearing signal because a
+// polecat's mail-check loop is its PRIMARY reachability channel, so a silent
+// drop leaves a live worker unreachable with no telemetry (mg-6fe0). Written
+// here alongside emitSchedulerRemovalEvent so all scheduler observability shares
+// one own-root emit path.
+//
+// This is a package function taking logPath rather than a *Scheduler method on
+// purpose: the load-bearing case is the STARTUP nil-registrar (scheduler.New
+// failed, so there is no *Scheduler to hang a method on), yet the failure still
+// needs to be loud. The reason field is a short, machine-stable cause
+// ("nil_registrar", "register_error: ...") so a reader can tell the two live
+// suspects apart — a benign startup nil registrar vs. a transient persist-IO
+// failure that survived verify+retry.
+func EmitScheduleRegisterFailedTo(logPath, agent, scheduleID, reason string) {
+	events.EmitTo(context.Background(), logPath, events.Event{
+		EventType: "schedule_register_failed",
+		Agent:     "pogod",
+		Details: map[string]any{
+			"agent":       agent,
+			"schedule_id": scheduleID,
+			"reason":      reason,
+		},
 	})
 }


### PR DESCRIPTION
Hardens `registerPolecatMailCheck` so a polecat's mail-check loop — its **primary reachability channel**, which drives the modify↔review loop — is no longer registered best-effort-and-silent. Two distinct suspects, two distinct mechanisms (per the approved triage spec, mg-6fe0):

**1. LOUD ALWAYS (load-bearing).** Emit a structured `schedule_register_failed` event (fields: `agent`, `schedule_id`, `reason`) on **both** the register-error path and the previously-silent nil-registrar no-op. Written via the scheduler's **own-root** event path (`scheduler.EmitScheduleRegisterFailedTo`), never the global `events.log` (mg-e06d). The failure reporter is wired into the agent registry **independently of the mail-check registrar**, so it still fires when the registrar is nil — i.e. when pogod's scheduler failed to load at startup and `SetMailCheckRegistrar` was never called.

**2. VERIFY-AFTER-REGISTER + retry-once.** The pogod `mailCheckRegistrar` adapter confirms the `(agent, mail-check-<id>)` entry via `Scheduler.Get` after `Add`, and retries **once** if absent. This recovers the transient persist-IO suspect. It cannot fix nil-registrar (the registrar is nil synchronously in the same call) — that path is covered **solely** by event emission.

**3. ESCALATE to a mayor nudge ONLY on the persistent post-retry failure** (a live polecat left with no reachability channel). The benign startup nil-registrar is event-only — **no** nudge (noise).

Distinct `reason` values (`nil_registrar` vs `register_error: ...`) keep a reader from mis-reading the telemetry as retry having caught a nil registrar — two suspects, two mechanisms.

**Non-fatal to spawn throughout** — registration failure never kills a running polecat.

### Affected areas
- `internal/agent/mailcheck.go` — `ScheduleRegisterFailureReporter` interface + wiring; reworked `registerPolecatMailCheck`.
- `internal/agent/agent.go` — reporter field on `Registry`.
- `internal/scheduler/scheduler.go` — `schedule_register_failed` emitter + `EventLogPath` helper (own-root path), alongside `emitSchedulerRemovalEvent`.
- `cmd/pogod/main.go` — adapter verify+retry, mayor escalator, own-root reporter wired even when the scheduler fails to load.
- Tests: `internal/agent/mailcheck_test.go` (louder-but-still-non-fatal; new nil-registrar case), `cmd/pogod/mailcheck_test.go` (happy-path no-escalation; persistent-failure escalates), `internal/scheduler/register_events_test.go` (emitter + own-root path).

Full `./build.sh` gate green; affected packages clean under `-race`.

Resolves drellem2/pogo#83

Approved triage recommendation: mg-6fe0 (IMPLEMENT / bug — reliability+observability hardening)
Work item: mg-75d9