### PR TITLE
build: refinery --defer-done + bounded backstop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ is the curated, human-readable summary kept in sync at each release cut.
 
 ## [Unreleased]
 
+### Added
+
+- **`pogo refinery submit --defer-done` + bounded backstop (gh drellem2/pogo#81).**
+  By default, the instant a polecat's branch merges pogod records the work item
+  done and stops the polecat (the gh #35 event-driven stop). For a `--branch`
+  (PR-flow) polecat that still has post-merge work — open the PR, run verify
+  checks, mail the PR URL — that stop lands mid-flow and the PR is never opened.
+  `--defer-done` makes the polecat **own its own lifecycle**: pogod skips the
+  auto-done/auto-stop at merge, and the polecat calls `mg done` itself once its
+  full flow finishes. To keep the swap from trading a silent KILL for a silent
+  LINGER (which would regress the gh #34/#35 slot-protection guarantees), a
+  **bounded backstop** arms when a deferred polecat merges — if it never ends its
+  lifecycle within the window (15m), pogod reaps the lingering process and
+  escalates to the mayor. A clean exit disarms the backstop via pogod's OnExit
+  hook. Default (non-defer) submits are unchanged.
+
 ### Fixed
 
 - **Concurrent-spawn init-stall self-heal (mg-feb3, gh drellem2/macguffin#24).**

--- a/cmd/pogo/main.go
+++ b/cmd/pogo/main.go
@@ -2261,6 +2261,7 @@ the actual restart. The recovery agent rate-limits to one kickstart per
 	var submitTarget string
 	var submitAuthor string
 	var submitAutoCreateTarget bool
+	var submitDeferDone bool
 	var cmdRefinerySubmit = &cobra.Command{
 		Use:   "submit <branch>",
 		Short: "Submit a branch to the merge queue",
@@ -2273,6 +2274,14 @@ By default the refinery rejects MRs whose --target ref does not exist on
 origin (catches typos like "fam-45" instead of "feat-45"). Pass
 --auto-create-target to opt into having the refinery create the target ref
 from the repo's default branch when it is missing.
+
+By default, the moment a polecat's branch merges pogod records the work item
+done and stops the polecat. A --branch (PR-flow) polecat that still has
+post-merge work — opening the PR, running verify checks, mailing the PR URL —
+gets killed mid-flow. Pass --defer-done to make the polecat own its own
+lifecycle: pogod skips the auto-done/auto-stop, and the polecat calls
+'mg done' itself once its full flow finishes. A bounded backstop still reaps
+and escalates a deferred polecat that never completes.
 
 Example:
   pogo refinery submit polecat-a3f --repo=/path/to/repo`,
@@ -2288,6 +2297,7 @@ Example:
 				TargetRef:           submitTarget,
 				Author:              submitAuthor,
 				AutoCreateTargetRef: submitAutoCreateTarget,
+				DeferDone:           submitDeferDone,
 			})
 			if err != nil {
 				cli.ExitWithError(jsonOutput, err.Error(), cli.ExitError)
@@ -2303,6 +2313,7 @@ Example:
 	cmdRefinerySubmit.Flags().StringVar(&submitTarget, "target", "main", "Target ref to merge into")
 	cmdRefinerySubmit.Flags().StringVar(&submitAuthor, "author", "", "Author agent name")
 	cmdRefinerySubmit.Flags().BoolVar(&submitAutoCreateTarget, "auto-create-target", false, "Create the target ref from the repo's default branch if it doesn't exist (off by default; safer to fail loudly on typos)")
+	cmdRefinerySubmit.Flags().BoolVar(&submitDeferDone, "defer-done", false, "Skip pogod's auto-done/auto-stop at merge so the polecat owns its post-merge lifecycle and calls 'mg done' itself (a bounded backstop reaps a deferred polecat that never completes)")
 
 	var cmdRefineryStatus = &cobra.Command{
 		Use:   "status",

--- a/cmd/pogod/main.go
+++ b/cmd/pogod/main.go
@@ -882,7 +882,29 @@ Flags:
 	// type-based defaults: crew=true, polecat=false). This preserves the
 	// historical behavior — crew agents are still restarted, polecats are
 	// still cleaned up — while letting users opt out per-agent.
+	// Bounded backstop for --defer-done polecats (gh #81): when such a polecat
+	// merges, OnMerged skips the auto-done/auto-stop and arms this instead, so
+	// the polecat can finish its own post-merge flow. If it never ends its
+	// lifecycle, the backstop reaps + escalates it — the OnExit hook below
+	// disarms it on a clean exit. Escalation mails the mayor.
+	deferBackstop := newDeferredBackstop(deferDoneBackstopTimeout, agentRegistry, func(mr *refinery.MergeRequest) {
+		subject := fmt.Sprintf("DEFER-DONE BACKSTOP FIRED: polecat %s lingered post-merge", mr.Author)
+		body := fmt.Sprintf("A --defer-done polecat merged but did not complete its lifecycle within %s.\n"+
+			"pogod reaped the lingering process to free its slot (gh #34/#35).\n\n"+
+			"Work item: %s\nBranch: %s\nMR: %s\n\n"+
+			"The polecat never called `mg done` — verify the work item state and re-dispatch if its post-merge flow (PR creation, verify, mail) did not finish.",
+			deferDoneBackstopTimeout, mr.Author, mr.Branch, mr.ID)
+		if err := client.SendMGMail(coordinator, "refinery", subject, body); err != nil {
+			log.Printf("refinery: failed to mail coordinator defer-done backstop escalation: %v", err)
+		}
+	})
+
 	agentRegistry.SetOnExit(func(a *agent.Agent, err error) {
+		// Disarm any defer-done backstop for this polecat: its process has
+		// ended, so the slot is free and there is nothing left to reap (gh #81).
+		// A no-op for the vast majority of agents, which are not --defer-done.
+		deferBackstop.cancel(a.Name)
+
 		if a.ShouldRespawn() {
 			// Restart-on-crash agents: respawn after a short backoff so a
 			// fast crash loop doesn't peg the daemon. The agent stays in
@@ -1108,7 +1130,7 @@ Flags:
 				// for the mayor's next coordination cycle. Run async — the
 				// stop can block up to its SIGTERM timeout and this
 				// callback fires on the refinery loop.
-				go reapMergedPolecat(agentRegistry, mr, client.CompleteMGWorkItem)
+				go reapMergedPolecat(agentRegistry, mr, client.CompleteMGWorkItem, deferBackstop)
 
 				// Mail the coordinator so it can archive the work item and
 				// handle QA. The mayor's reap loop stays as a backstop for

--- a/cmd/pogod/reap.go
+++ b/cmd/pogod/reap.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/drellem2/pogo/internal/agent"
@@ -13,6 +14,16 @@ import (
 // SIGTERMed polecat to exit before force-killing it — same budget as the
 // pogo agent stop HTTP handler.
 const mergedPolecatStopTimeout = 5 * time.Second
+
+// deferDoneBackstopTimeout bounds how long a --defer-done polecat may stay
+// alive after its branch merges before the backstop reaps + escalates it (gh
+// drellem2/pogo #81). It is deliberately generous — a healthy post-merge flow
+// (open PR, verify, mail PR URL, mg done) finishes in well under a minute — so
+// the backstop only fires on a genuinely stuck polecat, never on a slow-but-
+// live one. A deferred polecat that never ends its lifecycle would otherwise
+// hold its slot forever and re-submit its branch, regressing the gh #34/#35
+// slot-protection guarantees the auto-stop path exists to enforce.
+const deferDoneBackstopTimeout = 15 * time.Minute
 
 // polecatReaper is the slice of agent.Registry that reapMergedPolecat needs.
 type polecatReaper interface {
@@ -34,7 +45,7 @@ type polecatReaper interface {
 //
 // Only polecats are stopped: crew agents (or a human) can author MRs too, but
 // their lifecycle is not tied to a single work item.
-func reapMergedPolecat(reg polecatReaper, mr *refinery.MergeRequest, complete func(id, resultJSON string) error) {
+func reapMergedPolecat(reg polecatReaper, mr *refinery.MergeRequest, complete func(id, resultJSON string) error, backstop *deferredBackstop) {
 	if mr.Author == "" {
 		return
 	}
@@ -44,6 +55,22 @@ func reapMergedPolecat(reg polecatReaper, mr *refinery.MergeRequest, complete fu
 	// misses and the polecat lingers post-merge (gh #48).
 	a := reg.GetByWorkItemOrName(mr.Author)
 	if a == nil || a.Type != agent.TypePolecat {
+		return
+	}
+
+	// --defer-done (gh #81): the polecat owns its own post-merge lifecycle. It
+	// still has work to do after the merge lands — open the PR, run verify
+	// checks, mail the PR URL — and calls `mg done` itself when that flow
+	// finishes. Skip the auto-done + auto-stop below, which would kill it
+	// mid-flow (the exact bug #81 fixes), and arm a bounded backstop so a
+	// deferred polecat that never ends its lifecycle is still reaped +
+	// escalated. The backstop is disarmed by the OnExit hook when the polecat's
+	// process ends (it completed cleanly and freed its slot).
+	if mr.DeferDone {
+		log.Printf("refinery: merged polecat %s submitted --defer-done — skipping auto-done/auto-stop; polecat owns its lifecycle (gh #81)", a.Name)
+		if backstop != nil {
+			backstop.arm(a.Name, mr)
+		}
 		return
 	}
 
@@ -67,6 +94,120 @@ func reapMergedPolecat(reg polecatReaper, mr *refinery.MergeRequest, complete fu
 		return
 	}
 	log.Printf("refinery: stopped merged polecat %s (event-driven, gh #35)", a.Name)
+}
+
+// backstopTimer is the subset of *time.Timer the deferred backstop needs. It
+// is an interface so tests can substitute a hand-fired fake and drive both
+// directions of the acceptance control deterministically, without waiting real
+// wall-clock time.
+type backstopTimer interface {
+	Stop() bool
+}
+
+// deferredBackstop is the bounded safety net for --defer-done polecats (gh
+// #81). When a deferred polecat's branch merges, reapMergedPolecat arms a
+// timer here instead of stopping it. Two outcomes:
+//
+//   - The polecat finishes its post-merge flow, calls `mg done`, and its
+//     process ends. pogod's OnExit hook calls cancel(), which disarms the
+//     timer — the clean, common path.
+//   - The polecat never ends its lifecycle. The timer fires after the bounded
+//     window: fire() reaps the still-running process and escalates to the
+//     mayor, so a deferred polecat can never silently LINGER holding its slot
+//     (the gh #34/#35 regression this backstop exists to prevent).
+//
+// All state is guarded by mu; arm/cancel/fire are safe to call concurrently
+// (arm runs on the refinery loop's reap goroutine, cancel on the OnExit hook,
+// fire on the timer goroutine).
+type deferredBackstop struct {
+	mu       sync.Mutex
+	timeout  time.Duration
+	timers   map[string]backstopTimer // keyed by registry name (bare id)
+	reg      polecatReaper
+	escalate func(mr *refinery.MergeRequest)
+
+	// afterFunc schedules f to run after d and returns a stoppable handle.
+	// Defaults to time.AfterFunc; tests inject a fake for deterministic firing.
+	afterFunc func(d time.Duration, f func()) backstopTimer
+}
+
+// newDeferredBackstop builds a backstop that reaps via reg and escalates via
+// the given mailer. escalate may be nil (reap without a mail — the process is
+// still freed).
+func newDeferredBackstop(timeout time.Duration, reg polecatReaper, escalate func(mr *refinery.MergeRequest)) *deferredBackstop {
+	return &deferredBackstop{
+		timeout:   timeout,
+		timers:    make(map[string]backstopTimer),
+		reg:       reg,
+		escalate:  escalate,
+		afterFunc: func(d time.Duration, f func()) backstopTimer { return time.AfterFunc(d, f) },
+	}
+}
+
+// arm starts the bounded backstop for a merged --defer-done polecat. name is
+// the registry name (bare id); mr carries the escalation context. Re-arming an
+// already-armed polecat is a no-op — the first deadline stands.
+func (b *deferredBackstop) arm(name string, mr *refinery.MergeRequest) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.timers[name]; ok {
+		return
+	}
+	// Snapshot the MR: the caller's *mr may be mutated/pruned after arm returns,
+	// but the escalation, minutes later, must report the state at merge time.
+	mrCopy := *mr
+	b.timers[name] = b.afterFunc(b.timeout, func() { b.fire(name, &mrCopy) })
+	log.Printf("refinery: armed defer-done backstop for polecat %s — reaps + escalates if it does not complete within %s (gh #81)", name, b.timeout)
+}
+
+// cancel disarms the backstop for name. Called from pogod's OnExit hook when a
+// polecat's process ends: a gone process has freed its slot, so there is
+// nothing left to reap. Safe to call for a name that was never armed (the
+// common case — most polecats are not --defer-done).
+func (b *deferredBackstop) cancel(name string) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if t, ok := b.timers[name]; ok {
+		t.Stop()
+		delete(b.timers, name)
+		log.Printf("refinery: disarmed defer-done backstop for polecat %s (completed cleanly, gh #81)", name)
+	}
+}
+
+// fire runs when a deferred polecat outlives the backstop window without
+// ending its lifecycle. It reaps the lingering process and escalates to the
+// mayor. If the polecat has already left the registry (it exited in the race
+// between the timer firing and cancel acquiring the lock), there is nothing to
+// reap and no escalation is sent.
+func (b *deferredBackstop) fire(name string, mr *refinery.MergeRequest) {
+	b.mu.Lock()
+	// If cancel already removed our entry, a concurrent cancel won — stand down.
+	if _, ok := b.timers[name]; !ok {
+		b.mu.Unlock()
+		return
+	}
+	delete(b.timers, name)
+	b.mu.Unlock()
+
+	a := b.reg.GetByWorkItemOrName(name)
+	if a == nil {
+		// Raced with a clean exit — the slot is already free, no escalation.
+		log.Printf("refinery: defer-done backstop for polecat %s fired but the polecat was already gone — no action (gh #81)", name)
+		return
+	}
+	log.Printf("refinery: defer-done backstop FIRED for polecat %s — merged but did not complete within %s; reaping + escalating (gh #34/#35 slot protection, gh #81)", name, b.timeout)
+	if err := b.reg.Stop(a.Name, mergedPolecatStopTimeout); err != nil {
+		log.Printf("refinery: defer-done backstop failed to stop lingering polecat %s: %v", a.Name, err)
+	}
+	if b.escalate != nil {
+		b.escalate(mr)
+	}
 }
 
 // worktreeUnlinker is the slice of agent.Registry that

--- a/cmd/pogod/reap_test.go
+++ b/cmd/pogod/reap_test.go
@@ -57,7 +57,7 @@ func TestReapMergedPolecat_StopsPolecatAndMarksDone(t *testing.T) {
 	}
 
 	mr := &refinery.MergeRequest{ID: "mr-42", Branch: "polecat-mg-1234", Author: "mg-1234"}
-	reapMergedPolecat(reg, mr, complete)
+	reapMergedPolecat(reg, mr, complete, nil)
 
 	if completedID != "mg-1234" {
 		t.Errorf("expected mg done for work-item id mg-1234, got %q", completedID)
@@ -82,7 +82,7 @@ func TestReapMergedPolecat_IgnoresEmptyAuthor(t *testing.T) {
 	reapMergedPolecat(reg, &refinery.MergeRequest{ID: "mr-1", Branch: "b"}, func(string, string) error {
 		called = true
 		return nil
-	})
+	}, nil)
 	if called || len(reg.stopped) != 0 {
 		t.Errorf("expected no action for authorless MR (complete=%v, stopped=%v)", called, reg.stopped)
 	}
@@ -97,7 +97,7 @@ func TestReapMergedPolecat_IgnoresUnknownAuthor(t *testing.T) {
 	reapMergedPolecat(reg, &refinery.MergeRequest{ID: "mr-1", Branch: "b", Author: "mg-gone"}, func(string, string) error {
 		called = true
 		return nil
-	})
+	}, nil)
 	if called || len(reg.stopped) != 0 {
 		t.Errorf("expected no action for unknown author (complete=%v, stopped=%v)", called, reg.stopped)
 	}
@@ -111,7 +111,7 @@ func TestReapMergedPolecat_IgnoresCrewAuthor(t *testing.T) {
 	reapMergedPolecat(reg, &refinery.MergeRequest{ID: "mr-1", Branch: "b", Author: "mayor"}, func(string, string) error {
 		called = true
 		return nil
-	})
+	}, nil)
 	if called || len(reg.stopped) != 0 {
 		t.Errorf("expected no action for crew author (complete=%v, stopped=%v)", called, reg.stopped)
 	}
@@ -125,7 +125,7 @@ func TestReapMergedPolecat_StopsEvenWhenDoneFails(t *testing.T) {
 	}}
 	complete := func(string, string) error { return errors.New("mg done failed: already done") }
 
-	reapMergedPolecat(reg, &refinery.MergeRequest{ID: "mr-1", Branch: "b", Author: "mg-1234"}, complete)
+	reapMergedPolecat(reg, &refinery.MergeRequest{ID: "mr-1", Branch: "b", Author: "mg-1234"}, complete, nil)
 
 	if len(reg.stopped) != 1 || reg.stopped[0] != "1234" {
 		t.Errorf("expected Stop(1234) despite mg done failure, got %v", reg.stopped)
@@ -139,11 +139,171 @@ func TestReapMergedPolecat_StopFailureIsNonFatal(t *testing.T) {
 		},
 		stopErr: errors.New("agent wedged"),
 	}
-	reapMergedPolecat(reg, &refinery.MergeRequest{ID: "mr-1", Branch: "b", Author: "mg-1234"}, func(string, string) error { return nil })
+	reapMergedPolecat(reg, &refinery.MergeRequest{ID: "mr-1", Branch: "b", Author: "mg-1234"}, func(string, string) error { return nil }, nil)
 	// Must not panic; the mayor's backstop picks up the still-running polecat.
 	if len(reg.stopped) != 1 {
 		t.Errorf("expected one Stop attempt, got %v", reg.stopped)
 	}
+}
+
+// --- defer-done (gh #81) ---
+
+// fakeBackstopTimer is a hand-fired stand-in for *time.Timer. It captures the
+// scheduled func so a test can invoke it deterministically (fire the deadline)
+// and records whether Stop was called (the timer was disarmed).
+type fakeBackstopTimer struct {
+	fn      func()
+	stopped bool
+}
+
+func (t *fakeBackstopTimer) Stop() bool {
+	already := t.stopped
+	t.stopped = true
+	return !already
+}
+
+// newTestBackstop builds a deferredBackstop whose timers never fire on their
+// own — the returned func fires the most recently armed one on demand. escalate
+// increments *escalations. This lets each test drive both directions of the
+// acceptance control without real wall-clock time.
+func newTestBackstop(reg polecatReaper, escalations *[]string) (*deferredBackstop, func()) {
+	var last *fakeBackstopTimer
+	b := newDeferredBackstop(15*time.Minute, reg, func(mr *refinery.MergeRequest) {
+		*escalations = append(*escalations, mr.Author)
+	})
+	b.afterFunc = func(d time.Duration, f func()) backstopTimer {
+		last = &fakeBackstopTimer{fn: f}
+		return last
+	}
+	fire := func() {
+		if last != nil {
+			last.fn()
+		}
+	}
+	return b, fire
+}
+
+// TestReapMergedPolecat_DeferDoneArmsBackstopAndSkipsAutoStop is the core gh
+// #81 behavior: a --defer-done polecat must NOT be auto-done'd or auto-stopped
+// at merge — it owns its own lifecycle — but the backstop must be armed so it
+// cannot linger forever.
+func TestReapMergedPolecat_DeferDoneArmsBackstopAndSkipsAutoStop(t *testing.T) {
+	reg := &fakeReaper{agents: map[string]*agent.Agent{
+		"1234": {Name: "1234", WorkItemID: "mg-1234", Type: agent.TypePolecat},
+	}}
+	var escalations []string
+	backstop, _ := newTestBackstop(reg, &escalations)
+
+	completeCalled := false
+	complete := func(string, string) error { completeCalled = true; return nil }
+
+	mr := &refinery.MergeRequest{ID: "mr-42", Branch: "polecat-mg-1234", Author: "mg-1234", DeferDone: true}
+	reapMergedPolecat(reg, mr, complete, backstop)
+
+	if completeCalled {
+		t.Error("defer-done: mg done must NOT be called at merge — the polecat calls it itself")
+	}
+	if len(reg.stopped) != 0 {
+		t.Errorf("defer-done: polecat must NOT be auto-stopped at merge, got stopped=%v", reg.stopped)
+	}
+	backstop.mu.Lock()
+	_, armed := backstop.timers["1234"]
+	backstop.mu.Unlock()
+	if !armed {
+		t.Error("defer-done: backstop must be armed for the merged polecat")
+	}
+}
+
+// TestDeferredBackstop_FiresReapsAndEscalates is the FIRST direction of the
+// acceptance control: a deferred polecat that never completes gets reaped +
+// escalated once the bounded window elapses.
+func TestDeferredBackstop_FiresReapsAndEscalates(t *testing.T) {
+	reg := &fakeReaper{agents: map[string]*agent.Agent{
+		"1234": {Name: "1234", WorkItemID: "mg-1234", Type: agent.TypePolecat},
+	}}
+	var escalations []string
+	backstop, fire := newTestBackstop(reg, &escalations)
+
+	mr := &refinery.MergeRequest{ID: "mr-42", Branch: "polecat-mg-1234", Author: "mg-1234", DeferDone: true}
+	reapMergedPolecat(reg, mr, func(string, string) error { return nil }, backstop)
+
+	// The polecat never exits: the deadline elapses.
+	fire()
+
+	if len(reg.stopped) != 1 || reg.stopped[0] != "1234" {
+		t.Errorf("backstop fire: expected Stop(1234) to reap the lingering polecat, got %v", reg.stopped)
+	}
+	if len(escalations) != 1 || escalations[0] != "mg-1234" {
+		t.Errorf("backstop fire: expected one escalation for mg-1234, got %v", escalations)
+	}
+	// The fired timer must be cleared so a later cancel/exit is a clean no-op.
+	backstop.mu.Lock()
+	_, stillArmed := backstop.timers["1234"]
+	backstop.mu.Unlock()
+	if stillArmed {
+		t.Error("backstop fire: timer entry must be removed after firing")
+	}
+}
+
+// TestDeferredBackstop_CleanCompletionDisarms is the SECOND direction of the
+// acceptance control: a normal defer-done that completes cleanly (its process
+// exits → OnExit calls cancel) is never reaped or escalated.
+func TestDeferredBackstop_CleanCompletionDisarms(t *testing.T) {
+	reg := &fakeReaper{agents: map[string]*agent.Agent{
+		"1234": {Name: "1234", WorkItemID: "mg-1234", Type: agent.TypePolecat},
+	}}
+	var escalations []string
+	backstop, fire := newTestBackstop(reg, &escalations)
+
+	mr := &refinery.MergeRequest{ID: "mr-42", Branch: "polecat-mg-1234", Author: "mg-1234", DeferDone: true}
+	reapMergedPolecat(reg, mr, func(string, string) error { return nil }, backstop)
+
+	// The polecat finishes its post-merge flow and its process exits — the
+	// OnExit hook disarms the backstop.
+	backstop.cancel("1234")
+	// A late timer fire (already-disarmed) must do nothing.
+	fire()
+
+	if len(reg.stopped) != 0 {
+		t.Errorf("clean completion: polecat must NOT be reaped, got stopped=%v", reg.stopped)
+	}
+	if len(escalations) != 0 {
+		t.Errorf("clean completion: no escalation expected, got %v", escalations)
+	}
+}
+
+// TestDeferredBackstop_FireAfterExitIsNoop covers the race where the polecat
+// exits (leaving the registry) but the timer fires before cancel ran: with no
+// live agent to reap, the backstop must not escalate a phantom linger.
+func TestDeferredBackstop_FireAfterExitIsNoop(t *testing.T) {
+	reg := &fakeReaper{agents: map[string]*agent.Agent{
+		"1234": {Name: "1234", WorkItemID: "mg-1234", Type: agent.TypePolecat},
+	}}
+	var escalations []string
+	backstop, fire := newTestBackstop(reg, &escalations)
+
+	mr := &refinery.MergeRequest{ID: "mr-42", Branch: "polecat-mg-1234", Author: "mg-1234", DeferDone: true}
+	reapMergedPolecat(reg, mr, func(string, string) error { return nil }, backstop)
+
+	// Process is gone from the registry, but cancel has not run yet.
+	delete(reg.agents, "1234")
+	fire()
+
+	if len(reg.stopped) != 0 {
+		t.Errorf("fire-after-exit: nothing to reap, got stopped=%v", reg.stopped)
+	}
+	if len(escalations) != 0 {
+		t.Errorf("fire-after-exit: no escalation for an already-gone polecat, got %v", escalations)
+	}
+}
+
+// TestDeferredBackstop_NilIsSafe guards the nil-backstop path used by the
+// non-defer reap tests and any pogod build where the backstop is not wired.
+func TestDeferredBackstop_NilIsSafe(t *testing.T) {
+	var b *deferredBackstop
+	// None of these must panic.
+	b.arm("1234", &refinery.MergeRequest{Author: "mg-1234"})
+	b.cancel("1234")
 }
 
 // fakeUnlinker is a worktreeUnlinker backed by a static agent map, using the

--- a/internal/refinery/api.go
+++ b/internal/refinery/api.go
@@ -15,6 +15,12 @@ type SubmitRequest struct {
 	// AutoCreateTargetRef opts into branching the target ref off the repo's
 	// default branch when it does not exist on origin. Default false.
 	AutoCreateTargetRef bool `json:"auto_create_target_ref,omitempty"`
+	// DeferDone opts the submitter into owning its own post-merge lifecycle:
+	// pogod skips the auto-done + auto-stop it normally applies at merge time
+	// so a --branch (PR-flow) polecat can finish its post-merge work (open the
+	// PR, verify, mail) and call `mg done` itself (gh drellem2/pogo #81).
+	// Default false.
+	DeferDone bool `json:"defer_done,omitempty"`
 }
 
 // RegisterHandlers registers refinery API endpoints on the given mux,
@@ -108,6 +114,7 @@ func (r *Refinery) handleSubmit(w http.ResponseWriter, req *http.Request) {
 		TargetRef:           submitReq.TargetRef,
 		Author:              submitReq.Author,
 		AutoCreateTargetRef: submitReq.AutoCreateTargetRef,
+		DeferDone:           submitReq.DeferDone,
 	}
 
 	id, err := r.Submit(mr)

--- a/internal/refinery/refinery.go
+++ b/internal/refinery/refinery.go
@@ -112,11 +112,21 @@ type MergeRequest struct {
 	// default — the safe behaviour (typo in target_ref → error) stays the
 	// default. Submitters that genuinely want a new feature branch carved
 	// off the default must set this explicitly.
-	AutoCreateTargetRef bool      `json:"auto_create_target_ref,omitempty"`
-	SubmitTime          time.Time `json:"submit_time"`
-	DoneTime            time.Time `json:"done_time,omitempty"`
-	Error               string    `json:"error,omitempty"`
-	GateOutput          string    `json:"gate_output,omitempty"`
+	AutoCreateTargetRef bool `json:"auto_create_target_ref,omitempty"`
+	// DeferDone opts the submitter into owning its own post-merge lifecycle
+	// (gh drellem2/pogo #81). When true, pogod's OnMerged reap path skips the
+	// auto-done + auto-stop it would otherwise apply the instant a polecat's
+	// branch merges — a --branch (PR-flow) polecat still has post-merge work to
+	// do (open the PR, run verify checks, mail the PR URL) and must not be
+	// killed mid-flow. The polecat calls `mg done` itself when its full flow
+	// finishes. A bounded backstop reaps + escalates a deferred polecat that
+	// never completes, so this does not regress the gh #34/#35 slot guarantees.
+	// Off by default — the auto-done/auto-stop path stays the default.
+	DeferDone  bool      `json:"defer_done,omitempty"`
+	SubmitTime time.Time `json:"submit_time"`
+	DoneTime   time.Time `json:"done_time,omitempty"`
+	Error      string    `json:"error,omitempty"`
+	GateOutput string    `json:"gate_output,omitempty"`
 	// AlreadyMerged marks an MR whose branch had already landed on the target
 	// before processing began (a re-submit of a merged branch, gh #34). The
 	// MR resolves as StatusMerged — so poll loops keying off status terminate

--- a/internal/refinery/refinery_test.go
+++ b/internal/refinery/refinery_test.go
@@ -1591,6 +1591,65 @@ func TestSubmitAutoCreateTargetRef(t *testing.T) {
 	})
 }
 
+// TestSubmitDeferDonePreserved covers gh drellem2/pogo #81: the DeferDone flag
+// set on a submitted MR must survive onto the queued MergeRequest (and its
+// persisted state) so pogod's OnMerged reap path can honour it at merge time.
+func TestSubmitDeferDonePreserved(t *testing.T) {
+	originDir := initBareOrigin(t, "main")
+	statePath := filepath.Join(t.TempDir(), "refinery.json")
+	r, err := New(Config{
+		Enabled:      true,
+		PollInterval: time.Hour,
+		WorktreeDir:  t.TempDir(),
+		StatePath:    statePath,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := r.Submit(MergeRequest{
+		RepoPath:  originDir,
+		Branch:    "feature-1",
+		TargetRef: "main",
+		Author:    "mg-1234",
+		DeferDone: true,
+	})
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if got := r.Get(id); got == nil || !got.DeferDone {
+		t.Fatalf("expected queued MR to carry DeferDone=true, got %+v", got)
+	}
+
+	// Default (non-defer) submit must stay DeferDone=false.
+	id2, err := r.Submit(MergeRequest{
+		RepoPath:  originDir,
+		Branch:    "feature-2",
+		TargetRef: "main",
+		Author:    "mg-5678",
+	})
+	if err != nil {
+		t.Fatalf("submit default: %v", err)
+	}
+	if got := r.Get(id2); got == nil || got.DeferDone {
+		t.Fatalf("expected default MR to have DeferDone=false, got %+v", got)
+	}
+
+	// DeferDone must round-trip through the persisted state file: a fresh
+	// Refinery loaded from the same StatePath sees the flag on recovery.
+	r2, err := New(Config{
+		Enabled:      true,
+		PollInterval: time.Hour,
+		WorktreeDir:  t.TempDir(),
+		StatePath:    statePath,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r2.Get(id); got == nil || !got.DeferDone {
+		t.Fatalf("expected DeferDone=true to survive state reload, got %+v", got)
+	}
+}
+
 func TestParseRefineryTomlPRMode(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

For `--branch` (PR-flow) polecats, the refinery's gh #35 event-driven stop fires the instant the branch merges — before the polecat runs its own post-merge steps (`gh pr create`, verify checks, mail PR URL). The branch merges correctly but the PR is never opened, forcing a rescue polecat.

This adds an opt-in **`pogo refinery submit --defer-done`** flag: pogod's OnMerged reap path skips the auto-done + auto-stop, so the polecat **owns its own lifecycle** and calls `mg done` itself once its full flow (including PR creation) finishes.

To avoid trading a silent KILL for a silent LINGER — which would regress the gh #34/#35 slot-protection guarantees — a **bounded backstop** arms when a deferred polecat merges. If it never ends its lifecycle within the window (15m), pogod reaps the lingering process and escalates to the mayor. A clean process exit disarms the backstop via pogod's OnExit hook.

## Changes

- `SubmitRequest.DeferDone` / `MergeRequest.DeferDone` (persisted, survives restart recovery) + `--defer-done` CLI flag.
- `reapMergedPolecat`: when `DeferDone`, skip auto-done/auto-stop and arm the backstop instead.
- `deferredBackstop` (cmd/pogod/reap.go): `arm` on deferred merge, `cancel` from OnExit on clean exit, `fire` reaps + escalates on timeout. Injectable timer for deterministic tests.
- Escalation mails the mayor when the backstop fires.

## Acceptance — two-directional positive control

`cmd/pogod/reap_test.go` proves both directions:
- **Backstop CAN fire** (`TestDeferredBackstop_FiresReapsAndEscalates`): a deferred polecat that never completes gets reaped (`Stop`) + escalated.
- **Normal deferred-done completes cleanly** (`TestDeferredBackstop_CleanCompletionDisarms`): a clean exit disarms the backstop — never reaped, never escalated.

Plus: defer-done skips auto-stop/auto-done, fire-after-exit is a no-op, nil-backstop safety, and `DeferDone` state round-trip (`internal/refinery`). Default (non-defer) submit path is unchanged. `-race` clean; `./build.sh` passes.

Resolves drellem2/pogo#81

Approved triage recommendation: Daniel GO recorded (pm-pogo relay 2026-07-15). Review ticket: mg-a14e
Work item: mg-93e2