### PR TITLE
[mg-36e3] fix(deploy): resolve git by execution, bind the real GH_TOKEN file

### DIFF
--- a/changelog.d/mg-36e3.fixed.md
+++ b/changelog.d/mg-36e3.fixed.md
@@ -1,0 +1,28 @@
+- **The nightly deploy job resolves `git` by running it, not by trusting a path (mg-36e3).**
+  `scripts/launchd/pogo-deploy.sh` pinned `GIT=/usr/bin/git` on the reasoning that git
+  ships in `/usr/bin` on every macOS. It does — but that path is the Xcode Command Line
+  Tools *shim*, and a damaged or half-installed Xcode makes it fail every invocation,
+  `git --version` included, with `unable to locate xcodebuild` and exit 71. On such a host
+  the nightly could not clone, fetch, or read a revision, so `sync_src` aborted and the job
+  alerted and deployed nothing — night after night, the exact silent-nightly failure this
+  job exists to end. `git` is now resolved the way `mg` already was: candidates in order,
+  each required to prove itself by actually running, preferring a real Homebrew/local git
+  over the shim while keeping the shim as a fallback. Existence is no longer the test — a
+  broken shim is executable, is on `PATH`, and passes every check short of execution. An
+  operator-pinned `$GIT` is still honoured, and still health-checked. This also repairs
+  three pre-existing failures in `scripts/pogo-deploy_test.sh`, which hardcoded the same
+  dead path (and whose neighbouring negative assertions had been passing *vacuously*,
+  because `sync_src` did fail — for the wrong reason).
+
+- **`install-deploy` binds the shell file that actually defines `GH_TOKEN` (mg-36e3).**
+  The runner treats a missing `GH_TOKEN` as a hard abort and reads it from exactly one
+  file, `$POGO_DEPLOY_ZSHENV`, defaulting to `~/.zshenv`. That default is the principled
+  one — `.zshenv` is the only zsh init file a non-interactive shell sources — but it is
+  routinely not where the export lives, and a host that keeps it in `~/.zshrc` got a
+  nightly that alerted every night about a token that was on disk the whole time.
+  `pogo service install-deploy` now detects which of `.zshenv`, `.zshrc`, `.zprofile`
+  contains the `export GH_TOKEN=` line and binds `POGO_DEPLOY_ZSHENV` to it, preferring
+  `.zshenv` when it qualifies and falling back to it when nothing does. Only the *path* is
+  written to the plist, never the value: `~/Library/LaunchAgents` is world-readable, and a
+  test now asserts the token value can never reach it. The installer prints the file it
+  chose.

--- a/internal/service/deploy.go
+++ b/internal/service/deploy.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"text/template"
 )
@@ -46,7 +47,15 @@ const deployLabel = "com.pogo.deploy"
 //
 // There is deliberately NO GH_TOKEN key. ~/Library/LaunchAgents is
 // world-readable, so a token here is a token every process on the box can read;
-// pogo-deploy.sh sources it from ~/.zshenv at run time instead.
+// pogo-deploy.sh sources it from a shell init file at run time instead.
+//
+// POGO_DEPLOY_ZSHENV names WHICH file that is — a path, never the value. The
+// runner's own default is ~/.zshenv, which is the principled choice (it is the
+// one zsh init file a non-interactive shell sources) but not always the true
+// one: plenty of boxes keep the export in ~/.zshrc. A missing GH_TOKEN is a hard
+// abort in the runner, so a token one file over produces a nightly that alerts
+// and deploys nothing, every night — the exact silent-nightly failure this job
+// was installed to end (mg-36e3). Bind whichever file actually defines it.
 const deployPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -84,6 +93,8 @@ const deployPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         <string>{{.PogoHome}}</string>
         <key>POGO_DEPLOY_SRC</key>
         <string>{{.DeploySrc}}</string>
+        <key>POGO_DEPLOY_ZSHENV</key>
+        <string>{{.ZshEnv}}</string>
     </dict>
 </dict>
 </plist>
@@ -103,6 +114,7 @@ type deployData struct {
 	Label      string
 	ScriptPath string
 	DeploySrc  string
+	ZshEnv     string
 	LogDir     string
 	Path       string
 	Home       string
@@ -133,6 +145,47 @@ func deploySrcDir() string {
 		return d
 	}
 	return filepath.Join(pogoHome(), "deploy-src")
+}
+
+// ghTokenExport matches the one line the runner cares about. It greps for this
+// exact shape and evals that line alone rather than sourcing the file, so
+// detection here has to agree with the runner's grep or the plist would bind a
+// file the runner then reads nothing out of.
+var ghTokenExport = regexp.MustCompile(`(?m)^[[:space:]]*export[[:space:]]+GH_TOKEN=`)
+
+// deployZshEnvCandidates — shell init files that may carry the export, in
+// preference order. ~/.zshenv first because it is the correct place for a
+// variable a non-interactive job depends on; the rest because it is routinely
+// not where the token actually is.
+func deployZshEnvCandidates() []string {
+	home, _ := os.UserHomeDir()
+	return []string{
+		filepath.Join(home, ".zshenv"),
+		filepath.Join(home, ".zshrc"),
+		filepath.Join(home, ".zprofile"),
+	}
+}
+
+// deployZshEnv picks the file the runner should read GH_TOKEN out of, returning
+// the first candidate that actually contains the export and falling back to
+// ~/.zshenv (the runner's own default) when none do — a wrong-but-documented
+// path produces the runner's clear "no export GH_TOKEN= line in X" alert, which
+// is a better failure than an empty setting that reads as intentional.
+//
+// This reads the file only to test for the export's PRESENCE. The value is never
+// captured, returned, or written to the plist; the runner reads it at run time.
+func deployZshEnv() string {
+	cands := deployZshEnvCandidates()
+	for _, c := range cands {
+		b, err := os.ReadFile(c)
+		if err != nil {
+			continue
+		}
+		if ghTokenExport.Match(b) {
+			return c
+		}
+	}
+	return cands[0]
 }
 
 // findDeployScriptSource locates the bundled pogo-deploy.sh. Mirrors
@@ -171,6 +224,7 @@ func renderDeployPlist() (string, deployData, error) {
 		Label:      deployLabel,
 		ScriptPath: deployScriptInstallPath(),
 		DeploySrc:  deploySrcDir(),
+		ZshEnv:     deployZshEnv(),
 		LogDir:     logDir(),
 		Path:       launchdPath(),
 		Home:       home,
@@ -245,6 +299,7 @@ func InstallDeploy() error {
 	fmt.Printf("Deploy agent installed: %s\n", plistPath)
 	fmt.Printf("Script:   %s\n", dst)
 	fmt.Printf("Checkout: %s (cloned on first run)\n", data.DeploySrc)
+	fmt.Printf("GH_TOKEN: read at run time from %s\n", data.ZshEnv)
 	fmt.Printf("Schedule: %02d:%02d local, daily\n", data.Hour, data.Minute)
 	fmt.Printf("Logs:     %s/pogo-deploy.log\n", data.LogDir)
 	return nil

--- a/internal/service/deploy_test.go
+++ b/internal/service/deploy_test.go
@@ -144,6 +144,99 @@ func TestDeployIsNotRecovery(t *testing.T) {
 	}
 }
 
+// TestDeployZshEnvFindsTheTokenFile covers the second reason this job can run
+// nightly and deploy nothing (mg-36e3). The runner treats a missing GH_TOKEN as
+// a hard abort, and reads it from ONE file. ~/.zshenv is the principled default
+// — the only zsh init file a non-interactive shell sources — but on a real box
+// the export routinely lives in ~/.zshrc, and then the nightly alerts every
+// night about a token that was on disk the whole time.
+//
+// Preference order matters as much as detection: when .zshenv does define the
+// token it must win, because that is the file that works in every context.
+func TestDeployZshEnvFindsTheTokenFile(t *testing.T) {
+	tokenLine := "export GH_TOKEN=sometoken\n"
+
+	tests := []struct {
+		name  string
+		files map[string]string
+		want  string
+	}{
+		{
+			name:  "token in .zshrc only — the observed case",
+			files: map[string]string{".zshenv": ". \"$HOME/.cargo/env\"\n", ".zshrc": "# rc\n" + tokenLine},
+			want:  ".zshrc",
+		},
+		{
+			name:  ".zshenv wins when it also defines the token",
+			files: map[string]string{".zshenv": tokenLine, ".zshrc": tokenLine},
+			want:  ".zshenv",
+		},
+		{
+			name:  "indented export is still an export",
+			files: map[string]string{".zshenv": "# nothing\n", ".zshrc": "  export GH_TOKEN=x\n"},
+			want:  ".zshrc",
+		},
+		{
+			name:  "a commented-out export does not count",
+			files: map[string]string{".zshenv": "# export GH_TOKEN=old\n", ".zshrc": tokenLine},
+			want:  ".zshrc",
+		},
+		{
+			name:  "falls back to .zshenv when nothing defines it",
+			files: map[string]string{".zshenv": "# nothing\n", ".zshrc": "# nothing\n"},
+			want:  ".zshenv",
+		},
+		{
+			name:  "token in .zprofile",
+			files: map[string]string{".zprofile": tokenLine},
+			want:  ".zprofile",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			for name, body := range tc.files {
+				if err := os.WriteFile(filepath.Join(home, name), []byte(body), 0644); err != nil {
+					t.Fatalf("write %s: %v", name, err)
+				}
+			}
+			got := deployZshEnv()
+			if got != filepath.Join(home, tc.want) {
+				t.Errorf("deployZshEnv() = %q; want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderDeployPlistBindsZshEnvPathNotSecret pins that the plist carries the
+// PATH to the token file and never the token. The whole reason GH_TOKEN is read
+// at run time is that ~/Library/LaunchAgents is world-readable; binding the file
+// location is what makes that indirection work on a box whose token is not in
+// the default file, and it must not become a shortcut to binding the value.
+func TestRenderDeployPlistBindsZshEnvPathNotSecret(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, ".zshrc"), []byte("export GH_TOKEN=supersecretvalue\n"), 0644); err != nil {
+		t.Fatalf("write .zshrc: %v", err)
+	}
+
+	rendered, data, err := renderDeployPlist()
+	if err != nil {
+		t.Fatalf("renderDeployPlist: %v", err)
+	}
+	if data.ZshEnv != filepath.Join(home, ".zshrc") {
+		t.Errorf("ZshEnv = %q; want the file that actually defines the token", data.ZshEnv)
+	}
+	if !strings.Contains(rendered, "<key>POGO_DEPLOY_ZSHENV</key>") {
+		t.Error("plist does not bind POGO_DEPLOY_ZSHENV: the runner would fall back to ~/.zshenv and abort nightly on a token it could have found")
+	}
+	if strings.Contains(rendered, "supersecretvalue") {
+		t.Error("rendered plist contains the TOKEN VALUE — a world-readable LaunchAgent must hold only the path")
+	}
+}
+
 // TestFindDeployScriptSourceHonorsOverride keeps the installer testable and
 // gives an operator a way out when the bundled copy cannot be located (a `go
 // install`ed pogo has no scripts/ sibling).

--- a/scripts/launchd/README.md
+++ b/scripts/launchd/README.md
@@ -241,17 +241,34 @@ belongs there instead. In order:
 2. **Lock.** `~/.pogo/deploy.lock.d`, its own, never recovery's. A redeploy can
    legitimately run for an hour while the drain waits on polecats; a second fire
    must not start a competing drain.
-3. **Tools.** `mg` and `pogo` are resolved to **absolute paths**, and `mg` only
-   after an identity check. On macOS `/usr/bin/mg` is the Micro-Emacs editor; it
-   satisfies `command -v mg`, panics headless, and delivers no alert at all
-   (mg-015f, mg-dd5f). The alert path is resolved *first*, before anything that
-   can fail — a job whose first failure is "I cannot tell you about failures" is
-   the silent nightly all over again.
-4. **`GH_TOKEN` at run time**, matched out of `~/.zshenv` one line at a time and
-   `eval`'d alone — never sourced wholesale (that file's `export PATH=` would
-   strip `go` and reproduce the 07-23 `go: command not found` failure), and
-   **never** in the plist: `~/Library/LaunchAgents` is world-readable. The value
-   is never logged.
+3. **Tools.** `mg`, `pogo` and `git` are all resolved to **absolute paths**, and
+   `mg` and `git` only after the candidate proves itself. On macOS `/usr/bin/mg`
+   is the Micro-Emacs editor; it satisfies `command -v mg`, panics headless, and
+   delivers no alert at all (mg-015f, mg-dd5f). The alert path is resolved
+   *first*, before anything that can fail — a job whose first failure is "I
+   cannot tell you about failures" is the silent nightly all over again.
+
+   `git` is checked by **execution**, not existence (mg-36e3). `/usr/bin/git` is
+   the Xcode Command Line Tools shim, and on a host with a damaged Xcode it fails
+   *every* call — `git --version` included — with `unable to locate xcodebuild`
+   and exit 71. It is executable, it is on `PATH`, and it cannot clone. So a real
+   Homebrew/local git is preferred and each candidate must print `git version`
+   before it is accepted; the shim stays in the list so a CLT-only box still
+   deploys. `GIT=` pins one explicitly and is health-checked too.
+4. **`GH_TOKEN` at run time**, matched one line at a time out of the shell init
+   file named by `POGO_DEPLOY_ZSHENV` and `eval`'d alone — never sourced
+   wholesale (that file's `export PATH=` would strip `go` and reproduce the 07-23
+   `go: command not found` failure), and **never** in the plist:
+   `~/Library/LaunchAgents` is world-readable. The value is never logged.
+
+   `install-deploy` binds that variable to whichever of `~/.zshenv`, `~/.zshrc`,
+   `~/.zprofile` actually contains the `export GH_TOKEN=` line, preferring
+   `.zshenv` (mg-36e3). `.zshenv` is the principled home — it is the one zsh init
+   file a *non-interactive* shell sources — but it is routinely not where the
+   token is, and a missing `GH_TOKEN` is a hard abort, so a token one file over
+   produced a nightly that alerted every night about a secret that was on disk
+   the whole time. Only the **path** is bound; the value is still read at run
+   time.
 5. **Safe sync** of `~/.pogo/deploy-src` — a **dedicated** checkout, never
    `~/dev/pogo`. The dev tree is a place a human works; a 03:00
    fetch/checkout/merge there can land on a half-finished edit or an in-progress
@@ -290,6 +307,7 @@ belongs there instead. In order:
 | `StandardOutPath` / `StandardErrorPath` | `~/Library/Logs/pogo/pogo-deploy.log` | Its own log. Deploy history must not be interleaved with recovery bounces. |
 | `EnvironmentVariables.PATH` | Same value as `com.pogo.recovery` (via `launchdPath()`) | Must resolve **both** `go` (`/opt/homebrew/bin`) and `mg`/`pogo` (`~/go/bin`). launchd's default PATH has neither, and the 07-23 manual redeploy died on `go: command not found` for exactly this. |
 | `EnvironmentVariables.POGO_DEPLOY_SRC` | `~/.pogo/deploy-src` | Bound here so the plist and the script cannot disagree about which tree is built. Must never name a developer working tree. |
+| `EnvironmentVariables.POGO_DEPLOY_ZSHENV` | the init file that defines `export GH_TOKEN=` (`~/.zshenv`, else `~/.zshrc`, else `~/.zprofile`) | A **path**, never the value. Bound because the runner hard-aborts without the token and reads exactly one file; a host that keeps the export in `.zshrc` would otherwise alert every night about a token already on disk (mg-36e3). |
 | `EnvironmentVariables.GH_TOKEN` | **absent, deliberately** | `~/Library/LaunchAgents` is world-readable. The runner sources the token at run time instead. |
 
 ### Runner env overrides
@@ -304,7 +322,8 @@ All optional; the defaults are the production values.
 | `POGO_DEPLOY_SKIP_WINDOW` | unset | `1` bypasses the window guard. For controls only. |
 | `POGO_DEPLOY_NOW` | unset | `HH` override for the window guard. Tests only. |
 | `POGO_DEPLOY_GRACE` | `120` | Seconds before the post-bounce mail-check re-read. |
-| `POGO_DEPLOY_ZSHENV` | `~/.zshenv` | Where `GH_TOKEN` is read from. |
+| `POGO_DEPLOY_ZSHENV` | `~/.zshenv` (the plist binds the file that actually defines the export) | Which shell init file `GH_TOKEN` is read from. |
+| `GIT` | first candidate that prints `git version` | Pins a specific git. Still health-checked — a pin that cannot run is the same outage as no pin. |
 | `POGO_DEPLOY_ALERT_TO` | `pm-pogo` | First alert recipient; `human` is always copied. |
 
 ### Managing the deploy agent

--- a/scripts/launchd/pogo-deploy.sh
+++ b/scripts/launchd/pogo-deploy.sh
@@ -48,6 +48,23 @@
 # `pogo-self-deploy` are addressed by absolute path too. A wrapper that alerts
 # via a binary it did not verify is a wrapper with no alert path.
 #
+# ...BUT AN ABSOLUTE PATH IS NOT A WORKING BINARY (mg-36e3)
+# ---------------------------------------------------------
+# The same discipline applied to `git` produced the opposite bug. git was pinned
+# to /usr/bin/git on the reasoning that git ships in /usr/bin on every macOS. It
+# does — but /usr/bin/git is the Command Line Tools SHIM, and a damaged or
+# half-installed Xcode makes it fail EVERY invocation, `git --version` included,
+# with "Error loading required libraries ... unable to locate xcodebuild" and
+# exit 71. On such a box this job cannot clone, cannot fetch and cannot read a
+# rev, so sync_src aborts and the nightly alerts and deploys nothing — night
+# after night, which is precisely the silent-nightly failure this file exists to
+# end. Observed on Daniel's box, where /usr/local/bin/git 2.40.0 was fine and
+# only the shim was broken.
+#
+# So git is resolved like mg: candidates in order, each required to prove itself
+# by actually RUNNING. Existence is not the test — the broken shim is executable,
+# on PATH, and satisfies every check short of execution.
+#
 # GH_TOKEN IS SOURCED AT RUNTIME, NEVER FROM THE PLIST
 # ----------------------------------------------------
 # ~/Library/LaunchAgents is world-readable; a token in the plist is a token on
@@ -64,7 +81,10 @@
 #   POGO_DEPLOY_REMOTE       clone URL used to create it if absent
 #   POGO_DEPLOY_BOOTSTRAP_REPO  repo to read the origin URL from ($HOME/dev/pogo)
 #   POGO_DEPLOY_WINDOW       "START-END" local hours, half-open (default "2-5")
-#   POGO_DEPLOY_ZSHENV       file to read GH_TOKEN from ($HOME/.zshenv)
+#   POGO_DEPLOY_ZSHENV       file to read GH_TOKEN from ($HOME/.zshenv; the
+#                            installed plist binds whichever init file actually
+#                            defines the export)
+#   GIT                      pin a specific git (still health-checked)
 #   POGO_DEPLOY_GRACE        seconds to wait before the post-bounce check (120)
 #   POGO_DEPLOY_LOCK_DIR     mutual-exclusion dir
 #   POGO_DEPLOY_ALERT_TO     first alert recipient (pm-pogo)
@@ -86,9 +106,11 @@ DEPLOY_REF="${POGO_DEPLOY_REF:-main}"
 STALE_LOCK_MIN="${POGO_DEPLOY_STALE_LOCK_MIN:-180}"
 DRY_RUN=false
 
-# Absolute paths to the stable primitives. `git` and `curl` are in /usr/bin on
-# every macOS; MG and POGO_CLI are resolved (and identity-checked) at run time.
-GIT="${GIT:-/usr/bin/git}"
+# GIT, MG and POGO_CLI are all resolved (and checked by execution) at run time.
+# GIT is seeded from the environment when an operator pins one, and that value is
+# still health-checked rather than trusted — a pinned path that cannot run is the
+# same outage as an unpinned one.
+GIT="${GIT:-}"
 MG=""
 POGO_CLI=""
 
@@ -164,6 +186,34 @@ resolve_mg() {
         return 0
     done
     err "mg: no macguffin 'mg' among ${cands[*]} — refusing bare 'mg' (that is /usr/bin/mg, the EDITOR)"
+    return 1
+}
+
+# `git`, resolved by EXECUTION rather than by existence. See the header note: a
+# broken Command Line Tools shim at /usr/bin/git is executable, is on PATH, and
+# fails every call with exit 71 — so -x and `command -v` both say yes about a
+# binary that cannot clone. Requiring "git version" on stdout is the cheapest
+# check that the thing actually works.
+#
+# A real Homebrew/local git is preferred over the shim because the shim is the
+# fragile one, but the shim stays in the list so a box with only CLT installed
+# still deploys. An operator-pinned $GIT is tried first and health-checked too.
+resolve_git() {
+    local cand
+    local -a cands=()
+    [ -n "${GIT:-}" ] && cands+=("$GIT")
+    cands+=("/opt/homebrew/bin/git" "/usr/local/bin/git" "/usr/bin/git")
+    cand="$(command -v git 2>/dev/null)"
+    [ -n "$cand" ] && cands+=("$cand")
+
+    for cand in "${cands[@]}"; do
+        [ -x "$cand" ] || continue
+        "$cand" --version 2>/dev/null | grep -q '^git version' || continue
+        GIT="$cand"
+        log "git: resolved working git at $GIT ($("$cand" --version 2>/dev/null))"
+        return 0
+    done
+    err "git: no WORKING git among ${cands[*]} — note a present-but-broken /usr/bin/git (damaged Xcode CLT) fails every call with exit 71, so existence proves nothing"
     return 1
 }
 
@@ -388,7 +438,11 @@ main() {
     while [ $# -gt 0 ]; do
         case "$1" in
             --dry-run) DRY_RUN=true ;;
-            -h|--help) sed -n '2,80p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+            # Bounded by the `set -u` sentinel rather than a line number: the
+            # header is long and grows, and a hardcoded range silently starts
+            # truncating --help mid-sentence the first time somebody documents
+            # something (it had already drifted past the ENV list).
+            -h|--help) sed -n '2,/^set -u/p' "${BASH_SOURCE[0]}" | sed '/^set -u/d' | sed 's/^# \{0,1\}//'; exit 0 ;;
             *) err "unknown flag: $1"; exit 2 ;;
         esac
         shift
@@ -421,6 +475,24 @@ main() {
     # tell you about failures" is the silent nightly all over again.
     resolve_mg   || { err "no alert path — refusing to run unattended"; exit 1; }
     resolve_pogo || log "pogo CLI unresolved — the post-bounce schedule check will be skipped"
+    # After resolve_mg, so a git failure can actually be reported; before
+    # sync_src, which is the first thing that needs git.
+    resolve_git || {
+        alert "[pogo-deploy] ABORTED: no working git" \
+"The nightly redeploy could not find a git that RUNS, so it could not sync its
+checkout. Nothing was deployed and the running pogod is untouched.
+
+The usual cause is a damaged Xcode Command Line Tools install: /usr/bin/git is
+the CLT shim, and when Xcode is broken it fails every call — 'git --version'
+included — with 'unable to locate xcodebuild' and exit 71. Existence checks pass;
+the binary just cannot work.
+
+  log: $HOME/Library/Logs/pogo/pogo-deploy.log
+  fix: install or repair a real git (xcode-select --install, or brew install git)
+       and confirm 'git --version' prints a version. Pin one for this job with
+       GIT=/path/to/git if several are installed."
+        exit 1
+    }
     load_gh_token || {
         alert "[pogo-deploy] ABORTED: no GH_TOKEN" \
 "The nightly redeploy could not obtain GH_TOKEN from $ZSHENV, so any gh call in

--- a/scripts/pogo-deploy_test.sh
+++ b/scripts/pogo-deploy_test.sh
@@ -169,6 +169,67 @@ load_gh_token "$WORK/notoken" >/dev/null 2>&1 \
 unset GH_TOKEN
 
 # ---------------------------------------------------------------------------
+# resolve_git — a WORKING git, not merely a present one (mg-36e3)
+# ---------------------------------------------------------------------------
+# git used to be pinned to /usr/bin/git, since git ships in /usr/bin on every
+# macOS. It does — but that path is the Command Line Tools SHIM, and a damaged
+# Xcode makes it fail every call, `git --version` included, with "unable to
+# locate xcodebuild" and exit 71. On such a box the nightly cannot clone, cannot
+# fetch and cannot read a rev: sync_src aborts, the job alerts, and nothing
+# deploys — the silent nightly all over again, from a binary that passes every
+# check short of running it.
+#
+# So these tests are all about the difference between "exists" and "runs". A
+# fake that is executable and on PATH but broken must be REJECTED.
+FAKEBIN="$WORK/fakebin"; mkdir -p "$FAKEBIN"
+# Reproduces the real failure: exit 71, diagnostic on stderr, nothing on stdout.
+cat > "$FAKEBIN/brokengit" <<'EOF'
+#!/bin/sh
+echo "Error loading required libraries. git: error: unable to locate xcodebuild" >&2
+exit 71
+EOF
+cat > "$FAKEBIN/workinggit" <<'EOF'
+#!/bin/sh
+[ "$1" = "--version" ] && { echo "git version 9.9.9"; exit 0; }
+exit 0
+EOF
+chmod +x "$FAKEBIN/brokengit" "$FAKEBIN/workinggit"
+
+SAVED_GIT="${GIT:-}"
+
+# The core regression. The old `GIT="${GIT:-/usr/bin/git}"` would have taken this
+# path verbatim and failed on the very first clone.
+GIT="$FAKEBIN/brokengit"
+[ -x "$FAKEBIN/brokengit" ] \
+    && pass "resolve_git premise: the broken fake IS executable (so -x cannot catch it)" \
+    || fail "broken fake is not executable"
+resolve_git >/dev/null 2>&1 \
+    && [ "$GIT" != "$FAKEBIN/brokengit" ] \
+    && pass "resolve_git REJECTS a pinned-but-broken git and falls through to a working one" \
+    || fail "resolve_git accepted a broken git, or found no working git at all"
+"$GIT" --version 2>/dev/null | grep -q '^git version' \
+    && pass "resolve_git left GIT pointing at a git that actually runs" || fail "resolved GIT does not run"
+
+# An operator pin that works is honoured verbatim — that is the escape hatch for
+# a box with several gits installed.
+GIT="$FAKEBIN/workinggit"
+resolve_git >/dev/null 2>&1 && [ "$GIT" = "$FAKEBIN/workinggit" ] \
+    && pass "resolve_git honours a working operator-pinned \$GIT" || fail "resolve_git ignored a valid pin"
+
+# Unpinned resolution must still land on a working git.
+GIT=""
+resolve_git >/dev/null 2>&1 && [ -n "$GIT" ] \
+    && "$GIT" --version 2>/dev/null | grep -q '^git version' \
+    && pass "resolve_git resolves a working git with no pin at all" || fail "resolve_git unpinned"
+
+# And the runner must not reintroduce the pin.
+grep -qE '^[[:space:]]*GIT="\$\{GIT:-/usr/bin/git\}"' "$RUNNER" \
+    && fail "the runner has gone back to hardcoding /usr/bin/git" \
+    || pass "the runner does not hardcode /usr/bin/git (existence is not a health check)"
+
+GIT="$SAVED_GIT"
+
+# ---------------------------------------------------------------------------
 # sync_src — never clobber, never diverge
 # ---------------------------------------------------------------------------
 mkrepo() {
@@ -181,7 +242,11 @@ UPSTREAM="$WORK/upstream"
 mkrepo "$UPSTREAM"
 
 # Fresh clone, then a clean fast-forward: the ordinary night.
-SRC="$WORK/src"; GIT=/usr/bin/git; DEPLOY_REF=main
+# GIT comes from resolve_git, not a hardcoded /usr/bin/git: on a box with a
+# damaged Xcode CLT the pinned shim fails every call, and these tests then fail
+# for a reason that has nothing to do with what they are checking (mg-36e3).
+SRC="$WORK/src"; DEPLOY_REF=main
+resolve_git >/dev/null 2>&1 || { echo "FATAL: no working git for the sync_src tests"; exit 1; }
 POGO_DEPLOY_REMOTE="$UPSTREAM"; DEPLOY_REMOTE="$UPSTREAM"
 sync_src >/dev/null 2>&1 && pass "sync_src bootstraps the dedicated checkout on first run" || fail "sync_src bootstrap"
 echo two > "$UPSTREAM/f"; git -C "$UPSTREAM" commit --quiet -am two


### PR DESCRIPTION
<h4>Description</h4>

Cutting over from the broken `com.pogo.daily-rebuild` nightly to the upstream `com.pogo.deploy` job (mg-36e3) turned up two host-side defects that would have made the new job run every night and deploy nothing — the exact silent-nightly failure it was written to end. Both are fixed here, with tests.

**`pogo-deploy.sh` pinned `GIT=/usr/bin/git`.** The reasoning in the file was that git ships in `/usr/bin` on every macOS, which is true — but that path is the Xcode Command Line Tools *shim*, and on a host with a damaged Xcode it fails **every** invocation, `git --version` included, with `unable to locate xcodebuild` and exit 71. The nightly could not clone, fetch, or read a revision, so `sync_src` aborted and the job alerted instead of deploying. `git` is now resolved the way the file already resolved `mg`: candidates in order, each required to prove itself by actually running, preferring a real Homebrew/local git while keeping the shim as a fallback so a CLT-only box still works. The lesson the file now records is that for this script *execution*, not an absolute path, was ever the safety property — a broken shim is executable, is on `PATH`, and passes every check short of running it. This also repairs three pre-existing failures in `scripts/pogo-deploy_test.sh`, which hardcoded the same dead path; worth noting that the negative assertions beside them had been passing **vacuously**, since `sync_src` did fail, just for the wrong reason.

**`pogo service install-deploy` did not bind the file that actually holds `GH_TOKEN`.** The runner treats a missing token as a hard abort and reads exactly one file, `$POGO_DEPLOY_ZSHENV`, defaulting to `~/.zshenv`. That default is the principled one — `.zshenv` is the only zsh init file a non-interactive shell sources — but it is routinely not where the export lives, and a host keeping it in `~/.zshrc` got a nightly that alerted every night about a secret that was on disk the whole time. The installer now detects which of `.zshenv`, `.zshrc`, `.zprofile` contains the `export GH_TOKEN=` line and binds `POGO_DEPLOY_ZSHENV` to it, preferring `.zshenv`. Only the **path** is written to the plist, never the value — `~/Library/LaunchAgents` is world-readable — and a new test asserts the token value can never reach it.

Caller-visible effects: `install-deploy` prints one extra line naming the file it will read the token from, and the generated plist carries a new `POGO_DEPLOY_ZSHENV` key. A `GIT=` override is still honoured, now health-checked. `--help` for the runner is bounded by the `set -u` sentinel rather than a hardcoded line number, which had already drifted and was truncating the ENV list mid-list. No behaviour change on a healthy host: `/usr/bin/git` remains a candidate and is accepted when it works.

<!-- payit-compliance-checklist-start -->
<details open>
<summary><h4>Compliance Checklist</h4></summary>

- [x] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have [submitted a ticket to InfoSec](https://payitdev.atlassian.net/servicedesk/customer/portal/15/group/154/create/526) to review the new project and gained approval.

- [x] I have verified that the backout plan for this change conforms to our standard engineering backout plan located [here](https://payitdev.atlassian.net/wiki/spaces/SEC/pages/2833416205/Standard+Change+Control+Back+Out+Plan). If it does not, I have documented an alternative backout plan below:

  Standard `git revert` of this commit. Because the change also ships an installed artifact, the full reversal is: revert, then re-run `pogo service install-deploy` to rewrite `~/.pogo/bin/pogo-deploy.sh` and the plist from the reverted source. The job is `RunAtLoad=false`, so neither installing nor reverting bounces anything. Reverting restores the prior behaviour on a healthy host and restores the nightly-abort on a host with a broken Xcode CLT.

- [x] I have verified that this change is backwards compatible. If it is not, I have specified the breaking changes and how they will be handled below:

  Additive. The plist gains a key; an operator-set `GIT` is still honoured; `/usr/bin/git` is still a candidate and is used when it works. `POGO_DEPLOY_ZSHENV` already existed as a documented runner override — this only binds it.

- [x] I have verified that this change will not impact the security controls built into the application or introduce any new security vulnerabilities. If it will, I have defined the security impact below:

  Reviewed specifically, since the change touches secret handling, and it preserves the existing control rather than relaxing it. The no-secret-in-the-plist invariant is unchanged and is now **enforced by a test** (`TestRenderDeployPlistBindsZshEnvPathNotSecret` asserts the token value never appears in the rendered plist; the pre-existing `TestRenderDeployPlistHasNoSecrets` still passes). `deployZshEnv()` reads candidate init files only to test for the presence of an `export GH_TOKEN=` line; the value is never captured, returned, logged, or written. The runner still `eval`s that single matched line rather than sourcing the file. One honest note: the plist now names *which* world-readable-adjacent file holds the token (e.g. `/Users/<user>/.zshrc`), which discloses the location but not the secret — the previous code disclosed the same fact by hardcoding `~/.zshenv`, so this is not a new class of disclosure.

- [x] I have verified that this change will not result in downtime. If it will, I have noted the impact below:

  No process is started, stopped, or restarted by this change. `RunAtLoad=false` means installing or reloading the job does not bounce the fleet; `pogod` was deliberately left running and untouched.

- [x] I have verified that no new dependencies were introduced. If they were, I have vetted them below:

  No `go.mod`/`go.sum` change. The one new import, `regexp`, is Go standard library.

- [x] I have verified that all applicable tests were updated to ensure complete test coverage of any new or modified code.

  `scripts/pogo-deploy_test.sh` gains six assertions for `resolve_git` — including that a pinned-but-broken git is rejected (the core regression, using a fake that reproduces exit 71 with empty stdout), that an executable-but-broken candidate proves `-x` cannot catch this, and a grep guard against the hardcoded path returning. `internal/service/deploy_test.go` gains `TestDeployZshEnvFindsTheTokenFile` (six sub-cases: token in `.zshrc` only, `.zshenv` preference, indented export, commented-out export ignored, fallback when absent, `.zprofile`) and the secret-leak assertion above. The shell suite goes from 49 passing / 3 failing to 58 passing on this host.

- [x] I have verified that any relevant documentation such as the README is still up to date and not impacted by my changes. If documentation needs updating for accuracy, I have done so.

  Updated `scripts/launchd/README.md` — the tool-resolution section now covers `git`-by-execution, the `GH_TOKEN` section describes the bound init file, the plist-contract table gains the `POGO_DEPLOY_ZSHENV` row, and the runner-env table documents `GIT` and the new `POGO_DEPLOY_ZSHENV` default. The runner's own header and inline ENV list are updated to match, and a `changelog.d/mg-36e3.fixed.md` fragment is added per `changelog.d/README.md`.
</details>
<!-- payit-compliance-checklist-end -->
