### PR TITLE
fix(gitgc): decide worktree in-use by live-agent path ownership, not branch name (mg-3b7c)

### DIFF
--- a/changelog.d/mg-3b7c.fixed.md
+++ b/changelog.d/mg-3b7c.fixed.md
@@ -1,0 +1,41 @@
+- **git GC no longer deletes a LIVE polecat's worktree when it has checked out
+  a branch other than its own (mg-3b7c).** The sweep decided a worktree was in
+  use by taking its CHECKED-OUT BRANCH, stripping `polecat-`, and looking the
+  remainder up in the live set. That assumed every polecat stays on its own
+  `polecat-<name>` branch for its whole life — but a polecat dispatched to fix
+  or rebase an **existing pull request** must check out that PR's head branch,
+  because that is the only way to update a PR in place. The moment it did, its
+  worktree resolved to the *other* polecat's name, missed the live set,
+  inherited that other ticket's concluded state, and was removed **together
+  with the branch ref** out from under a running agent that pogod was still
+  reporting healthy. On 2026-07-29 that took out polecat `caa65`'s worktree
+  five minutes after it was created; the work survived only because the commit
+  was still loose in the shared object store, which a `--prune=now` would have
+  reaped. This is a whole class of ticket, not an edge case: every
+  fix-the-conflicts-on-PR-#N dispatch produces it, and the workflow cannot be
+  changed away without abandoning PR continuity.
+
+  In-use is now decided by **worktree PATH ownership**, which is what pogod
+  knew all along — it records `Agent.WorktreeDir` at spawn and logs it — and
+  never passed to the sweep. pogod now supplies it as
+  `gitgc.Options.LiveWorktrees`, and gitgc additionally re-derives
+  `<PolecatsDir>/<name>` for every live NAME, so a polecat that outlived the
+  pogod which spawned it (registry empty after a restart, only the on-disk
+  witness left, which stores names and not paths) is covered too. Paths
+  compare through symlinks, since git canonicalizes the worktree paths it
+  reports and `/var` vs `/private/var` would otherwise read as two trees.
+
+  Three further guards ride along:
+
+  - a branch checked out in any **surviving** worktree is never deleted —
+    `freed` used to be set *before* the removal was attempted, so a removal
+    that FAILED still told the branch phase the ref was loose;
+  - a worktree holding another polecat's branch is kept even when nobody is
+    live, because that ticket's conclusion is not evidence about this
+    directory;
+  - pogod logs **which** worktree or branch it destroyed and why, instead of
+    only `deleted N branches, removed N worktrees` — the count-only line is
+    why diagnosing this took a log grep plus the affected polecat's own
+    incident report.
+
+  Prune stays conservative; nothing moves toward `--prune=now`.

--- a/cmd/pogod/gitgc.go
+++ b/cmd/pogod/gitgc.go
@@ -79,12 +79,14 @@ func runGitGCSweep(reg *agent.Registry, cfg config.GitGCConfig) {
 		log.Printf("pogod: git GC skipped — cannot read polecat witness: %v", err)
 		return
 	}
+	liveWorktrees := livePolecatWorktrees(reg)
 	for _, repo := range repos {
 		res, err := gitgc.Sweep(gitgc.Options{
-			Repo:         repo,
-			LivePolecats: live,
-			Tickets:      tickets,
-			PolecatsDir:  polecatsDir,
+			Repo:          repo,
+			LivePolecats:  live,
+			LiveWorktrees: liveWorktrees,
+			Tickets:       tickets,
+			PolecatsDir:   polecatsDir,
 		})
 		if err != nil {
 			log.Printf("pogod: git GC sweep of %s failed: %v", repo, err)
@@ -93,11 +95,33 @@ func runGitGCSweep(reg *agent.Registry, cfg config.GitGCConfig) {
 		if len(res.BranchesDeleted) > 0 || len(res.WorktreesRemoved) > 0 || len(res.Errors) > 0 {
 			log.Printf("pogod: git GC %s — deleted %d branches, removed %d worktrees, %d errors",
 				repo, len(res.BranchesDeleted), len(res.WorktreesRemoved), len(res.Errors))
+			// Then name each one. The counts alone are what made mg-3b7c take a
+			// log grep plus a polecat's own incident report to diagnose: "removed
+			// 1 worktrees" does not say WHICH tree vanished, and the agent whose
+			// tree it was gets no signal at all. A destructive action should be
+			// legible from the log that records it.
+			for _, w := range res.WorktreesRemoved {
+				log.Printf("pogod: git GC %s removed worktree %s (branch %s) — %s",
+					repo, w.Path, orNone(w.Branch), w.Reason)
+			}
+			for _, b := range res.BranchesDeleted {
+				log.Printf("pogod: git GC %s deleted branch %s (work item %s) — %s",
+					repo, b.Branch, orNone(b.ID), b.Reason)
+			}
 			for _, e := range res.Errors {
 				log.Printf("pogod: git GC %s error: %s", repo, e)
 			}
 		}
 	}
+}
+
+// orNone renders an empty optional field as a word rather than a blank gap in
+// the middle of a log line.
+func orNone(s string) string {
+	if s == "" {
+		return "none"
+	}
+	return s
 }
 
 // gitGCRepos returns the deduplicated set of repositories to sweep:
@@ -167,4 +191,26 @@ func livePolecatSet(reg *agent.Registry) (map[string]bool, error) {
 		}
 	}
 	return live, nil
+}
+
+// livePolecatWorktrees returns the worktree DIRECTORY of every polecat in the
+// registry, which is what gitgc uses to decide a tree is in use. pogod has
+// known this all along — it records WorktreeDir at spawn and logs it ("polecat
+// <name>: created worktree at <path>") — but never handed it to the sweep,
+// which was left inferring occupancy from the checked-out branch instead and
+// deleted a running polecat's tree because of it (mg-3b7c).
+//
+// Registry-only on purpose: the persisted witness records names and PIDs, not
+// paths, so it cannot answer this. That gap is closed inside gitgc, which
+// re-derives <PolecatsDir>/<name> for every live NAME — covering the polecat
+// that outlived the pogod which spawned it, whose registry entry is gone.
+// Exited agents are excluded; their trees are what the sweep is for.
+func livePolecatWorktrees(reg *agent.Registry) map[string]bool {
+	paths := map[string]bool{}
+	for _, a := range reg.List() {
+		if a.Type == agent.TypePolecat && a.Status != agent.StatusExited && a.WorktreeDir != "" {
+			paths[a.WorktreeDir] = true
+		}
+	}
+	return paths
 }

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -418,19 +418,35 @@ An environment override exists for the file-count ceiling
 Every polecat runs in an isolated git worktree on its own
 `polecat-<agent-name>` branch — named after the agent name passed to
 `spawn-polecat`, not the work item id (`spawn-polecat abea --id=mg-abea`
-gets branch `polecat-abea`). `gitgc` relies on this: a polecat's name equals
-its branch's `polecat-` suffix *and* its worktree basename. When a polecat exits — normally or abnormally — pogod removes that
-worktree. But branches accumulate, and a worktree can still leak if pogod
-itself dies mid-polecat. pogo garbage-collects both, plus orphaned polecat
-directories under `~/.pogo/polecats` — dirs no longer in `git worktree
-list` whose files were never deleted because the exit cleanup never got to
-run (gh #31).
+gets branch `polecat-abea`, in a worktree at `~/.pogo/polecats/abea`). When
+a polecat exits — normally or abnormally — pogod removes that worktree. But
+branches accumulate, and a worktree can still leak if pogod itself dies
+mid-polecat. pogo garbage-collects both, plus orphaned polecat directories
+under `~/.pogo/polecats` — dirs no longer in `git worktree list` whose files
+were never deleted because the exit cleanup never got to run (gh #31).
 
 The collector (`internal/gitgc`) only ever touches artifacts whose work
 item has **concluded**: an archived ticket's branch is deleted
 unconditionally; a done ticket's branch is deleted once it is merged into
 `main`. Branches of in-flight work, of currently-running polecats, and
 anything whose work item cannot be positively identified are always kept.
+
+**A worktree is in use when a live agent owns its directory** — not when its
+checked-out branch happens to match `polecat-<name>`. The distinction is
+load-bearing: a polecat dispatched to fix or rebase an existing pull request
+*must* check out that PR's head branch, because that is the only way to
+update a PR in place. Its worktree is still `~/.pogo/polecats/<its-name>`,
+and that path is what the collector matches against pogod's live agents.
+Consequently:
+
+- a live polecat's worktree is never removed, whatever branch is inside it;
+- a branch checked out in any surviving worktree is never deleted;
+- a worktree holding a branch belonging to some *other* polecat is kept even
+  when nobody is live — that other ticket's conclusion says nothing about
+  whether this directory is finished with.
+
+Every removal is logged individually, naming the worktree path or branch and
+the reason, rather than only a count.
 
 pogod runs it automatically — once on startup (catching anything leaked
 while pogod was down) and then on a periodic ticker. Tune it with a

--- a/internal/gitgc/foreignbranch_test.go
+++ b/internal/gitgc/foreignbranch_test.go
@@ -1,0 +1,318 @@
+package gitgc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The regression suite for mg-3b7c: a LIVE polecat whose worktree has a branch
+// other than its own polecat-<name> checked out.
+//
+// This is not a hypothetical shape. It is what every ticket of the form "fix
+// the conflicts on PR #N" produces, because updating an existing pull request
+// in place requires checking out that PR's head branch — there is no other
+// way to do it, so the platform has to support it. On 2026-07-29 the sweep
+// removed polecat caa65's worktree and deleted the branch ref five minutes
+// after the worktree was created, while the agent was still running and still
+// reported healthy by `pogo agent list`. The work survived only because the
+// commit was still loose in the shared object store.
+//
+// The names below mirror that incident with in-convention 4-hex codes: `aa65`
+// is the live polecat (worktree <polecats>/aa65), `dccb` is the other
+// polecat's PR head branch it had to check out, and mg-dccb is long since
+// archived — which is precisely what made the tree look reclaimable.
+
+// polecatWorktree registers a worktree for branch at <polecatsDir>/<name>,
+// exactly as internal/agent lays one out at spawn.
+func (r *testRepo) polecatWorktree(polecatsDir, name, branch string) string {
+	r.t.Helper()
+	path := filepath.Join(polecatsDir, name)
+	r.git("worktree", "add", "-q", path, branch)
+	return path
+}
+
+// tempPolecatsDir returns a symlink-resolved temp dir to stand in for
+// ~/.pogo/polecats, so paths built here match what git reports.
+func tempPolecatsDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if real, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = real
+	}
+	return dir
+}
+
+func hasWorktreeKept(res Result, path string) (WorktreeAction, bool) {
+	for _, w := range res.WorktreesKept {
+		if w.Path == path {
+			return w, true
+		}
+	}
+	return WorktreeAction{}, false
+}
+
+// TestSweepKeepsLiveWorktreeOnForeignBranch is the incident itself: the sweep
+// must keep both the tree and the ref when a live agent owns the directory,
+// regardless of which branch is checked out inside it.
+func TestSweepKeepsLiveWorktreeOnForeignBranch(t *testing.T) {
+	r := newTestRepo(t)
+	polecats := tempPolecatsDir(t)
+
+	r.branch("polecat-dccb") // another polecat's PR head, ticket long archived
+	wt := r.polecatWorktree(polecats, "aa65", "polecat-dccb")
+
+	tickets := TicketIndex{
+		"mg-dccb": TicketArchived,
+		"mg-aa65": TicketInFlight,
+	}
+	res, err := Sweep(Options{
+		Repo:          r.dir,
+		TargetBranch:  "main",
+		Tickets:       tickets,
+		PolecatsDir:   polecats,
+		LivePolecats:  map[string]bool{"aa65": true},
+		LiveWorktrees: map[string]bool{wt: true},
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("unexpected sweep errors: %v", res.Errors)
+	}
+
+	if _, err := os.Stat(wt); err != nil {
+		t.Errorf("live polecat's worktree must survive the sweep: %v", err)
+	}
+	if len(res.WorktreesRemoved) != 0 {
+		t.Errorf("nothing should have been removed, got %+v", res.WorktreesRemoved)
+	}
+	if len(res.BranchesDeleted) != 0 {
+		t.Errorf("no branch should have been deleted, got %+v", res.BranchesDeleted)
+	}
+
+	// The branch ref is what made the incident near-unrecoverable: deleting it
+	// left the commit reachable only as a dangling object.
+	remaining, _ := ListPolecatBranches(r.dir)
+	var found bool
+	for _, b := range remaining {
+		if b == "polecat-dccb" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("polecat-dccb ref must survive; remaining branches = %v", remaining)
+	}
+
+	// The kept reason has to name the situation, not just say "kept" — the
+	// original diagnosis needed a log grep plus the polecat's own report.
+	kept, ok := hasWorktreeKept(res, wt)
+	if !ok {
+		t.Fatalf("worktree %s should appear in WorktreesKept, got %+v", wt, res.WorktreesKept)
+	}
+	if !strings.Contains(kept.Reason, "live polecat") || !strings.Contains(kept.Reason, "polecat-dccb") {
+		t.Errorf("kept reason should name the live owner and the foreign branch, got %q", kept.Reason)
+	}
+}
+
+// TestSweepKeepsLiveWorktreeOnForeignBranchAfterRestart covers the same shape
+// with the registry empty — the state pogod is in after a restart, when the
+// only evidence is the on-disk witness, which records names and not paths.
+// gitgc must re-derive <PolecatsDir>/<name> rather than fall back to the
+// branch, or the fix would not survive the very restart that widened mg-0130.
+func TestSweepKeepsLiveWorktreeOnForeignBranchAfterRestart(t *testing.T) {
+	r := newTestRepo(t)
+	polecats := tempPolecatsDir(t)
+
+	r.branch("polecat-dccb")
+	wt := r.polecatWorktree(polecats, "aa65", "polecat-dccb")
+
+	res, err := Sweep(Options{
+		Repo:         r.dir,
+		TargetBranch: "main",
+		Tickets:      TicketIndex{"mg-dccb": TicketArchived},
+		PolecatsDir:  polecats,
+		LivePolecats: map[string]bool{"aa65": true}, // witness-only: no path
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Errorf("worktree must survive on the name-derived path alone: %v", err)
+	}
+	if len(res.WorktreesRemoved) != 0 || len(res.BranchesDeleted) != 0 {
+		t.Errorf("nothing should have been destroyed: removed=%+v deleted=%+v",
+			res.WorktreesRemoved, res.BranchesDeleted)
+	}
+}
+
+// TestSweepKeepsLiveWorktreeByBasename covers the `pogo gc` CLI path, where
+// the live set arrives from pogod's HTTP agent list as bare names and no
+// PolecatsDir was resolvable. A polecat worktree is named for its polecat by
+// construction, so the basename is still direct evidence of ownership.
+func TestSweepKeepsLiveWorktreeByBasename(t *testing.T) {
+	r := newTestRepo(t)
+	elsewhere := tempPolecatsDir(t)
+
+	r.branch("polecat-dccb")
+	wt := r.polecatWorktree(elsewhere, "aa65", "polecat-dccb")
+
+	res, err := Sweep(Options{
+		Repo:         r.dir,
+		TargetBranch: "main",
+		Tickets:      TicketIndex{"mg-dccb": TicketArchived},
+		LivePolecats: map[string]bool{"aa65": true},
+		// No PolecatsDir, no LiveWorktrees.
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Errorf("worktree must survive on the basename match alone: %v", err)
+	}
+	if len(res.WorktreesRemoved) != 0 || len(res.BranchesDeleted) != 0 {
+		t.Errorf("nothing should have been destroyed: removed=%+v deleted=%+v",
+			res.WorktreesRemoved, res.BranchesDeleted)
+	}
+}
+
+// TestSweepLiveWorktreeMatchesThroughSymlink guards the path comparison. git
+// canonicalizes the worktree paths it reports; a path handed to us from the
+// agent registry has not been, and on macOS ~/.pogo under /var vs /private/var
+// is exactly that mismatch. A comparison that missed it would silently drop
+// the whole protection.
+func TestSweepLiveWorktreeMatchesThroughSymlink(t *testing.T) {
+	r := newTestRepo(t)
+	polecats := tempPolecatsDir(t)
+
+	r.branch("polecat-dccb")
+	wt := r.polecatWorktree(polecats, "aa65", "polecat-dccb")
+
+	// A second name for the same directory, as the registry might hold.
+	link := filepath.Join(t.TempDir(), "polecats-link")
+	if err := os.Symlink(polecats, link); err != nil {
+		t.Skipf("cannot create symlink on this filesystem: %v", err)
+	}
+	viaLink := filepath.Join(link, "aa65")
+
+	res, err := Sweep(Options{
+		Repo:          r.dir,
+		TargetBranch:  "main",
+		Tickets:       TicketIndex{"mg-dccb": TicketArchived},
+		LiveWorktrees: map[string]bool{viaLink: true},
+		// Deliberately no LivePolecats: the path must carry it alone.
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Errorf("worktree named through a symlink must still be recognised: %v", err)
+	}
+	if len(res.WorktreesRemoved) != 0 || len(res.BranchesDeleted) != 0 {
+		t.Errorf("nothing should have been destroyed: removed=%+v deleted=%+v",
+			res.WorktreesRemoved, res.BranchesDeleted)
+	}
+}
+
+// TestSweepKeepsForeignBranchWorktreeOfDeadPolecat is the other half of the
+// same conflation. Even with nobody live, another ticket's conclusion says
+// nothing about whether THIS directory is finished with, so the tree is kept
+// and reported rather than reclaimed on borrowed evidence.
+func TestSweepKeepsForeignBranchWorktreeOfDeadPolecat(t *testing.T) {
+	r := newTestRepo(t)
+	polecats := tempPolecatsDir(t)
+
+	r.branch("polecat-dccb")
+	wt := r.polecatWorktree(polecats, "aa65", "polecat-dccb")
+
+	res, err := Sweep(Options{
+		Repo:         r.dir,
+		TargetBranch: "main",
+		Tickets:      TicketIndex{"mg-dccb": TicketArchived, "mg-aa65": TicketInFlight},
+		PolecatsDir:  polecats,
+		// No live polecats at all.
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Errorf("worktree should be kept, not reclaimed on another ticket's state: %v", err)
+	}
+	kept, ok := hasWorktreeKept(res, wt)
+	if !ok {
+		t.Fatalf("worktree %s should be reported as kept, got %+v", wt, res.WorktreesKept)
+	}
+	if !strings.Contains(kept.Reason, "another polecat's branch") {
+		t.Errorf("kept reason should explain the mismatch, got %q", kept.Reason)
+	}
+}
+
+// TestSweepStillReclaimsConcludedPolecatWorktree pins the behaviour the fix
+// must NOT cost: a dead polecat sitting on its OWN concluded branch is still
+// swept, tree and ref together. Without this, the guards above could be
+// satisfied by a GC that simply stopped collecting.
+func TestSweepStillReclaimsConcludedPolecatWorktree(t *testing.T) {
+	r := newTestRepo(t)
+	polecats := tempPolecatsDir(t)
+
+	r.branch("polecat-aa65")
+	wt := r.polecatWorktree(polecats, "aa65", "polecat-aa65")
+
+	res, err := Sweep(Options{
+		Repo:         r.dir,
+		TargetBranch: "main",
+		Tickets:      TicketIndex{"mg-aa65": TicketArchived},
+		PolecatsDir:  polecats,
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("unexpected sweep errors: %v", res.Errors)
+	}
+	if _, err := os.Stat(wt); !os.IsNotExist(err) {
+		t.Errorf("concluded polecat's worktree should be gone, stat err = %v", err)
+	}
+	if len(res.WorktreesRemoved) != 1 {
+		t.Errorf("want the worktree removed, got %+v", res.WorktreesRemoved)
+	}
+	if deleted := branchSet(res.BranchesDeleted); !deleted["polecat-aa65"] {
+		t.Errorf("want polecat-aa65 deleted, got %v", keys(deleted))
+	}
+}
+
+// TestSweepNeverDeletesBranchCheckedOutInSurvivingWorktree pins the rule
+// directly: whatever else the sweep concludes, a ref that a still-present
+// worktree has checked out is not deletable. `freed` used to be set before the
+// removal was even attempted, so a removal that FAILED still told the branch
+// phase the ref was loose.
+func TestSweepNeverDeletesBranchCheckedOutInSurvivingWorktree(t *testing.T) {
+	r := newTestRepo(t)
+	polecats := tempPolecatsDir(t)
+
+	// Concluded and merged: every gate except the checkout is open.
+	r.branch("polecat-aa65")
+	wt := r.polecatWorktree(polecats, "aa65", "polecat-aa65")
+
+	res, err := Sweep(Options{
+		Repo:          r.dir,
+		TargetBranch:  "main",
+		Tickets:       TicketIndex{"mg-aa65": TicketArchived},
+		PolecatsDir:   polecats,
+		LiveWorktrees: map[string]bool{wt: true}, // owner is live -> tree stays
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Fatalf("precondition: worktree should have been kept: %v", err)
+	}
+	if deleted := branchSet(res.BranchesDeleted); deleted["polecat-aa65"] {
+		t.Errorf("branch checked out in a surviving worktree must not be deleted")
+	}
+	remaining, _ := ListPolecatBranches(r.dir)
+	if len(remaining) != 1 || remaining[0] != "polecat-aa65" {
+		t.Errorf("polecat-aa65 should still exist, got %v", remaining)
+	}
+}

--- a/internal/gitgc/sweep.go
+++ b/internal/gitgc/sweep.go
@@ -21,7 +21,43 @@ type Options struct {
 	// pogod fills this from its agent registry so a sweep never disturbs a
 	// running polecat — even one whose worktree was unlinked at refinery
 	// submit time and so is no longer git-checked-out.
+	//
+	// A NAME is not by itself an answer to "is this worktree in use" — see
+	// LiveWorktrees. It still answers "is this BRANCH a live polecat's own
+	// branch", and it names the worktree directory a live polecat owns, so
+	// both uses survive.
 	LivePolecats map[string]bool
+	// LiveWorktrees is the do-not-touch set keyed by worktree PATH — the
+	// directory a live agent is actually working in, as recorded at spawn
+	// time (Agent.WorktreeDir). It is the authoritative in-use signal, and
+	// the one that matters: a polecat's worktree belongs to the polecat, not
+	// to whatever branch happens to be checked out inside it.
+	//
+	// # Why a path and not a branch name (mg-3b7c)
+	//
+	// The sweep used to decide a worktree was in use by taking its
+	// CHECKED-OUT BRANCH, stripping "polecat-", and looking the remainder up
+	// in LivePolecats. That silently assumed every polecat stays on its own
+	// polecat-<name> branch for its whole life. It does not, and cannot: a
+	// polecat dispatched to fix or rebase an EXISTING pull request must check
+	// out that PR's head branch, because there is no other way to update a PR
+	// in place. The moment it did, its worktree resolved to the OTHER
+	// polecat's name, missed the live set, inherited that other ticket's
+	// concluded state, and was removed — with the branch ref — out from under
+	// a running agent. On 2026-07-29 that removed polecat caa65's worktree
+	// five minutes after it was created; the work survived only because the
+	// commit was still loose in the shared object store, which a
+	// `--prune=now` would have reaped.
+	//
+	// Ownership is a property of the directory, so it is checked against the
+	// directory. Paths are compared after symlink resolution, since git
+	// canonicalizes worktree paths and /var vs /private/var would otherwise
+	// read as two different trees on macOS.
+	//
+	// Empty is not "nothing is live": the name-derived fallbacks in
+	// liveWorktreePaths still apply, and callers that supply neither get the
+	// conservative behaviour of keeping anything they cannot classify.
+	LiveWorktrees map[string]bool
 	// Tickets, when non-nil, supplies work-item states directly. When nil,
 	// Sweep loads them via LoadTicketIndex (`mg list`). Injecting a map
 	// keeps Sweep unit-testable without the mg binary.
@@ -54,6 +90,101 @@ func (o Options) logf(format string, args ...any) {
 	if o.Logf != nil {
 		o.Logf(format, args...)
 	}
+}
+
+// canonicalPaths returns the spellings of p that a comparison should accept:
+// the cleaned path, plus its symlink-resolved form when that differs and the
+// path still exists. Both are kept rather than picking one, because the two
+// sides of a comparison resolve differently — git canonicalizes the worktree
+// paths it reports, while a path assembled from PolecatsDir has not been — and
+// on macOS ~/.pogo under /var vs /private/var is exactly that mismatch.
+func canonicalPaths(p string) []string {
+	if p == "" {
+		return nil
+	}
+	clean := filepath.Clean(p)
+	out := []string{clean}
+	if resolved, err := filepath.EvalSymlinks(clean); err == nil {
+		if resolved = filepath.Clean(resolved); resolved != clean {
+			out = append(out, resolved)
+		}
+	}
+	return out
+}
+
+// liveWorktreePaths returns every worktree directory a live agent owns, in all
+// spellings a comparison might see. It unions two sources because neither is
+// complete alone:
+//
+//   - Options.LiveWorktrees — the paths pogod read straight off its agent
+//     registry (Agent.WorktreeDir). Authoritative, but empty for a polecat
+//     that outlived the pogod which spawned it: the registry has no reattach
+//     path, so a restart leaves only the on-disk witness, which records names
+//     and not paths.
+//   - <PolecatsDir>/<name> for each live NAME — the convention every polecat
+//     worktree is created under (internal/agent calls DefaultPolecatsDir and
+//     joins the polecat's name; that function's doc names itself the single
+//     source of truth for the location). This is what covers the
+//     witness-only survivor, and it is why the fix does not depend on a
+//     pogod restart to take effect.
+func (o Options) liveWorktreePaths() map[string]bool {
+	set := map[string]bool{}
+	add := func(p string) {
+		for _, c := range canonicalPaths(p) {
+			set[c] = true
+		}
+	}
+	for p := range o.LiveWorktrees {
+		add(p)
+	}
+	if o.PolecatsDir != "" {
+		for name := range o.LivePolecats {
+			add(filepath.Join(o.PolecatsDir, name))
+		}
+	}
+	return set
+}
+
+// polecatDirOwner returns the name of the polecat that owns worktreeDir, when
+// that is knowable: a directory sitting directly under polecatsDir is a
+// polecat worktree and its basename is the polecat's name, because that is
+// precisely how internal/agent builds the path at spawn. Anywhere else the
+// answer is ("", false) — there is no naming convention to read an owner out
+// of, and guessing one would be worse than admitting ignorance.
+func polecatDirOwner(polecatsDir, worktreeDir string) (string, bool) {
+	if polecatsDir == "" || worktreeDir == "" {
+		return "", false
+	}
+	name := filepath.Base(filepath.Clean(worktreeDir))
+	for _, root := range canonicalPaths(polecatsDir) {
+		for _, wt := range canonicalPaths(worktreeDir) {
+			if filepath.Dir(wt) == root {
+				return name, true
+			}
+		}
+	}
+	return "", false
+}
+
+// ownedByLive reports whether a live agent owns worktreeDir. The question is
+// asked of the DIRECTORY and answered without ever consulting the branch
+// checked out inside it — that conflation is the mg-3b7c defect.
+//
+// The basename fallback is deliberate belt-and-braces: a polecat's worktree
+// directory is named for the polecat by construction, so a live name matching
+// the directory's basename is direct evidence of ownership even when neither
+// LiveWorktrees nor PolecatsDir was supplied (the `pogo gc` CLI path, where
+// the live set comes from pogod's HTTP agent list).
+func (o Options) ownedByLive(livePaths map[string]bool, worktreeDir string) bool {
+	if worktreeDir == "" {
+		return false
+	}
+	for _, c := range canonicalPaths(worktreeDir) {
+		if livePaths[c] {
+			return true
+		}
+	}
+	return o.LivePolecats[filepath.Base(filepath.Clean(worktreeDir))]
 }
 
 // BranchAction records the GC decision for one polecat branch.
@@ -117,12 +248,39 @@ func Sweep(opts Options) (Result, error) {
 		return res, fmt.Errorf("list worktrees: %w", err)
 	}
 
-	// Branches whose worktree was (or would be) removed this pass — they
-	// become un-checked-out and thus deletable in phase 2.
+	// Branches whose worktree was removed this pass — they become
+	// un-checked-out and thus deletable in phase 2.
 	freed := map[string]bool{}
+	// Branches held by a worktree a live agent owns, mapped to that worktree.
+	// Phase 2 refuses to delete these and says whose tree is holding them.
+	heldByLive := map[string]string{}
+
+	livePaths := opts.liveWorktreePaths()
 
 	for _, wt := range worktrees {
-		if wt.Main || wt.Bare || !wt.IsPolecat() {
+		if wt.Main || wt.Bare {
+			continue
+		}
+		// Ownership is decided FIRST and by PATH, before the branch is even
+		// looked at. A live agent's worktree is off limits whatever it has
+		// checked out — its own polecat branch, another polecat's PR head, or
+		// a plain upstream branch (mg-3b7c).
+		if opts.ownedByLive(livePaths, wt.Path) {
+			reason := "live polecat owns this worktree"
+			if wt.Branch != "" {
+				heldByLive[wt.Branch] = wt.Path
+				if BranchSuffix(wt.Branch) != filepath.Base(filepath.Clean(wt.Path)) {
+					// Worth naming: this is precisely the shape that used to be
+					// mistaken for an orphan.
+					reason += " (working on branch " + wt.Branch + ")"
+				}
+			}
+			res.WorktreesKept = append(res.WorktreesKept, WorktreeAction{
+				Path: wt.Path, Branch: wt.Branch, Reason: reason,
+			})
+			continue
+		}
+		if !wt.IsPolecat() {
 			continue
 		}
 		name := BranchSuffix(wt.Branch)
@@ -130,6 +288,27 @@ func Sweep(opts Options) (Result, error) {
 			res.WorktreesKept = append(res.WorktreesKept, WorktreeAction{
 				Path: wt.Path, Branch: wt.Branch, Reason: "live polecat",
 			})
+			continue
+		}
+		// A branch that is not this directory's own is not evidence about this
+		// directory. mg-3b7c is the liveness half of that conflation; this is
+		// the other half — a polecat that ended on someone else's PR head
+		// would otherwise have its tree reclaimed on the strength of THAT
+		// ticket's conclusion, which says nothing about whether this tree is
+		// finished with. Keep and report; a leaked directory is recoverable
+		// and a deleted one is not.
+		//
+		// Only asked where the answer is knowable: under PolecatsDir a
+		// worktree's basename IS its owning polecat's name (internal/agent
+		// joins exactly that at spawn). Anywhere else there is no owner to
+		// infer, so the branch remains the only classifier available.
+		if owner, ok := polecatDirOwner(opts.PolecatsDir, wt.Path); ok && owner != name {
+			res.WorktreesKept = append(res.WorktreesKept, WorktreeAction{
+				Path: wt.Path, Branch: wt.Branch,
+				Reason: fmt.Sprintf("worktree of polecat %s holds another polecat's branch %s — "+
+					"that branch's ticket does not classify this tree", owner, wt.Branch),
+			})
+			opts.logf("kept worktree %s: holds foreign branch %s (owner %s)", wt.Path, wt.Branch, owner)
 			continue
 		}
 		_, state := tickets.BranchState(wt.Branch)
@@ -154,7 +333,6 @@ func Sweep(opts Options) (Result, error) {
 				continue
 			}
 		}
-		freed[wt.Branch] = true
 		action := WorktreeAction{Path: wt.Path, Branch: wt.Branch, Reason: "ticket " + state.String()}
 		if opts.DryRun {
 			opts.logf("would remove worktree %s (%s)", wt.Path, wt.Branch)
@@ -165,6 +343,11 @@ func Sweep(opts Options) (Result, error) {
 			}
 			opts.logf("removed worktree %s (%s)", wt.Path, wt.Branch)
 		}
+		// Marked only once the removal has actually succeeded (or was a dry
+		// run, where nothing was attempted). It used to be set before the
+		// attempt, so a FAILED removal still told phase 2 the branch was free
+		// — deleting the ref out from under a worktree that was still there.
+		freed[wt.Branch] = true
 		res.WorktreesRemoved = append(res.WorktreesRemoved, action)
 	}
 
@@ -185,7 +368,7 @@ func Sweep(opts Options) (Result, error) {
 		for _, wt := range worktrees {
 			registered[wt.Path] = true
 		}
-		sweepOrphanDirs(opts, tickets, registered, &res)
+		sweepOrphanDirs(opts, tickets, registered, livePaths, &res)
 	}
 
 	// Drop registrations whose directory is already gone.
@@ -215,9 +398,24 @@ func Sweep(opts Options) (Result, error) {
 			res.BranchesKept = append(res.BranchesKept, action)
 			continue
 		}
-		// A branch checked out in a worktree we did not remove cannot be
-		// deleted — git refuses, and we should not want to.
-		if checkedOut[br] && !freed[br] {
+		// A live agent is working in a tree that has this branch checked out.
+		// The branch is not that agent's own polecat-<name> branch — that case
+		// is caught above — which is exactly why this arm has to exist: a
+		// polecat sent to fix an existing PR holds a branch that looks, by
+		// name, like some other concluded polecat's (mg-3b7c).
+		if wtPath, held := heldByLive[br]; held {
+			action.Reason = "checked out in live polecat's worktree " + wtPath
+			res.BranchesKept = append(res.BranchesKept, action)
+			continue
+		}
+		// Never delete a branch that is checked out in a worktree that still
+		// exists — git refuses, and we should not want to. `checkedOut` is
+		// read AFTER phase 1, so a worktree successfully removed above is
+		// already absent from it; `freed` supplies the same answer for a dry
+		// run, where nothing was actually removed. Consulting `freed` only in
+		// dry-run mode is what keeps a failed removal from licensing the
+		// deletion of a still-checked-out ref.
+		if checkedOut[br] && !(opts.DryRun && freed[br]) {
 			action.Reason = "checked out in a worktree"
 			res.BranchesKept = append(res.BranchesKept, action)
 			continue
@@ -269,7 +467,7 @@ func Sweep(opts Options) (Result, error) {
 // directories directly under PolecatsDir whose basename resolves to a
 // concluded work item; anything with a .git entry is still a linked
 // worktree and is left to the registered-worktree scan of its owning repo.
-func sweepOrphanDirs(opts Options, tickets TicketIndex, registered map[string]bool, res *Result) {
+func sweepOrphanDirs(opts Options, tickets TicketIndex, registered, livePaths map[string]bool, res *Result) {
 	entries, err := os.ReadDir(opts.PolecatsDir)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -293,7 +491,7 @@ func sweepOrphanDirs(opts Options, tickets TicketIndex, registered map[string]bo
 			continue
 		}
 		branch := BranchPrefix + name
-		if opts.LivePolecats[name] {
+		if opts.ownedByLive(livePaths, path) {
 			res.WorktreesKept = append(res.WorktreesKept, WorktreeAction{
 				Path: path, Branch: branch, Reason: "orphan dir, live polecat",
 			})


### PR DESCRIPTION
<h4>Description</h4>

pogod's hourly git GC removed a **running** polecat's worktree and deleted its branch ref mid-task, because `Sweep` decided a worktree was in use by taking its **checked-out branch**, stripping `polecat-`, and looking the remainder up in the live set. That silently assumed every polecat stays on its own `polecat-<name>` branch for its whole life. It cannot: a polecat dispatched to fix or rebase an **existing pull request** must check out that PR's head branch, because that is the only way to update a PR in place. The moment it did, its worktree resolved to the *other* polecat's name, missed the live set, inherited that other ticket's concluded state, and was removed together with the branch ref out from under an agent that `pogo agent list` still reported healthy. On 2026-07-29 that took out polecat `caa65`'s worktree five minutes after it was created; the work survived only because the commit was still loose in the shared object store, which a `--prune=now` would have reaped. This is a whole class of dispatch, not an edge case — every "fix the conflicts on PR #N" ticket produces it. Filed upstream as Refs drellem2/pogo#94.

In-use is now decided by **worktree PATH ownership**, which pogod knew all along — it records `Agent.WorktreeDir` at spawn and logs `polecat <name>: created worktree at <path>` — and simply never handed to the sweep. pogod passes it as the new `gitgc.Options.LiveWorktrees`, and gitgc additionally re-derives `<PolecatsDir>/<name>` for every live *name*, so a polecat that outlived the pogod which spawned it (registry empty after a restart, only the on-disk witness left, and the witness stores names and PIDs but not paths) is covered too. Paths compare through `filepath.EvalSymlinks`, since git canonicalizes the worktree paths it reports and `/var` vs `/private/var` would otherwise read as two different trees on macOS. A basename fallback covers the `pogo gc` CLI, where the live set arrives from pogod's HTTP agent list as bare names.

Three further guards ride along: a branch checked out in any **surviving** worktree is never deleted (`freed` used to be set *before* the removal was attempted, so a removal that **failed** still told the branch phase the ref was loose); a worktree holding another polecat's branch is kept even when nobody is live, because that ticket's conclusion is not evidence about *this* directory; and pogod now logs **which** worktree or branch it destroyed and why, rather than only `deleted N branches, removed N worktrees` — the count-only line is why diagnosing this took a log grep plus the affected polecat's own incident report. Prune stays conservative; nothing moves toward `--prune=now`.

**Caller-visible effects.** `gitgc.Options` gains one optional field (`LiveWorktrees`); every existing call site compiles and behaves as before. The GC is strictly *more* conservative — it keeps trees and refs it previously destroyed and never destroys anything it previously kept, pinned by `TestSweepStillReclaimsConcludedPolecatWorktree`. pogod's GC log lines are additive: the existing summary line is unchanged, with per-item detail lines after it. The fix takes effect on the next pogod restart; no restart is performed by this PR.

`internal/gitgc/foreignbranch_test.go` reproduces the incident and each guard. Against the pre-fix `Sweep` the live-worktree cases fail exactly as observed in production — the tree is removed and `remaining branches = []`.

<!-- payit-compliance-checklist-start -->
<details open>
<summary><h4>Compliance Checklist</h4></summary>

- [x] I have verified that this is not a new project. If it is a new project (new service, new application, new repository), I have [submitted a ticket to InfoSec](https://payitdev.atlassian.net/servicedesk/customer/portal/15/group/154/create/526) to review the new project and gained approval.

- [x] I have verified that the backout plan for this change conforms to our standard engineering backout plan located [here](https://payitdev.atlassian.net/wiki/spaces/SEC/pages/2833416205/Standard+Change+Control+Back+Out+Plan). If it does not, I have documented an alternative backout plan below:

- [x] I have verified that this change is backwards compatible. If it is not, I have specified the breaking changes and how they will be handled below:

- [x] I have verified that this change will not impact the security controls built into the application or introduce any new security vulnerabilities. If it will, I have defined the security impact below:

- [x] I have verified that this change will not result in downtime. If it will, I have noted the impact below:

- [x] I have verified that no new dependencies were introduced. If they were, I have vetted them below:

- [x] I have verified that all applicable tests were updated to ensure complete test coverage of any new or modified code.

- [x] I have verified that any relevant documentation such as the README is still up to date and not impacted by my changes. If documentation needs updating for accuracy, I have done so.
</details>
<!-- payit-compliance-checklist-end -->

---

**Test evidence.** `go test ./...` passes clean. `./build.sh` exits 0. `scripts/pogo-deploy_test.sh` reports 49 passed and 3 `sync_src` FAILs — these are **pre-existing**, verified by running the identical suite against a pristine `git archive origin/main` checkout, which produces the same three failures. They are in `scripts/`, which this PR does not touch.
