### PR TITLE
fix(gitgc): key worktree liveness off the path, not the branch (gh #94)

### DIFF
--- a/changelog.d/mg-dd92.fixed.md
+++ b/changelog.d/mg-dd92.fixed.md
@@ -29,3 +29,10 @@
   always going to refuse — reporting an error in place of the correct "kept:
   checked out in a worktree". Found by code read during the gh #94 triage and
   never observed in the wild.
+
+- **`pogo gc` now itemises the worktrees it KEPT, not just the ones it removed
+  (mg-dd92).** `pogo gc --help` promises a worktree holding uncommitted work is
+  "KEPT and reported"; the summary reported it as a count, while pogod's log
+  emitted the full line. A preserved tree pins its branch until someone acts on
+  it, so a count told an operator a branch was stuck without telling them which
+  tree to go rescue.

--- a/changelog.d/mg-dd92.fixed.md
+++ b/changelog.d/mg-dd92.fixed.md
@@ -1,0 +1,31 @@
+- **git GC no longer deletes a live polecat's worktree when it works a foreign
+  branch (gh #94, mg-dd92).** The sweep decided whether a worktree was occupied
+  from the polecat name embedded in the branch *checked out inside it*, never
+  from the worktree's path — whose basename is the polecat that owns the tree.
+  A live polecat on any branch but its own was therefore invisible to the
+  liveness gate: it inherited the foreign, concluded ticket's state, its
+  worktree was removed mid-task, and freeing its branch waived the branch guard
+  so the ref went too. The agent kept running and `pogo agent list` kept
+  reporting it healthy; the work survived only while the commit was still loose
+  in the shared object store. Liveness is now keyed on the worktree **path**
+  (`gitgc.PolecatNameForWorktree`) and branch deletion on the branch suffix —
+  they answer different questions and neither substitutes for the other. Not a
+  v0.6.0 regression: the branch-keyed check has been present since `gitgc`
+  existed. A normal polecat exit still reaps its tree; the test that inverts the
+  reproduction carries that control in the same sweep.
+
+- **git GC says what it removed and why (gh #94, mg-dd92).** The sweep already
+  assembled path, owner, branch and reason for every decision and logged only
+  counts, so a removal in a multi-megabyte pogod log was a bare number and "did
+  the GC take my worktree" was unanswerable for any past incident. Every
+  destructive action — and every tree deliberately preserved — now logs a line
+  naming the repo, the tree, its owner, the branch checked out in it, and the
+  reason. `pogo gc`'s summary carries the same detail. Keeps are not logged per
+  tick; only actions.
+
+- **A failed worktree removal no longer tells the branch phase the branch was
+  freed (mg-dd92).** `freed[branch]` was set before removal was attempted and
+  survived a failure, so the sweep went on to attempt a branch deletion git was
+  always going to refuse — reporting an error in place of the correct "kept:
+  checked out in a worktree". Found by code read during the gh #94 triage and
+  never observed in the wild.

--- a/cmd/pogod/gitgc.go
+++ b/cmd/pogod/gitgc.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
@@ -85,6 +86,16 @@ func runGitGCSweep(reg *agent.Registry, cfg config.GitGCConfig) {
 			LivePolecats: live,
 			Tickets:      tickets,
 			PolecatsDir:  polecatsDir,
+			// One line per ACTION, not just the counts below. The sweep
+			// already assembles path, owner, branch and reason for every
+			// decision and used to throw all of it away — so a removal in a
+			// multi-megabyte log was a bare number, and "did the GC take my
+			// worktree, and why" was unanswerable after the fact for any past
+			// incident (gh #94). Only actions log: a keep-because-live line
+			// per polecat per tick would be pure noise, and the two decisions
+			// worth reading — something was destroyed, something dirty was
+			// preserved — are exactly the ones the sweep emits.
+			Logf: gitGCLogf(repo),
 		})
 		if err != nil {
 			log.Printf("pogod: git GC sweep of %s failed: %v", repo, err)
@@ -97,6 +108,15 @@ func runGitGCSweep(reg *agent.Registry, cfg config.GitGCConfig) {
 				log.Printf("pogod: git GC %s error: %s", repo, e)
 			}
 		}
+	}
+}
+
+// gitGCLogf returns the per-action logger for one repo's sweep, tagging every
+// line with the repo so a multi-repo sweep stays readable and greppable
+// alongside the summary line runGitGCSweep already emits.
+func gitGCLogf(repo string) func(string, ...any) {
+	return func(format string, args ...any) {
+		log.Printf("pogod: git GC %s — %s", repo, fmt.Sprintf(format, args...))
 	}
 }
 

--- a/cmd/pogod/gitgc.go
+++ b/cmd/pogod/gitgc.go
@@ -45,6 +45,17 @@ func startGitGC(ctx context.Context, reg *agent.Registry, cfg config.GitGCConfig
 	}()
 }
 
+// loadTicketIndexFn is the work-item lookup a sweep runs on, indirected so a
+// test can drive runGitGCSweep end to end. It is the FIRST thing the sweep
+// does and it shells out to `mg`, which a sandboxed test cannot reach — so
+// without this seam the sweep returns at "cannot load work items" and nothing
+// below it, including the Logf wiring, is reachable from a test at all. That
+// unreachability is how the wiring came to have zero coverage in round 1 of
+// this ticket's review: deleting the Logf line left the whole package green.
+// Same shape as gitgc.removeWorktreeFn. Production always uses
+// gitgc.LoadTicketIndex.
+var loadTicketIndexFn = gitgc.LoadTicketIndex
+
 // runGitGCSweep performs one GC pass over every repo known to pogod:
 // repos listed in config plus the source repo of every registered agent.
 // The live-polecat set is passed as the do-not-touch exclusion so a sweep
@@ -54,7 +65,7 @@ func runGitGCSweep(reg *agent.Registry, cfg config.GitGCConfig) {
 	if len(repos) == 0 {
 		return
 	}
-	tickets, err := gitgc.LoadTicketIndex()
+	tickets, err := loadTicketIndexFn()
 	if err != nil {
 		log.Printf("pogod: git GC skipped — cannot load work items: %v", err)
 		return

--- a/cmd/pogod/gitgc_log_test.go
+++ b/cmd/pogod/gitgc_log_test.go
@@ -3,50 +3,172 @@ package main
 import (
 	"bytes"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/drellem2/pogo/internal/agent"
+	"github.com/drellem2/pogo/internal/config"
 	"github.com/drellem2/pogo/internal/gitgc"
 )
 
-// TestGitGCLogfCarriesTheAction is the pogod half of gh #94's diagnosability
-// requirement. internal/gitgc has always assembled a full description of every
-// decision — path, owner, branch, reason — and pogod threw all of it away,
-// logging four counts per sweep. One worktree removal sits in a 5.5MB log on
-// the reporting host and there is no way to tell whether it was legitimate.
-//
-// The assertion is deliberately about the ASSEMBLED line pogod writes, not
-// about the format string it passes down: the defect was a wiring omission, so
-// a test that stopped at "Options.Logf is non-nil" would pass on the broken
-// version too.
-func TestGitGCLogfCarriesTheAction(t *testing.T) {
+// captureLog redirects the standard logger into a buffer for the duration of
+// one test and returns a reader for what was written.
+func captureLog(t *testing.T) func() string {
+	t.Helper()
 	var buf bytes.Buffer
-	old := log.Writer()
-	oldFlags := log.Flags()
+	oldOut, oldFlags := log.Writer(), log.Flags()
 	log.SetOutput(&buf)
 	log.SetFlags(0)
-	t.Cleanup(func() { log.SetOutput(old); log.SetFlags(oldFlags) })
+	t.Cleanup(func() { log.SetOutput(oldOut); log.SetFlags(oldFlags) })
+	return buf.String
+}
 
-	logf := gitGCLogf("/Users/x/dev/pogo")
-	logf("removed worktree %s", gitgc.WorktreeAction{
+// TestRunGitGCSweepLogsTheAction is the guard for the ONE LINE that delivers
+// gh #94's diagnosability half: `Logf: gitGCLogf(repo)` in runGitGCSweep.
+//
+// It drives runGitGCSweep itself — not the format helper — against a real
+// throwaway repo, and asserts the line pogod actually writes. Deleting the
+// Logf wiring makes this test fail; nothing else in the tree does, which is
+// what the review of round 1 caught. The sweep's counts summary survives that
+// deletion untouched, so the assertion has to be for the per-ACTION line and
+// not merely for "the GC said something".
+//
+// Diagnosability is the deliverable that was promised to the reporter on the
+// issue. This PR exists because a guard's real protection lived somewhere
+// other than where it appeared to; a test whose stated purpose a one-line
+// deletion falsifies is that same shape, so this one drives the wiring.
+func TestRunGitGCSweepLogsTheAction(t *testing.T) {
+	sandboxPogoHome(t)
+	logged := captureLog(t)
+
+	// A concluded, non-live polecat: a normal exit's leftovers, which is the
+	// removal an operator most needs to be able to audit after the fact.
+	repo := newPolecatRepo(t)
+	wt := repo.addPolecatWorktree("0047")
+
+	// The sweep's first act is `mg list`, unreachable from a sandbox — see
+	// loadTicketIndexFn. Without this the sweep returns before the wiring.
+	orig := loadTicketIndexFn
+	t.Cleanup(func() { loadTicketIndexFn = orig })
+	loadTicketIndexFn = func() (gitgc.TicketIndex, error) {
+		return gitgc.TicketIndex{"mg-0047": gitgc.TicketArchived}, nil
+	}
+
+	reg, err := agent.NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	runGitGCSweep(reg, config.GitGCConfig{Enabled: true, Repos: []string{repo.dir}})
+
+	// Precondition: the sweep actually ran and actually removed something. A
+	// sweep that did nothing would satisfy no assertion below for the right
+	// reason, so fail loudly here rather than in the log check.
+	if _, err := os.Stat(wt); !os.IsNotExist(err) {
+		t.Fatalf("precondition: the sweep did not remove the concluded polecat's worktree (stat err = %v) — "+
+			"nothing was destroyed, so there is no action to log:\n%s", err, logged())
+	}
+
+	out := logged()
+	line := findLogLine(out, "removed worktree")
+	if line == "" {
+		t.Fatalf("pogod destroyed a worktree and logged no line naming it. The per-action log wiring "+
+			"(Logf: gitGCLogf(repo) in runGitGCSweep) is what makes a removal auditable; without it a "+
+			"deletion is a bare count in a multi-megabyte log (gh #94).\nlog was:\n%s", out)
+	}
+	for _, want := range []string{
+		"git GC",              // the subsystem
+		repo.dir,              // WHICH repo was swept
+		wt,                    // WHICH tree was destroyed
+		"owner 0047",          // WHOSE tree it was
+		"branch polecat-0047", // what was checked out in it
+		"ticket archived",     // and WHY
+	} {
+		if !strings.Contains(line, want) {
+			t.Errorf("git GC removal line missing %q — an operator cannot judge this removal.\ngot: %s", want, line)
+		}
+	}
+}
+
+// TestRunGitGCSweepLogsForeignBranchRemovalDistinctly is the diagnosability
+// case gh #94 was actually reported from: owner and branch DISAGREE. A log
+// line that printed only one of them could not distinguish "this polecat's own
+// tree was reaped" from "somebody else's tree was taken", which is precisely
+// the question the reporter could not answer from their 5.5MB log.
+func TestRunGitGCSweepLogsForeignBranchRemovalDistinctly(t *testing.T) {
+	sandboxPogoHome(t)
+	logged := captureLog(t)
+
+	// A dead polecat 0047 parked on the foreign, concluded branch of 02eb.
+	repo := newPolecatRepo(t)
+	repo.git("branch", gitgc.BranchPrefix+"02eb")
+	wt := filepath.Join(filepath.Dir(repo.dir), "polecats", "0047")
+	repo.git("worktree", "add", "-q", wt, gitgc.BranchPrefix+"02eb")
+
+	orig := loadTicketIndexFn
+	t.Cleanup(func() { loadTicketIndexFn = orig })
+	loadTicketIndexFn = func() (gitgc.TicketIndex, error) {
+		return gitgc.TicketIndex{"mg-02eb": gitgc.TicketArchived}, nil
+	}
+
+	reg, err := agent.NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	runGitGCSweep(reg, config.GitGCConfig{Enabled: true, Repos: []string{repo.dir}})
+
+	line := findLogLine(logged(), "removed worktree")
+	if line == "" {
+		t.Fatalf("no removal line logged; log was:\n%s", logged())
+	}
+	if !strings.Contains(line, "owner 0047") || !strings.Contains(line, "branch polecat-02eb") {
+		t.Errorf("owner and branch must BOTH appear and be distinguishable — when they differ you are "+
+			"looking at exactly the gh #94 situation.\ngot: %s", line)
+	}
+}
+
+// TestGitGCLogfFormat covers the format helper alone: the repo tag and the
+// assembled action text. It deliberately does NOT claim to guard the wiring —
+// it cannot, since it never reaches runGitGCSweep. TestRunGitGCSweepLogsTheAction
+// above is what goes red when the wiring is deleted.
+func TestGitGCLogfFormat(t *testing.T) {
+	logged := captureLog(t)
+
+	gitGCLogf("/Users/x/dev/pogo")("removed worktree %s", gitgc.WorktreeAction{
 		Path:   "/Users/x/.pogo/polecats/caa65",
 		Owner:  "caa65",
 		Branch: "polecat-dccb",
 		Reason: "ticket archived",
 	}.String())
 
-	line := strings.TrimSpace(buf.String())
+	line := strings.TrimSpace(logged())
 	for _, want := range []string{
 		"git GC",
-		"/Users/x/dev/pogo",             // WHICH repo was swept
-		"removed worktree",              // WHAT happened
-		"/Users/x/.pogo/polecats/caa65", // to WHICH tree
-		"owner caa65",                   // WHOSE tree it was
-		"branch polecat-dccb",           // what was checked out in it
-		"ticket archived",               // and WHY
+		"/Users/x/dev/pogo",
+		"removed worktree",
+		"/Users/x/.pogo/polecats/caa65",
+		"owner caa65",
+		"branch polecat-dccb",
+		"ticket archived",
 	} {
 		if !strings.Contains(line, want) {
-			t.Errorf("git GC log line missing %q — an operator cannot judge this removal.\ngot: %s", want, line)
+			t.Errorf("git GC log line missing %q.\ngot: %s", want, line)
 		}
 	}
+}
+
+// findLogLine returns the first captured log line containing needle.
+func findLogLine(out, needle string) string {
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, needle) {
+			return l
+		}
+	}
+	return ""
 }

--- a/cmd/pogod/gitgc_log_test.go
+++ b/cmd/pogod/gitgc_log_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/drellem2/pogo/internal/gitgc"
+)
+
+// TestGitGCLogfCarriesTheAction is the pogod half of gh #94's diagnosability
+// requirement. internal/gitgc has always assembled a full description of every
+// decision — path, owner, branch, reason — and pogod threw all of it away,
+// logging four counts per sweep. One worktree removal sits in a 5.5MB log on
+// the reporting host and there is no way to tell whether it was legitimate.
+//
+// The assertion is deliberately about the ASSEMBLED line pogod writes, not
+// about the format string it passes down: the defect was a wiring omission, so
+// a test that stopped at "Options.Logf is non-nil" would pass on the broken
+// version too.
+func TestGitGCLogfCarriesTheAction(t *testing.T) {
+	var buf bytes.Buffer
+	old := log.Writer()
+	oldFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() { log.SetOutput(old); log.SetFlags(oldFlags) })
+
+	logf := gitGCLogf("/Users/x/dev/pogo")
+	logf("removed worktree %s", gitgc.WorktreeAction{
+		Path:   "/Users/x/.pogo/polecats/caa65",
+		Owner:  "caa65",
+		Branch: "polecat-dccb",
+		Reason: "ticket archived",
+	}.String())
+
+	line := strings.TrimSpace(buf.String())
+	for _, want := range []string{
+		"git GC",
+		"/Users/x/dev/pogo",             // WHICH repo was swept
+		"removed worktree",              // WHAT happened
+		"/Users/x/.pogo/polecats/caa65", // to WHICH tree
+		"owner caa65",                   // WHOSE tree it was
+		"branch polecat-dccb",           // what was checked out in it
+		"ticket archived",               // and WHY
+	} {
+		if !strings.Contains(line, want) {
+			t.Errorf("git GC log line missing %q — an operator cannot judge this removal.\ngot: %s", want, line)
+		}
+	}
+}

--- a/cmd/pogod/gitgc_witness_restart_test.go
+++ b/cmd/pogod/gitgc_witness_restart_test.go
@@ -66,12 +66,14 @@ func (r *polecatRepo) git(args ...string) string {
 }
 
 // addPolecatWorktree creates branch polecat-<name> and checks it out in a
-// worktree, mirroring a live polecat's layout. The sweep keys its exclusion on
-// the branch's suffix, which is <name>.
+// worktree at <polecats>/<name>, mirroring a live polecat's layout exactly.
+// The basename is not decorative: since gh #94 the sweep keys its liveness
+// exclusion on the worktree's PATH, so a fixture parked anywhere else would be
+// making claims about a layout production never builds.
 func (r *polecatRepo) addPolecatWorktree(name string) string {
 	r.t.Helper()
 	branch := gitgc.BranchPrefix + name
-	path := filepath.Join(filepath.Dir(r.dir), "wt-"+name)
+	path := filepath.Join(filepath.Dir(r.dir), "polecats", name)
 	r.git("branch", branch)
 	r.git("worktree", "add", "-q", path, branch)
 	return path
@@ -172,7 +174,7 @@ func TestLivePolecatSet_WitnessGuardsDoneButRunningWorktreeAcrossRestart(t *test
 	}
 	// Kept for the RIGHT reason — the live-polecat guard, not some unrelated
 	// in-flight classification that would mask a broken guard.
-	if len(res.WorktreesKept) != 1 || res.WorktreesKept[0].Reason != "live polecat" {
+	if len(res.WorktreesKept) != 1 || res.WorktreesKept[0].Reason != "live polecat 0130" {
 		t.Fatalf("want the worktree kept as a live polecat, got %+v", res.WorktreesKept)
 	}
 }

--- a/docs/polecat-worktrees.md
+++ b/docs/polecat-worktrees.md
@@ -103,6 +103,29 @@ set under any key, so a normal exit still reaps its tree — the GC's ability to
 collect is asserted by a control in the same test as the fix
 (`TestSweepKeepsLivePolecatOnForeignBranch`).
 
+### Where the two phases still differ, and why
+
+Liveness is now owner-keyed everywhere. **Ticket-state classification is not**,
+and the two worktree phases disagree on it:
+
+- **Phase 1** (registered worktrees) classifies by the **checked-out branch**.
+- **Phase 1b** (orphan dirs — no `.git`, no registration) has no branch to
+  read, so it classifies by the **owner** it derives from the directory name.
+
+For the same directory name with the same dead owner, those can reach opposite
+conclusions: a registered tree parked on a foreign, still-in-flight branch is
+kept, while the identically-named orphan dir is removed. The two sets are
+disjoint within a sweep, so nothing contradicts itself — but the consequence is
+real: a dead polecat's tree can be pinned indefinitely by a foreign ticket that
+never concludes, and which way it goes depends on whether git still holds the
+registration.
+
+Phase 1's direction is the conservative one (it keeps, and no data is lost),
+which is why it was left alone when the liveness key moved. Re-keying it to the
+owner would strand every worktree whose basename resolves to no work item —
+the symmetric defect, never reaping a dead tree. Tracked as a follow-up rather
+than folded in; see mg-bdda.
+
 ## Reading the GC log
 
 The sweep logs one line per action. Before gh #94 it logged counts only, so a

--- a/docs/polecat-worktrees.md
+++ b/docs/polecat-worktrees.md
@@ -66,6 +66,62 @@ In the `onExit` callback (cmd/pogod/main.go):
 
 On pogod startup, run `git worktree prune` on repos with known worktrees. This handles the case where pogod crashed and left stale worktrees behind.
 
+## Ownership: the path names the polecat, the branch does not
+
+The garbage collector (`internal/gitgc`, run by pogod on a ticker and by
+`pogo gc`) reclaims concluded polecats' worktrees. Deciding *whether a worktree
+is still in use* is the one question it must never get wrong, and there are two
+strings that look like they answer it:
+
+| String | Answers | Sound key for |
+|---|---|---|
+| the worktree's **path basename** (`~/.pogo/polecats/<name>`) | whose tree this is | removing a **directory** |
+| the checked-out **branch's** `polecat-` suffix | whose work this is | deleting a **ref** |
+
+They agree only while a polecat stays on the branch it was spawned on. A
+polecat that checks out a *foreign* branch — which the review and QA roles are
+instructed to do, and which anyone fixing conflicts on an existing PR will do —
+makes them disagree.
+
+The GC used to read liveness off the **branch** (gh #94). A live polecat on a
+foreign branch was therefore invisible to the liveness gate: it inherited the
+foreign, concluded ticket's state, its worktree was removed **mid-task**, and
+freeing its branch waived the branch-deletion guard so the ref went too. The
+agent kept running, `pogo agent list` kept reporting it healthy, and the work
+survived only because the commit was still loose in the shared object store — a
+`git gc --prune=now` would have finished the job.
+
+**The rule now:** worktree liveness is keyed on the path
+(`gitgc.PolecatNameForWorktree`), branch deletion on the branch suffix. Neither
+substitutes for the other. This makes the spawn-time path layout load-bearing:
+`~/.pogo/polecats/<name>` is not a convention, it is the record of who owns the
+tree, and a spawn that named the directory anything else would make every live
+polecat invisible to the gate again.
+
+The inverse failure is not traded away. A polecat that has exited is in no live
+set under any key, so a normal exit still reaps its tree — the GC's ability to
+collect is asserted by a control in the same test as the fix
+(`TestSweepKeepsLivePolecatOnForeignBranch`).
+
+## Reading the GC log
+
+The sweep logs one line per action. Before gh #94 it logged counts only, so a
+removal in a multi-megabyte pogod log was a bare number and "did the GC take my
+worktree, and why" could not be answered after the fact.
+
+```
+pogod: git GC /Users/x/dev/pogo — removed worktree /Users/x/.pogo/polecats/caa65 (owner caa65, branch polecat-dccb): ticket archived
+pogod: git GC /Users/x/dev/pogo — kept worktree /Users/x/.pogo/polecats/beef (owner beef, branch polecat-beef): 3 uncommitted change(s) — rerun with --force to discard
+```
+
+Each line names the repo swept, what happened, which tree, **whose** tree
+(`owner`), what was checked out in it (`branch`), and the reason. `owner` and
+`branch` are printed separately on purpose: when they differ you are looking at
+exactly the situation gh #94 was about.
+
+Only *actions* log — removals, and trees deliberately preserved. A
+kept-because-live line per polecat per tick would be noise.
+
 ## What changes
 
 ### internal/agent/api.go — handleSpawnPolecat

--- a/internal/agent/api_test.go
+++ b/internal/agent/api_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/drellem2/pogo/internal/gitgc"
 	"github.com/drellem2/pogo/internal/testsandbox"
 )
 
@@ -685,6 +686,17 @@ func TestHandleSpawnPolecat_WorktreeTrueCreatesWorktree(t *testing.T) {
 	}
 	if _, err := os.Stat(expectedWorktree); err != nil {
 		t.Errorf("expected worktree at %s: %v", expectedWorktree, err)
+	}
+	// The path's BASENAME is the polecat's name, and that is now load-bearing
+	// rather than cosmetic: since gh #94 the git GC decides whether a worktree
+	// is occupied by reading the name back off the path and looking it up in
+	// its live set. A spawn that named the directory anything else would make
+	// every live polecat invisible to that gate and get its tree deleted
+	// mid-task — so this is asserted here, at the one place that writes the
+	// path, against the exact function that reads it.
+	if got := gitgc.PolecatNameForWorktree(a.WorktreeDir); got != a.Name {
+		t.Errorf("gitgc reads worktree %q as belonging to polecat %q, but it belongs to %q — "+
+			"the git GC liveness gate keys on this basename (gh #94)", a.WorktreeDir, got, a.Name)
 	}
 }
 

--- a/internal/gitgc/gitgc.go
+++ b/internal/gitgc/gitgc.go
@@ -85,6 +85,42 @@ func BranchSuffix(branch string) string {
 	return strings.TrimPrefix(branch, BranchPrefix)
 }
 
+// PolecatNameForWorktree returns the name of the polecat that OWNS a worktree
+// — the only fact a GC sweep may use to decide whether that worktree is in
+// use. It is the path's basename, because a polecat's worktree is created at
+// `<polecats dir>/<name>` at spawn time (internal/agent/api.go) and nothing
+// ever moves it.
+//
+// # Why the path and not the branch (gh #94, mg-dd92)
+//
+// The sweep used to read liveness off `BranchSuffix(wt.Branch)`: the polecat
+// name embedded in the branch CHECKED OUT INSIDE the worktree. Those two
+// strings agree for a polecat that stays on its own branch and disagree the
+// moment one does not — and checking out a foreign branch is something our own
+// shipped review and QA roles are instructed to do. When they disagree, the
+// live polecat is invisible to the liveness gate: its worktree is removed out
+// from under it mid-task, and the freeing of its branch waives the phase-2
+// guard so the ref goes too. The agent keeps running and `pogo agent list`
+// keeps reporting it healthy; the work survives only if the commit is still
+// loose in the shared object store.
+//
+// The branch is a fact about what the polecat is WORKING ON. The path is a
+// fact about WHOSE TREE THIS IS. Only the second one answers "may I delete
+// this directory", so only the second one is consulted here — the branch is
+// deliberately not retained as a fallback, because an OR would re-admit
+// exactly the signal that made a live tree look dead.
+//
+// The inverse failure is real too and is not traded away: a polecat that has
+// exited is not in the live set under any key, so its tree is still reaped on
+// the next sweep. See TestSweepKeepsLivePolecatOnForeignBranch, whose control
+// is a normal exit collecting as it always did.
+func PolecatNameForWorktree(path string) string {
+	if path == "" {
+		return ""
+	}
+	return filepath.Base(filepath.Clean(path))
+}
+
 // Worktree is one entry of `git worktree list`.
 type Worktree struct {
 	Path     string // absolute path of the worktree directory

--- a/internal/gitgc/liveness_test.go
+++ b/internal/gitgc/liveness_test.go
@@ -1,0 +1,325 @@
+package gitgc
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPolecatNameForWorktree pins the ownership rule the liveness gate reads:
+// a worktree belongs to the polecat its path is NAMED after, whatever branch
+// happens to be checked out inside it.
+func TestPolecatNameForWorktree(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/Users/x/.pogo/polecats/caa65", "caa65"},
+		{"/Users/x/.pogo/polecats/caa65/", "caa65"},
+		{"/Users/x/.pogo/polecats/cat-mg-30d5", "cat-mg-30d5"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := PolecatNameForWorktree(c.path); got != c.want {
+			t.Errorf("PolecatNameForWorktree(%q) = %q, want %q", c.path, got, c.want)
+		}
+	}
+}
+
+// TestSweepKeepsLivePolecatOnForeignBranch is gh #94 / mg-dd92, run as the
+// inversion of the reproduction that found it.
+//
+// THE DEFECT. `Sweep` decided a worktree was occupied from the polecat name
+// embedded in the branch CHECKED OUT INSIDE it, never from the path — whose
+// basename is the polecat that owns the tree. A live polecat working any
+// branch but its own was therefore invisible to the liveness gate: it
+// inherited the foreign, concluded ticket's state, its worktree was removed
+// mid-task, and freeing its branch waived phase 2's guard so the ref went too.
+// The agent kept running and `pogo agent list` kept calling it healthy. That
+// is not exotic — two shipped roles (review, QA) instruct a foreign checkout,
+// and were protected only by prompt conventions living in other files.
+//
+// THE CONTROL IS HALF THE TEST. A liveness gate that keeps everything is
+// indistinguishable from a disabled one, and the symmetric defect — never
+// reaping a dead polecat's tree — is just as real. So the same sweep also
+// carries a concluded, non-live polecat sitting on its OWN branch, i.e. the
+// normal end state of every polecat that ever exits, and that one must still
+// collect: directory gone, branch deleted.
+func TestSweepKeepsLivePolecatOnForeignBranch(t *testing.T) {
+	r := newTestRepo(t)
+
+	// caa65 is LIVE. Its own ticket is still in flight; it is working the
+	// branch of dccb, a DIFFERENT and concluded ticket — the PR-conflict /
+	// review / QA shape.
+	r.branch("polecat-caa65")
+	r.branch("polecat-dccb")
+	// beef is the control: concluded, not live, on its own branch.
+	r.branch("polecat-beef")
+
+	liveWT := r.worktreeOwnedBy("caa65", "polecat-dccb")
+	deadWT := r.worktreeOwnedBy("beef", "polecat-beef")
+
+	tickets := TicketIndex{
+		"mg-caa65": TicketInFlight,
+		"mg-dccb":  TicketArchived,
+		"mg-beef":  TicketArchived,
+	}
+	res, err := Sweep(Options{
+		Repo:         r.dir,
+		TargetBranch: "main",
+		LivePolecats: map[string]bool{"caa65": true},
+		Tickets:      tickets,
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("unexpected sweep errors: %v", res.Errors)
+	}
+
+	// --- The live polecat survives, tree and ref -------------------------
+	if _, err := os.Stat(liveWT); err != nil {
+		t.Errorf("LIVE polecat caa65's worktree was removed out from under it (gh #94): %v", err)
+	}
+	for _, w := range res.WorktreesRemoved {
+		if w.Path == liveWT {
+			t.Errorf("sweep reported removing the live polecat's worktree: %+v", w)
+		}
+	}
+	kept := findWorktreeAction(res.WorktreesKept, liveWT)
+	if kept == nil {
+		t.Errorf("live polecat's worktree not reported kept at all; kept=%+v", res.WorktreesKept)
+	} else {
+		if kept.Owner != "caa65" {
+			t.Errorf("kept worktree Owner = %q, want caa65 (the path's basename, not the branch's)", kept.Owner)
+		}
+		if !strings.Contains(kept.Reason, "live polecat") {
+			t.Errorf("kept reason = %q, want it to name liveness", kept.Reason)
+		}
+	}
+	// The branch it is working must survive too. Removing the tree is what
+	// used to free the ref, so a kept tree has to keep the ref pinned.
+	remaining := branchList(t, r)
+	if !remaining["polecat-dccb"] {
+		t.Error("the foreign branch the live polecat had checked out was deleted (gh #94 phase 2)")
+	}
+	if !remaining["polecat-caa65"] {
+		t.Error("the live polecat's own branch was deleted")
+	}
+	if kb := findBranchAction(res.BranchesKept, "polecat-dccb"); kb == nil || kb.Reason != "checked out in a worktree" {
+		t.Errorf("polecat-dccb should be kept as checked out in a worktree, got %+v", kb)
+	}
+
+	// --- The control still collects --------------------------------------
+	if _, err := os.Stat(deadWT); !os.IsNotExist(err) {
+		t.Errorf("concluded, non-live polecat beef's worktree should have been reaped, stat err = %v", err)
+	}
+	if removed := findWorktreeAction(res.WorktreesRemoved, deadWT); removed == nil {
+		t.Errorf("sweep did not report removing beef's worktree; removed=%+v", res.WorktreesRemoved)
+	} else if removed.Owner != "beef" {
+		t.Errorf("removed worktree Owner = %q, want beef", removed.Owner)
+	}
+	if remaining["polecat-beef"] {
+		t.Error("beef's branch should have been deleted once its worktree was freed")
+	}
+	if len(res.WorktreesRemoved) != 1 {
+		t.Errorf("want exactly 1 worktree removed (the control), got %+v", res.WorktreesRemoved)
+	}
+}
+
+// TestSweepLogsEveryAction is the positive control on diagnosability (gh #94).
+// The sweep has always assembled path, owner, branch and reason per decision
+// and thrown all of it away, logging counts only — so the one removal sitting
+// in a 5.5MB log on the reporting host cannot be judged legitimate or not, and
+// "did the GC ever fire on my worktree" is unanswerable for any past incident.
+// Every destructive action must now name what it took and why.
+func TestSweepLogsEveryAction(t *testing.T) {
+	r := newTestRepo(t)
+	r.branch("polecat-aaaa")
+	wt := r.worktree("polecat-aaaa")
+
+	// An orphan dir too — the other destructive path, which rm -rf's files
+	// git cannot even see.
+	polecats := r.polecatsDir()
+	orphan := filepath.Join(polecats, "bbbb")
+	if err := os.MkdirAll(orphan, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	var lines []string
+	res, err := Sweep(Options{
+		Repo:         r.dir,
+		TargetBranch: "main",
+		Tickets:      TicketIndex{"mg-aaaa": TicketArchived, "mg-bbbb": TicketArchived},
+		PolecatsDir:  polecats,
+		Logf: func(format string, args ...any) {
+			lines = append(lines, fmt.Sprintf(format, args...))
+		},
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if len(res.Errors) != 0 {
+		t.Fatalf("unexpected sweep errors: %v", res.Errors)
+	}
+	joined := strings.Join(lines, "\n")
+
+	// A REAL removal — not a dry run, not a compile — logs the tree it took,
+	// whose it was, what was checked out in it, and the reason.
+	wtLine := findLine(lines, "removed worktree ")
+	if wtLine == "" {
+		t.Fatalf("no worktree-removal line logged; log was:\n%s", joined)
+	}
+	for _, want := range []string{wt, "owner aaaa", "branch polecat-aaaa", "ticket archived"} {
+		if !strings.Contains(wtLine, want) {
+			t.Errorf("worktree-removal line missing %q: %s", want, wtLine)
+		}
+	}
+
+	// The orphan-dir path is destructive too and gets the same treatment.
+	orphanLine := findLine(lines, "removed orphan dir ")
+	if orphanLine == "" {
+		t.Fatalf("no orphan-dir removal line logged; log was:\n%s", joined)
+	}
+	for _, want := range []string{orphan, "owner bbbb", "ticket archived"} {
+		if !strings.Contains(orphanLine, want) {
+			t.Errorf("orphan-dir line missing %q: %s", want, orphanLine)
+		}
+	}
+
+	// Branch deletion already logged; assert it still names the reason.
+	brLine := findLine(lines, "deleted branch ")
+	if brLine == "" || !strings.Contains(brLine, "polecat-aaaa") {
+		t.Errorf("no branch-deletion line naming polecat-aaaa; log was:\n%s", joined)
+	}
+}
+
+// TestSweepLogsPreservedDirtyWorktree covers the other decision an operator
+// needs to find in a log: a tree the sweep deliberately did NOT take. Without
+// it, a worktree that quietly pins its branch forever looks like a GC that
+// never ran.
+func TestSweepLogsPreservedDirtyWorktree(t *testing.T) {
+	r := newTestRepo(t)
+	r.branch("polecat-aaaa")
+	wt := r.worktree("polecat-aaaa")
+	if err := os.WriteFile(filepath.Join(wt, "unmerged.txt"), []byte("work"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var lines []string
+	if _, err := Sweep(Options{
+		Repo:         r.dir,
+		TargetBranch: "main",
+		Tickets:      TicketIndex{"mg-aaaa": TicketArchived},
+		Logf:         func(f string, a ...any) { lines = append(lines, fmt.Sprintf(f, a...)) },
+	}); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	line := findLine(lines, "kept worktree ")
+	if line == "" {
+		t.Fatalf("preserved dirty worktree logged nothing; log was:\n%s", strings.Join(lines, "\n"))
+	}
+	for _, want := range []string{wt, "owner aaaa", "uncommitted change"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("dirty-keep line missing %q: %s", want, line)
+		}
+	}
+}
+
+// TestSweepFailedWorktreeRemovalKeepsBranchPinned covers the third part of the
+// gh #94 packet, which the triage reached by CODE READ ONLY and never
+// reproduced: `freed[wt.Branch]` was set BEFORE removal was attempted and
+// survived a failure. Phase 2 then believed the branch was no longer checked
+// out when it still was, so it went on to attempt a deletion git was always
+// going to refuse — turning a correct "kept: checked out in a worktree" into a
+// spurious error, and mis-reporting the sweep's own decision.
+//
+// The removal is faked because a real one losing to the filesystem needs both
+// `git worktree remove --force` and os.RemoveAll to fail, which no portable
+// fixture can arrange (and a chmod fixture silently passes as root).
+func TestSweepFailedWorktreeRemovalKeepsBranchPinned(t *testing.T) {
+	r := newTestRepo(t)
+	r.branch("polecat-aaaa")
+	wt := r.worktree("polecat-aaaa")
+
+	orig := removeWorktreeFn
+	t.Cleanup(func() { removeWorktreeFn = orig })
+	removeWorktreeFn = func(sourceRepo, worktreeDir string) error {
+		return fmt.Errorf("simulated removal failure")
+	}
+
+	res, err := Sweep(Options{
+		Repo:         r.dir,
+		TargetBranch: "main",
+		Tickets:      TicketIndex{"mg-aaaa": TicketArchived},
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	// A failed removal is not a removal.
+	if len(res.WorktreesRemoved) != 0 {
+		t.Errorf("failed removal reported as removed: %+v", res.WorktreesRemoved)
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Errorf("worktree dir should still be there: %v", err)
+	}
+
+	// And the branch is still checked out in it, so that is what the sweep
+	// must SAY — one error about the worktree, none about the branch.
+	kept := findBranchAction(res.BranchesKept, "polecat-aaaa")
+	if kept == nil || kept.Reason != "checked out in a worktree" {
+		t.Errorf("branch should be kept as checked out in a worktree, got %+v (errors: %v)", kept, res.Errors)
+	}
+	if len(res.BranchesDeleted) != 0 {
+		t.Errorf("no branch should have been deleted: %+v", res.BranchesDeleted)
+	}
+	if len(res.Errors) != 1 {
+		t.Errorf("want exactly the one removal error, got %v", res.Errors)
+	}
+	if !branchList(t, r)["polecat-aaaa"] {
+		t.Error("branch should still exist on disk")
+	}
+}
+
+func findWorktreeAction(actions []WorktreeAction, path string) *WorktreeAction {
+	for i := range actions {
+		if actions[i].Path == path {
+			return &actions[i]
+		}
+	}
+	return nil
+}
+
+func findBranchAction(actions []BranchAction, branch string) *BranchAction {
+	for i := range actions {
+		if actions[i].Branch == branch {
+			return &actions[i]
+		}
+	}
+	return nil
+}
+
+func findLine(lines []string, prefix string) string {
+	for _, l := range lines {
+		if strings.HasPrefix(l, prefix) {
+			return l
+		}
+	}
+	return ""
+}
+
+func branchList(t *testing.T, r *testRepo) map[string]bool {
+	t.Helper()
+	branches, err := ListPolecatBranches(r.dir)
+	if err != nil {
+		t.Fatalf("ListPolecatBranches: %v", err)
+	}
+	set := map[string]bool{}
+	for _, b := range branches {
+		set[b] = true
+	}
+	return set
+}

--- a/internal/gitgc/liveness_test.go
+++ b/internal/gitgc/liveness_test.go
@@ -323,3 +323,32 @@ func branchList(t *testing.T, r *testRepo) map[string]bool {
 	}
 	return set
 }
+
+// TestSummaryItemisesKeptWorktrees is the `pogo gc` half of diagnosability.
+// The command's help promises a worktree holding uncommitted work is "KEPT and
+// reported"; the summary reported it as a count. A preserved tree pins its
+// branch until someone acts on it, so a count tells an operator a branch is
+// stuck without telling them which tree to go rescue.
+func TestSummaryItemisesKeptWorktrees(t *testing.T) {
+	r := newTestRepo(t)
+	r.branch("polecat-aaaa")
+	wt := r.worktree("polecat-aaaa")
+	if err := os.WriteFile(filepath.Join(wt, "unmerged.txt"), []byte("work"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Sweep(Options{
+		Repo:         r.dir,
+		TargetBranch: "main",
+		Tickets:      TicketIndex{"mg-aaaa": TicketArchived},
+	})
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	summary := res.Summary()
+	for _, want := range []string{wt, "owner aaaa", "branch polecat-aaaa", "uncommitted change"} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("gc summary missing %q — the operator cannot tell which tree to rescue.\n%s", want, summary)
+		}
+	}
+}

--- a/internal/gitgc/sweep.go
+++ b/internal/gitgc/sweep.go
@@ -16,11 +16,23 @@ type Options struct {
 	// TargetBranch is the merge target a *done* ticket's branch must be
 	// merged into before deletion. Empty defaults to DefaultTargetBranch.
 	TargetBranch string
-	// LivePolecats is the do-not-touch set, keyed by polecat name (which
-	// equals a branch's "polecat-" suffix and its worktree basename).
-	// pogod fills this from its agent registry so a sweep never disturbs a
-	// running polecat — even one whose worktree was unlinked at refinery
-	// submit time and so is no longer git-checked-out.
+	// LivePolecats is the do-not-touch set, keyed by polecat NAME. pogod
+	// fills it from its agent registry unioned with the restart-surviving
+	// polecat witness (mg-0130), so a sweep never disturbs a running polecat
+	// — including one that outlived the pogod that spawned it, and one whose
+	// worktree was unlinked at refinery submit time and so is no longer
+	// git-checked-out.
+	//
+	// A polecat's name reaches this set from TWO independent directions, and
+	// conflating them is what caused gh #94:
+	//
+	//   - a worktree's PATH basename — whose tree this is. The only sound key
+	//     for "may I delete this directory" (see PolecatNameForWorktree).
+	//   - a branch's "polecat-" suffix — whose work this is. The sound key
+	//     for "may I delete this ref", used in phase 2.
+	//
+	// They agree only while a polecat stays on its own branch. Phase 1 must
+	// use the first and phase 2 the second; neither substitutes for the other.
 	LivePolecats map[string]bool
 	// Tickets, when non-nil, supplies work-item states directly. When nil,
 	// Sweep loads them via LoadTicketIndex (`mg list`). Injecting a map
@@ -56,6 +68,13 @@ func (o Options) logf(format string, args ...any) {
 	}
 }
 
+// removeWorktreeFn is the worktree-removal call the sweep makes, indirected so
+// a test can force the FAILED-removal branch. A failed removal is otherwise
+// unreachable from a test — it needs git and os.RemoveAll to both lose to the
+// filesystem — and it is the branch the freed-flag ordering turns on
+// (mg-dd92). Production always uses RemoveWorktreeForce.
+var removeWorktreeFn = RemoveWorktreeForce
+
 // BranchAction records the GC decision for one polecat branch.
 type BranchAction struct {
 	Branch string
@@ -66,9 +85,31 @@ type BranchAction struct {
 
 // WorktreeAction records the GC decision for one polecat worktree.
 type WorktreeAction struct {
-	Path   string
+	Path string
+	// Owner is the polecat the worktree BELONGS to, derived from Path (see
+	// PolecatNameForWorktree). It is what the liveness gate is keyed on, and
+	// it is recorded separately from Branch because the two differ in exactly
+	// the case gh #94 was about — reading a removal line without it cannot
+	// tell you whose tree was taken.
+	Owner  string
 	Branch string
 	Reason string
+}
+
+// String renders one worktree action for an operator: whose tree it was, what
+// was checked out in it, and why the sweep decided what it decided. It is the
+// unit of a GC log line, and it is exported because the caller that writes
+// those lines (cmd/pogod) is what has to be tested for actually carrying them.
+func (a WorktreeAction) String() string {
+	owner := a.Owner
+	if owner == "" {
+		owner = "unknown"
+	}
+	branch := a.Branch
+	if branch == "" {
+		branch = "none"
+	}
+	return fmt.Sprintf("%s (owner %s, branch %s): %s", a.Path, owner, branch, a.Reason)
 }
 
 // Result is the outcome of a sweep.
@@ -125,17 +166,28 @@ func Sweep(opts Options) (Result, error) {
 		if wt.Main || wt.Bare || !wt.IsPolecat() {
 			continue
 		}
-		name := BranchSuffix(wt.Branch)
-		if opts.LivePolecats[name] {
-			res.WorktreesKept = append(res.WorktreesKept, WorktreeAction{
-				Path: wt.Path, Branch: wt.Branch, Reason: "live polecat",
-			})
+		// WHOSE tree this is, not what is checked out in it. These differ
+		// whenever a polecat works a foreign branch, and reading liveness off
+		// the branch is what deleted a live polecat's tree in gh #94.
+		owner := PolecatNameForWorktree(wt.Path)
+		if opts.LivePolecats[owner] {
+			kept := WorktreeAction{
+				Path: wt.Path, Owner: owner, Branch: wt.Branch, Reason: "live polecat " + owner,
+			}
+			res.WorktreesKept = append(res.WorktreesKept, kept)
 			continue
 		}
+		// Ticket state stays keyed on the checked-out branch. It answers a
+		// different question from liveness — "has this work concluded", not
+		// "is anyone using this directory" — and it is only ever reached for a
+		// tree whose owner is already established as not live, so it cannot
+		// reach a running polecat. Re-keying it too would strand every
+		// worktree whose basename resolves to no work item, which is the
+		// symmetric defect: never reaping a dead tree.
 		_, state := tickets.BranchState(wt.Branch)
 		if !state.Concluded() {
 			res.WorktreesKept = append(res.WorktreesKept, WorktreeAction{
-				Path: wt.Path, Branch: wt.Branch, Reason: "ticket " + state.String(),
+				Path: wt.Path, Owner: owner, Branch: wt.Branch, Reason: "ticket " + state.String(),
 			})
 			continue
 		}
@@ -146,24 +198,36 @@ func Sweep(opts Options) (Result, error) {
 		// decision an apply would make.
 		if !opts.Force {
 			if isDirty, files, derr := WorktreeDirty(wt.Path); derr == nil && isDirty {
-				res.WorktreesKept = append(res.WorktreesKept, WorktreeAction{
-					Path: wt.Path, Branch: wt.Branch,
+				kept := WorktreeAction{
+					Path: wt.Path, Owner: owner, Branch: wt.Branch,
 					Reason: fmt.Sprintf("%d uncommitted change(s) — rerun with --force to discard", len(files)),
-				})
-				opts.logf("kept worktree %s (%s): %d uncommitted change(s)", wt.Path, wt.Branch, len(files))
+				}
+				res.WorktreesKept = append(res.WorktreesKept, kept)
+				opts.logf("kept worktree %s", kept.String())
 				continue
 			}
 		}
-		freed[wt.Branch] = true
-		action := WorktreeAction{Path: wt.Path, Branch: wt.Branch, Reason: "ticket " + state.String()}
+		action := WorktreeAction{Path: wt.Path, Owner: owner, Branch: wt.Branch, Reason: "ticket " + state.String()}
 		if opts.DryRun {
-			opts.logf("would remove worktree %s (%s)", wt.Path, wt.Branch)
+			// A dry run reports what an apply WOULD do, so the branch is
+			// treated as freed for phase 2's benefit — no removal is attempted
+			// and none can fail.
+			freed[wt.Branch] = true
+			opts.logf("would remove worktree %s", action.String())
 		} else {
-			if err := RemoveWorktreeForce(opts.Repo, wt.Path); err != nil {
+			if err := removeWorktreeFn(opts.Repo, wt.Path); err != nil {
 				res.Errors = append(res.Errors, fmt.Sprintf("remove worktree %s: %v", wt.Path, err))
 				continue
 			}
-			opts.logf("removed worktree %s (%s)", wt.Path, wt.Branch)
+			// Marked freed only AFTER the removal actually succeeded. Setting
+			// it up front survived a failed removal and told phase 2 the
+			// branch was no longer checked out when it still was, so the
+			// sweep went on to attempt a deletion git was always going to
+			// refuse — reporting an error instead of the correct "kept:
+			// checked out in a worktree" (mg-dd92; code-read, never
+			// reproduced in the wild).
+			freed[wt.Branch] = true
+			opts.logf("removed worktree %s", action.String())
 		}
 		res.WorktreesRemoved = append(res.WorktreesRemoved, action)
 	}
@@ -295,26 +359,26 @@ func sweepOrphanDirs(opts Options, tickets TicketIndex, registered map[string]bo
 		branch := BranchPrefix + name
 		if opts.LivePolecats[name] {
 			res.WorktreesKept = append(res.WorktreesKept, WorktreeAction{
-				Path: path, Branch: branch, Reason: "orphan dir, live polecat",
+				Path: path, Owner: name, Branch: branch, Reason: "orphan dir, live polecat " + name,
 			})
 			continue
 		}
 		_, state := tickets.BranchState(branch)
 		if !state.Concluded() {
 			res.WorktreesKept = append(res.WorktreesKept, WorktreeAction{
-				Path: path, Branch: branch, Reason: "orphan dir, ticket " + state.String(),
+				Path: path, Owner: name, Branch: branch, Reason: "orphan dir, ticket " + state.String(),
 			})
 			continue
 		}
-		action := WorktreeAction{Path: path, Branch: branch, Reason: "orphan dir, ticket " + state.String()}
+		action := WorktreeAction{Path: path, Owner: name, Branch: branch, Reason: "orphan dir, ticket " + state.String()}
 		if opts.DryRun {
-			opts.logf("would remove orphan dir %s (%s)", path, branch)
+			opts.logf("would remove orphan dir %s", action.String())
 		} else {
 			if err := os.RemoveAll(path); err != nil {
 				res.Errors = append(res.Errors, fmt.Sprintf("remove orphan dir %s: %v", path, err))
 				continue
 			}
-			opts.logf("removed orphan dir %s (%s)", path, branch)
+			opts.logf("removed orphan dir %s", action.String())
 		}
 		res.WorktreesRemoved = append(res.WorktreesRemoved, action)
 	}
@@ -338,7 +402,7 @@ func (r Result) Summary() string {
 	if len(r.WorktreesRemoved) > 0 {
 		fmt.Fprintf(&b, "  worktrees %s:\n", verb)
 		for _, w := range sortedWorktrees(r.WorktreesRemoved) {
-			fmt.Fprintf(&b, "    %s (%s)\n", w.Path, w.Branch)
+			fmt.Fprintf(&b, "    %s\n", w.String())
 		}
 	}
 	if len(r.BranchesDeleted) > 0 {

--- a/internal/gitgc/sweep.go
+++ b/internal/gitgc/sweep.go
@@ -405,6 +405,18 @@ func (r Result) Summary() string {
 			fmt.Fprintf(&b, "    %s\n", w.String())
 		}
 	}
+	// Kept worktrees are itemised, not just counted. `pogo gc --help` promises
+	// a worktree holding uncommitted work is "KEPT and reported", and a
+	// preserved tree pins its branch until someone acts on it — so a bare
+	// count tells an operator a branch is stuck without telling them which
+	// tree to go rescue. pogod's log has always emitted the full line for
+	// these; the CLI summary was the half that only counted.
+	if len(r.WorktreesKept) > 0 {
+		fmt.Fprintf(&b, "  worktrees kept:\n")
+		for _, w := range sortedWorktrees(r.WorktreesKept) {
+			fmt.Fprintf(&b, "    %s\n", w.String())
+		}
+	}
 	if len(r.BranchesDeleted) > 0 {
 		fmt.Fprintf(&b, "  branches %s:\n", delVerb)
 		for _, br := range sortedBranches(r.BranchesDeleted) {

--- a/internal/gitgc/sweep_test.go
+++ b/internal/gitgc/sweep_test.go
@@ -61,12 +61,32 @@ func (r *testRepo) branch(name string) {
 	r.git("branch", name)
 }
 
-// worktree registers a worktree at <repo>/../wt-<name> for branch.
+// worktree registers a worktree for branch at the PRODUCTION-shaped path — a
+// directory under a polecats dir whose basename is the owning polecat's name,
+// as `git worktree add <polecats>/<name> -b polecat-<name>` builds it at spawn.
+// The basename is load-bearing since mg-dd92: it is what the liveness gate
+// reads. A helper that parked worktrees at an arbitrary path would make every
+// liveness assertion in this file a statement about a layout production never
+// produces.
 func (r *testRepo) worktree(branch string) string {
 	r.t.Helper()
-	path := filepath.Join(filepath.Dir(r.dir), "wt-"+branch)
+	return r.worktreeOwnedBy(BranchSuffix(branch), branch)
+}
+
+// worktreeOwnedBy registers a worktree at <polecats>/<owner> checked out on
+// branch — which may be a FOREIGN branch, i.e. one whose name does not embed
+// owner. That divergence is the whole subject of gh #94, so it has to be
+// expressible here.
+func (r *testRepo) worktreeOwnedBy(owner, branch string) string {
+	r.t.Helper()
+	path := filepath.Join(r.polecatsDir(), owner)
 	r.git("worktree", "add", "-q", path, branch)
 	return path
+}
+
+// polecatsDir is this repo's stand-in for ~/.pogo/polecats.
+func (r *testRepo) polecatsDir() string {
+	return filepath.Join(filepath.Dir(r.dir), "polecats")
 }
 
 func TestListPolecatBranchesAndWorktrees(t *testing.T) {


### PR DESCRIPTION
Keys the git GC's worktree-liveness gate off the worktree **path** instead of the branch checked out inside it, logs what the sweep removed and why, and preserves the triage's reproduction as a test with its control.

## The fix

`Sweep` phase 1 read liveness from `BranchSuffix(wt.Branch)` — the polecat name embedded in the branch checked out *inside* the worktree. The worktree's **path basename** is the polecat that owns the tree. Those two strings agree only while a polecat stays on its own branch, and our own shipped review and QA roles instruct a foreign checkout. When they disagree the live polecat was invisible to the gate: tree removed mid-task, `freed[wt.Branch]` waived phase 2's guard so the ref went too, and the agent kept running with `pogo agent list` reporting it healthy.

Liveness now uses `gitgc.PolecatNameForWorktree(wt.Path)`. Branch deletion (phase 2) keeps its branch-suffix key — that one is correct, and the two answer different questions:

| String | Answers | Sound key for |
|---|---|---|
| worktree path basename | whose tree this is | removing a **directory** |
| branch `polecat-` suffix | whose work this is | deleting a **ref** |

The branch is deliberately **not** retained as an `OR` fallback. An `OR` would re-admit the exact signal that made a live tree look dead, and would create the symmetric defect on the other side (a dead tree parked on a live polecat's branch, never reaped). Ticket-state classification stays branch-keyed — it is only ever reached for a tree whose owner is already established as not live, and re-keying it too would strand every worktree whose basename resolves to no work item.

The orphan-dir scan (phase 1b) was already path-keyed; phase 1 now matches it.

## Acceptance — the reproduction, inverted, against a live agent

Same fixture, same live daemon, only the binary differs. A **genuinely live polecat** (`dd92`, the one that wrote this PR) with a sandbox worktree at `polecats/dd92` checked out on the foreign, archived branch `polecat-beef`; and a control identical but for ownership, a dead polecat `cafe` on its own archived branch.

**Pre-fix binary, built from `main`:**

```
  worktrees: removed 2, kept 0
  branches:  deleted 2, kept 0
  worktrees removed:
    .../polecats/cafe (polecat-cafe)
    .../polecats/dd92 (polecat-beef)     <-- a LIVE agent's tree
--- surviving polecat dirs ---
--- surviving branches ---
```

**This branch:**

```
  worktrees: removed 1, kept 1
  branches:  deleted 1, kept 1
  worktrees removed:
    .../polecats/cafe (owner cafe, branch polecat-cafe): ticket archived
  branches deleted:
    polecat-cafe — ticket archived
--- surviving polecat dirs ---
  dd92
--- surviving branches ---
  polecat-beef
```

The live polecat keeps its tree **and** the branch it was working; the control still collects, tree and ref. A gate that keeps everything is indistinguishable from a disabled one, so the control is half the test — `TestSweepKeepsLivePolecatOnForeignBranch` carries both in a single sweep, and it goes red on the pre-fix key.

## Diagnosability

The sweep already assembled path, branch and reason for every decision and logged only counts, so the one removal sitting in a 5.5MB pogod log on the reporting host cannot be judged legitimate or not. `WorktreeAction` gains `Owner` and a `String()`; pogod wires `Options.Logf`:

```
pogod: git GC /Users/x/dev/pogo — removed worktree /Users/x/.pogo/polecats/caa65 (owner caa65, branch polecat-dccb): ticket archived
pogod: git GC /Users/x/dev/pogo — kept worktree /Users/x/.pogo/polecats/beef (owner beef, branch polecat-beef): 3 uncommitted change(s) — rerun with --force to discard
```

`owner` and `branch` print separately on purpose: when they differ you are looking at exactly this bug's situation. Only *actions* log — a keep-because-live line per polecat per tick would be noise.

`pogo gc`'s summary now carries the same detail **for keeps as well as removals**. It previously itemised removals and counted keeps, while pogod's log emitted the full line for both — so `pogo gc --help`'s promise that a dirty worktree is "KEPT and reported" was only half true, and a count told an operator a branch was pinned without saying which tree to rescue. (Round 1 advisory B.)

`TestRunGitGCSweepLogsTheAction` drives `runGitGCSweep` itself against a real throwaway repo and asserts the line pogod actually writes — **verified red** when `Logf: gitGCLogf(repo)` is deleted, with the whole `cmd/pogod` package failing. Reaching that line from a test needed a seam (`loadTicketIndexFn`), because the sweep's first act shells out to `mg` and returns early under a sandbox; that unreachability is exactly why the wiring had no coverage in round 1. `TestGitGCLogfFormat` covers the format helper and no longer claims to cover the wiring.

## The third part, labelled UNREPRODUCED

`freed[wt.Branch] = true` was set **before** removal was attempted and survived a failure, so phase 2 believed the branch was un-checked-out when it still was and attempted a deletion git was always going to refuse — reporting a spurious error in place of the correct `kept: checked out in a worktree`. This is **code-read only**, from the triage; it was never observed in the wild, and it does not inherit the confirmed half's standing. Setting `freed` after a successful removal fixes it. Tested through an injected removal failure (`removeWorktreeFn`) — a real one needs both `git worktree remove --force` and `os.RemoveAll` to lose to the filesystem, and a chmod fixture silently passes as root.

## Sibling: mg-0130 is fixed

*"livePolecatSet is registry-built, so a restart unprotects a done-but-still-running polecat's worktree"* — **fixed**, in commit `ec7fee1`, and independently of this ticket. `cmd/pogod/gitgc.go:livePolecatSet` unions the registry with `agent.WitnessedPolecatVerdicts()`, the `(pid, start_time)` store that survives a pogod restart, and a witness *read error* skips the sweep rather than sweeping against a live set known to be missing survivors. Guarded by `TestLivePolecatSet_WitnessGuardsDoneButRunningWorktreeAcrossRestart`, which asserts both directions. That test's fixture parked its worktree at `wt-<name>`; since the basename is now load-bearing it has been moved to the production-shaped `polecats/<name>`, and it still passes.

Two independent defects did land in one gate, which is an argument about its shape: both were the live set being keyed or populated by something other than "a running process owns this path".

## Out of scope, flagged not fixed

`pogo gc` (`cmd/pogo/main.go`, outside this ticket's scope) builds its live set from `client.ListAgents()` alone. `/agents` returns the registry plus parked crew — **no witness union** — so mg-0130's shape still applies to the manual CLI path after a pogod restart. Dry-run-by-default and human-driven, so it is not the same severity, but it is the same hole. Not fixed here; raising it separately.

## Notes

- **Not a v0.6.0 regression.** The branch-keyed check has been present since `gitgc` existed.
- `internal/agent/prompts/**` and `internal/agent/templates/**` untouched — the point is that the GC is correct without the prompt conventions that were incidentally protecting the review and QA roles.
- One file outside the declared scope (`internal/gitgc/**`, `cmd/pogod/**`, `docs/*.md`): `internal/agent/api_test.go`. Test-only, and it pins the new path coupling at the single site that writes the path, with the function that reads it. Flagged deliberately, not creep.
- **Follow-ups filed, not folded in:** [mg-1403] `pogo gc` builds its live set from `client.ListAgents()` alone and `/agents` has no witness union, so mg-0130's restart hole survives in the CLI path (`cmd/pogo` is outside this ticket's scope). [mg-bdda] phase 1 classifies ticket state by branch while phase 1b classifies by owner, so the same dead tree is kept or `rm -rf`'d depending on whether git still holds the registration — conservative direction, pre-existing, and now documented in `docs/polecat-worktrees.md`.
- Full gate green: `./build.sh` exits 0.

Refs drellem2/pogo#94

Approved triage recommendation: mg-ee98 (packet), public plan at drellem2/pogo#94 (comment 5119065619)
Work item: mg-dd92
