### PR TITLE
BUILD gh#91: cursor's trust-dialog watch stops giving up at a fixed 12s, and both widened watches are proved to end with their agent

### DIFF
--- a/changelog.d/mg-8792.fixed.md
+++ b/changelog.d/mg-8792.fixed.md
@@ -1,0 +1,61 @@
+- **The Cursor trust-dialog hook stops giving up at a fixed 12 seconds, and the
+  Claude hook's widened window is finally proved to end when its agent does
+  (mg-8792, refs drellem2/pogo#91).**
+  A trust dialog that renders after the watching hook has already returned is
+  never dismissed, and the stall is *permanent*: the dialog renders with no
+  composer, so the readiness sentinel never matches, the kickoff prompt is never
+  delivered, and the polecat sits there until a human answers by hand. That is
+  the failure CloverRoss reported 3-in-3 from an Ocean droplet, and their
+  `pogo nudge <id> "1"` rescue was literally answering the dialog — option 1,
+  *"Yes, I trust this folder"*.
+
+  **The bound was the bug, not its value.** A fixed wall-clock timeout set at
+  spawn is the same shape of defect as the one it is trying to catch, so a bigger
+  number moves the failure rather than removing it. Both hooks now take their
+  bound from the provider's own cold-start budget — the one the spawn path is
+  already willing to wait for the composer — so there is ONE budget rather than
+  two that disagree, and the hook that unblocks the composer cannot stop watching
+  before the spawn path stops waiting for it.
+
+  **What was already shipped, and what this adds.** Claude's half landed at
+  `d8e8a2b` (mg-ea45): the bound moved to `DefaultNudgeProfile.InitialNudgeTimeout`
+  and a `composerReady` gate came with it. This change adds the control that
+  half was missing and takes the cursor sibling:
+
+  - `internal/cursor`: `TrustDialogTimeout` is sourced from the provider's
+    `initialNudgeTimeout` (12s fixed -> 30s cold-start budget), the loop body is
+    split into a timing-injectable `watchForTrustDialog` the way claude's is, and
+    the four race controls are ported.
+  - `internal/claude` **and** `internal/cursor`: a positive control proving the
+    watcher terminates on agent exit.
+
+  **Why that last one is not a formality.** Every other test in both race files
+  proves the hook *fires*, and all of them pass just as well on an implementation
+  that never stops — which is exactly the cost of this fix, because the window
+  grew and the hook runs once per spawn. A watcher that outlives its agent is a
+  goroutine leak that compounds. The new control drives a scripted agent that
+  renders neither marker under a 90-second budget the test will not sit through,
+  so a prompt return can only have come from the `a.Done()` arm, and it asserts
+  the premise both ways rather than trusting it. Verified by mutation: deleting
+  that arm fails it in both packages, and restoring the fixed 12s fails the
+  cursor bound pin.
+
+  **The widened window is closed by the composer-ready gate, not by the clock.**
+  `trustDialogMarker` matches PTY *text*, and both harnesses echo the task into
+  the TUI — a work item whose body merely quotes the dialog matches. A short
+  window hid that by expiring before the echo arrived; a longer one does not. So
+  the gate is what makes the window safe: the moment the composer renders the
+  hook returns without sending anything, which also means a healthy spawn never
+  pays the longer budget at all.
+
+  **`internal/codex` deliberately still carries its fixed 12s**, and that is
+  recorded in the code rather than left to be rediscovered. Codex has no
+  composer-ready marker to gate on — `Provider.Nudge.PromptReadySentinel` is
+  empty because its ratatui composer has no stable ready string — so widening its
+  window would remove the timing failure by introducing the keypress-into-a-live-
+  composer failure the gate exists to prevent. Establishing a Codex ready marker
+  is an empirical job against a live CLI, not a code change; it is owed as
+  **mg-86e7**.
+
+  **drellem2/pogo#91 stays open.** It closes when CloverRoss confirms their
+  3-in-3 became 0-in-3, not when this lands — as promised on the issue.

--- a/internal/codex/trust_hook.go
+++ b/internal/codex/trust_hook.go
@@ -44,6 +44,32 @@ const TrustDialogPollInterval = 250 * time.Millisecond
 
 // TrustDialogTimeout bounds how long after spawn the hook watches for the
 // dialog before giving up.
+//
+// DELIBERATELY STILL A FIXED WALL-CLOCK BOUND, and that is a known defect —
+// the same shape drellem2/pogo#91 removed from claude (and, in the same change,
+// from cursor). It is left here rather than widened because the guard that makes
+// a widened window safe does not exist for Codex.
+//
+// claude and cursor both gate their watch on a composer-ready marker: the moment
+// the composer renders, the hook returns without sending anything. That gate is
+// what lets the window grow without risking a stray keypress, because
+// trustDialogMarker matches on PTY *text* and the harness echoes the task into
+// the TUI — a work item whose body merely quotes this dialog matches the marker.
+// While the window is short the hook has almost always expired before the echo;
+// widen it and the hook is still watching when the echo arrives, and on an
+// already-trusted directory (Registry.Respawn re-enters the same Dir, and Codex
+// persists trust in ~/.codex/config.toml) it would match the echo and press
+// Enter into a live composer.
+//
+// Codex has no such marker to gate on: Provider.Nudge.PromptReadySentinel is
+// empty, because its ratatui composer has no stable ready string (see the
+// PromptReadySentinel doc in internal/agent/provider.go and
+// docs/investigations/codex-nudge-calibration.md). Establishing one is an
+// empirical job against a live Codex CLI, not a code change — so widening this
+// bound is blocked on that measurement, not on writing the loop.
+//
+// Follow-up: mg-86e7. Do not simply raise this number; that moves the failure
+// rather than removing it, which is the whole finding of #91.
 const TrustDialogTimeout = 12 * time.Second
 
 // TrustDialogHook is the Codex provider's PostSpawnHook. It auto-accepts

--- a/internal/cursor/provider.go
+++ b/internal/cursor/provider.go
@@ -51,6 +51,27 @@ const personaRuleHeader = "---\n" +
 // uses its appearance to prove there is no trust dialog left to dismiss.
 const promptReadySentinel = "Plan, search, build anything"
 
+// initialNudgeTimeout is Cursor's cold-start budget: how long the spawn path is
+// willing to wait for the composer to appear.
+//
+// Cursor is a Node CLI; the trust dialog renders ~0.7s from spawn and the
+// composer settles ~3.0s. 30s is a generous upper bound.
+//
+// Two consumers, deliberately — Provider.Nudge.InitialNudgeTimeout, and
+// TrustDialogTimeout, which bounds how long TrustDialogHook watches for the
+// dialog. They must be the SAME number rather than two independent guesses: the
+// hook is what unblocks the composer, so it must not stop watching before the
+// spawn path stops waiting. See TrustDialogTimeout for what a hook that gives
+// up first costs.
+//
+// It is a const rather than `TrustDialogTimeout = Provider.Nudge.InitialNudgeTimeout`
+// because Provider's initializer references TrustDialogHook, whose body reads
+// TrustDialogTimeout — Go's initialization-dependency analysis is transitive
+// through function bodies, so sourcing the timeout from Provider would be an
+// initialization cycle. (claude has no such problem: its bound comes from
+// agent.DefaultNudgeProfile, another package.)
+const initialNudgeTimeout = 30 * time.Second
+
 // Provider is the Cursor CLI harness descriptor.
 //
 // Prompt injection uses the ContextFile strategy, because Cursor has no
@@ -143,10 +164,10 @@ var Provider = agent.Provider{
 		NeedsInitialNudge: false,
 
 		// Unused while NeedsInitialNudge is false; retained as the measured
-		// calibration record should the nudge path ever be needed again.
-		// Cursor is a Node CLI: the trust dialog renders ~0.7s from spawn and
-		// the composer settles ~3.0s. 30s is a generous upper bound.
-		InitialNudgeTimeout: 30 * time.Second,
+		// calibration record should the nudge path ever be needed again. It is
+		// also the bound TrustDialogTimeout is sourced from, so it is live even
+		// with the nudge path off — see initialNudgeTimeout.
+		InitialNudgeTimeout: initialNudgeTimeout,
 
 		// A carriage return submits the Cursor composer.
 		SubmitTerminator: "\r",

--- a/internal/cursor/trust_hook.go
+++ b/internal/cursor/trust_hook.go
@@ -79,7 +79,23 @@ const TrustDialogPollInterval = 250 * time.Millisecond
 
 // TrustDialogTimeout bounds how long after spawn the hook watches for the
 // dialog before giving up.
-const TrustDialogTimeout = 12 * time.Second
+//
+// It is Cursor's own cold-start budget, not an independent guess. The previous
+// value was a fixed 12s, and that shape was the defect fixed for Claude in
+// drellem2/pogo#91: the hook starts at spawn and gives up N seconds later, so on
+// a CPU-starved host under concurrent spawns the dialog can render AFTER the
+// hook has returned. Nothing then dismisses it — the composer never appears, the
+// ready sentinel never matches, and the polecat hangs until a human answers the
+// dialog by hand. A fixed wall-clock bound is the same SHAPE of defect as the
+// one it is trying to catch, so a bigger number would move the failure rather
+// than remove it.
+//
+// Sourcing the bound from initialNudgeTimeout means there is ONE cold-start
+// budget rather than two that disagree. Watching longer is close to free because
+// composerReady returns the hook early on every healthy spawn — the full budget
+// is only ever spent when neither marker appears, which is the drift signature
+// recorded at the deadline below.
+const TrustDialogTimeout = initialNudgeTimeout
 
 // trustDialogAccept is the key that accepts the dialog.
 //
@@ -96,13 +112,22 @@ const trustDialogAccept = "a"
 // Cursor's workspace-trust dialog by scanning PTY output and pressing "a", so a
 // polecat is not blocked at startup in its fresh worktree.
 //
-// It mirrors codex.TrustDialogHook — the same spawn-scoped, poll-and-dismiss
-// shape — because Cursor needs the same treatment for an analogous dialog. The
-// dialog renders ~0.7s after spawn and the composer settles ~2.3s after it is
-// dismissed; the 250ms poll clears it well inside the initial-task path.
+// It mirrors claude.TrustDialogHook — the same spawn-scoped, poll-and-dismiss
+// shape, bounded by the same provider's own cold-start budget — because Cursor
+// needs the same treatment for an analogous dialog. The dialog renders ~0.7s
+// after spawn and the composer settles ~2.3s after it is dismissed; the 250ms
+// poll clears it well inside the initial-task path.
 func TrustDialogHook(a *agent.Agent) {
-	deadline := time.After(TrustDialogTimeout)
-	ticker := time.NewTicker(TrustDialogPollInterval)
+	watchForTrustDialog(a, TrustDialogTimeout, TrustDialogPollInterval)
+}
+
+// watchForTrustDialog is TrustDialogHook's body with the timing injected, so
+// tests can drive the real loop against a real PTY on a millisecond budget
+// instead of waiting out the production one. Mirrors claude's split for the
+// same reason.
+func watchForTrustDialog(a *agent.Agent, budget, poll time.Duration) {
+	deadline := time.After(budget)
+	ticker := time.NewTicker(poll)
 	defer ticker.Stop()
 
 	for {

--- a/internal/cursor/trust_hook_race_test.go
+++ b/internal/cursor/trust_hook_race_test.go
@@ -1,4 +1,4 @@
-package claude
+package cursor
 
 import (
 	"bytes"
@@ -14,32 +14,50 @@ import (
 
 // These tests drive the REAL hook loop against a REAL Agent on a REAL PTY —
 // agent.Registry.Spawn forks a scripted shell whose output timing we control to
-// the tenth of a second. Only the timing budget is injected (watchForTrustDialog
-// takes it as a parameter) so the loop can be exercised on a sub-second budget
-// instead of the production one.
+// the tenth of a second. Only the timing budget is injected
+// (watchForTrustDialog takes it as a parameter) so the loop can be exercised on
+// a sub-second budget instead of the production one.
+//
+// They are the cursor half of drellem2/pogo#91 and mirror
+// internal/claude/trust_hook_race_test.go deliberately: the defect being removed
+// is the same shape in both providers, so it is worth being able to diff the two
+// files and see the same four controls.
 //
 // What this reproduces and what it does not: the mechanism is faithful — a
 // dialog that renders after the hook's budget has elapsed is never dismissed —
 // and TestLateRenderingDialogIsNeverDismissed is the positive control that
-// fails-by-design under the old fixed-guess shape. What is NOT reproduced here
-// is the production trigger: a genuinely CPU-starved host under concurrent
-// spawns pushing the real Claude Code TUI past 8 seconds. That race was not
-// constructed; the dialog is not even reachable on this machine (~/.claude.json
-// carries a blanket "/" entry with hasTrustDialogAccepted: true). The scripted
-// delay stands in for the starvation, not the other way round.
+// fails-by-design under the old fixed-guess shape. What is NOT reproduced is the
+// production trigger: a genuinely CPU-starved host under concurrent spawns
+// pushing the real Cursor TUI past 12 seconds. The scripted delay stands in for
+// the starvation, not the other way round.
 
 const (
-	// dialogLine is the real Claude Code trust-dialog prompt.
-	dialogLine = "Quick safety check: Is this a project you created or one you trust?"
-	// answeredMarker is printed by the script only after it reads a line from
+	// dialogLine is the real Cursor trust-dialog header (2026.07.09-a3815c0).
+	dialogLine = "Workspace Trust Required"
+	// composerLine is the real composer placeholder — promptReadySentinel as
+	// Cursor draws it.
+	composerLine = "> " + promptReadySentinel
+	// answeredMarker is printed by the script only after it reads a byte from
 	// the PTY — i.e. only if the hook actually answered the dialog.
 	answeredMarker = "POGO-DIALOG-ANSWERED"
 )
 
+// readOneByte makes the scripted shell able to observe Cursor's accept key.
+//
+// It is needed here and not in claude's equivalent because the two providers
+// answer with different keys: claude sends "\r", which ICRNL turns into a
+// newline and so completes an ordinary canonical-mode `read`. Cursor sends the
+// bare "a" accelerator (see trustDialogAccept) with no terminator, and a
+// canonical-mode read would block forever waiting for a newline that never
+// comes. Dropping the line discipline to min=1 makes a single byte readable,
+// which is what the hook actually sends.
+const readOneByte = "stty -icanon min 1 time 0 2>/dev/null\n" +
+	"dd bs=1 count=1 >/dev/null 2>&1\n"
+
 // spawnScripted forks `sh -c script` on a real PTY under a real Registry and
 // returns the live Agent. The provider is a copy of the real one with both
-// lifecycle hooks removed and the initial nudge disabled, so the only thing
-// touching this PTY is the hook the test drives itself.
+// lifecycle hooks removed, so the only thing touching this PTY is the hook the
+// test drives itself.
 func spawnScripted(t *testing.T, name, script string) *agent.Agent {
 	t.Helper()
 
@@ -97,23 +115,23 @@ func sawWithin(a *agent.Agent, want string, timeout time.Duration) bool {
 func lateDialogScript(delay string) string {
 	return "sleep " + delay + "\n" +
 		"printf '" + dialogLine + "\\n'\n" +
-		"read -r _\n" +
+		readOneByte +
 		"printf '" + answeredMarker + "\\n'\n" +
 		"sleep 30\n"
 }
 
-// TestLateRenderingDialogIsNeverDismissed is the POSITIVE CONTROL for
-// drellem2/macguffin#25: it reproduces the defect rather than the fix.
+// TestLateRenderingDialogIsNeverDismissed is the POSITIVE CONTROL for the
+// cursor half of drellem2/pogo#91: it reproduces the defect rather than the fix.
 //
 // The hook is given a budget SHORTER than the dialog's render delay — which is
-// exactly what a fixed 8s wall-clock guess becomes on a host loaded enough to
-// push the TUI past it. The hook returns, the dialog renders into an empty
-// room, and nothing ever answers it. That is the stall CloverRoss hit 3/3: no
-// composer, ready-sentinel never matches, kickoff prompt never delivered.
+// exactly what a fixed 12s wall-clock guess becomes on a host loaded enough to
+// push the TUI past it. The hook returns, the dialog renders into an empty room,
+// and nothing ever answers it. No composer follows, so the readiness sentinel
+// never matches and the polecat is stalled until a human answers by hand.
 //
 // If this test ever starts failing — i.e. a too-short budget still gets the
-// dialog dismissed — the mechanism described in the ticket is wrong and the
-// rest of this file is resting on a bad premise.
+// dialog dismissed — the mechanism is wrong and the rest of this file is resting
+// on a bad premise.
 func TestLateRenderingDialogIsNeverDismissed(t *testing.T) {
 	a := spawnScripted(t, "late-ctl", lateDialogScript("0.7"))
 
@@ -122,20 +140,20 @@ func TestLateRenderingDialogIsNeverDismissed(t *testing.T) {
 
 	// The dialog does render — the script is not broken, the hook just wasn't
 	// watching any more.
-	if !sawWithin(a, "safety check", 3*time.Second) {
+	if !sawWithin(a, dialogLine, 3*time.Second) {
 		t.Fatal("script never rendered the dialog: the control proves nothing")
 	}
 	if sawWithin(a, answeredMarker, 1*time.Second) {
 		t.Error("dialog was answered after the hook's budget expired — the " +
-			"late-render mechanism in drellem2/macguffin#25 does not hold")
+			"late-render mechanism this fix is built on does not hold")
 	}
 }
 
-// TestLateRenderingDialogIsDismissedWithinTheNudgeBudget is the same scenario
-// with the shipped shape: a budget tied to the initial-nudge cold-start budget
-// rather than an independent 8s guess. The dialog renders late and is still
-// dismissed.
-func TestLateRenderingDialogIsDismissedWithinTheNudgeBudget(t *testing.T) {
+// TestLateRenderingDialogIsDismissedWithinTheColdStartBudget is the same
+// scenario with the shipped shape: a budget tied to the provider's own
+// cold-start budget rather than an independent 12s guess. The dialog renders
+// late and is still dismissed.
+func TestLateRenderingDialogIsDismissedWithinTheColdStartBudget(t *testing.T) {
 	a := spawnScripted(t, "late-fix", lateDialogScript("0.7"))
 
 	watchForTrustDialog(a, 5*time.Second, 50*time.Millisecond)
@@ -147,11 +165,11 @@ func TestLateRenderingDialogIsDismissedWithinTheNudgeBudget(t *testing.T) {
 }
 
 // TestHookReturnsEarlyOnceComposerIsUp pins the early exit. Watching for the
-// full 60s budget would be a real cost if the hook always spent it; it does not,
-// because a rendered composer resolves the hook immediately.
+// full cold-start budget would be a real cost if the hook always spent it; it
+// does not, because a rendered composer resolves the hook immediately.
 func TestHookReturnsEarlyOnceComposerIsUp(t *testing.T) {
 	a := spawnScripted(t, "early-out",
-		"printf '? for shortcuts\\n'\nsleep 30\n")
+		"printf '"+composerLine+"\\n'\nsleep 30\n")
 
 	start := time.Now()
 	watchForTrustDialog(a, 10*time.Second, 50*time.Millisecond)
@@ -163,12 +181,49 @@ func TestHookReturnsEarlyOnceComposerIsUp(t *testing.T) {
 	}
 }
 
+// TestEchoedTaskIsNotTypedInto is why composerReady had to come with the longer
+// window. TestEchoedTaskLooksLikeTheTrustDialog already pins the two predicates
+// against strings; this drives the actual loop against a real PTY and asserts
+// that nothing is sent.
+//
+// trustDialogMarker matches PTY *text*, and Cursor echoes the argv-delivered
+// task into the TUI. A task that merely quotes the dialog matches. At the old
+// 12s budget the hook had usually expired before the echo; at the cold-start
+// budget it is still watching. On an already-trusted workspace (Respawn
+// re-enters the same Dir; Cursor persists trust per workspace) there is no
+// dialog to find — so an unguarded hook would match the echo and type a stray
+// "a" into the live composer, corrupting the next nudge.
+func TestEchoedTaskIsNotTypedInto(t *testing.T) {
+	echoed := "Investigate the dialog offering [a] Trust this workspace"
+
+	// Precondition: the echoed task really does look like the dialog.
+	if !matchesTrustDialog([]byte(echoed)) {
+		t.Fatal("precondition changed: the echoed task no longer matches " +
+			"trustDialogMarker — if the marker got stricter this guard may be " +
+			"redundant, but verify before deleting composerReady")
+	}
+
+	a := spawnScripted(t, "echo-guard",
+		"printf '"+composerLine+"\\n'\n"+
+			"printf '"+echoed+"\\n'\n"+
+			readOneByte+
+			"printf 'POGO-TYPED-INTO-COMPOSER\\n'\n"+
+			"sleep 30\n")
+
+	watchForTrustDialog(a, 3*time.Second, 50*time.Millisecond)
+
+	if sawWithin(a, "POGO-TYPED-INTO-COMPOSER", 1*time.Second) {
+		t.Error("hook sent the accept key into a live composer after matching " +
+			"the echoed task — composerReady must gate it off")
+	}
+}
+
 // TestWatchTerminatesWhenTheAgentExits is the NEGATIVE-SIDE control the rest of
 // this file needs to mean anything.
 //
 // Every other test here proves the hook FIRES. All of them pass just as well on
 // an implementation that never stops — and "never stops" is the specific cost of
-// this fix: the budget went from a fixed 8s to the 60s initial-nudge budget, and
+// this fix: the budget went from a fixed 12s to the 30s cold-start budget, and
 // the hook runs once per spawn. A watcher that outlives its agent is a goroutine
 // leak that compounds with every spawn, so the widened window is only safe if
 // agent exit ends the watch.
@@ -213,39 +268,19 @@ func TestWatchTerminatesWhenTheAgentExits(t *testing.T) {
 	}
 }
 
-// TestEchoedPromptIsNotTypedInto is why composerReady had to come with the
-// longer window.
-//
-// trustDialogMarker matches PTY *text*, and Claude echoes its kickoff prompt
-// into the TUI. A prompt that merely mentions a "safety check" matches. At the
-// old 8s budget the hook had almost always expired before the prompt was
-// echoed; at the initial-nudge budget it is still watching. On an already-
-// trusted worktree (Respawn re-enters the same Dir; Claude persists trust per
-// path) there is no dialog to find — so an unguarded hook would match the echo
-// and press Enter into the live composer, submitting a half-typed nudge.
-//
-// The composer is up here, so the hook must return without sending anything.
-func TestEchoedPromptIsNotTypedInto(t *testing.T) {
-	echoed := "Investigate the Quick safety check dialog and report back"
-
-	// Precondition: the echoed prompt really does look like the dialog.
-	if !matchesTrustDialog([]byte(echoed)) {
-		t.Fatal("precondition changed: the echoed prompt no longer matches " +
-			"trustDialogMarker — if the marker got stricter this guard may be " +
-			"redundant, but verify before deleting composerReady")
+// TestTrustDialogTimeoutIsTheColdStartBudget is the regression pin for the
+// cursor half of drellem2/pogo#91. The bug was a fixed wall-clock guess that
+// could expire before a loaded host rendered the dialog. The bound must be the
+// provider's own cold-start budget, so there is one timeout concept rather than
+// two that disagree.
+func TestTrustDialogTimeoutIsTheColdStartBudget(t *testing.T) {
+	if want := Provider.Nudge.InitialNudgeTimeout; TrustDialogTimeout != want {
+		t.Errorf("TrustDialogTimeout = %v, want the cold-start budget %v — the "+
+			"hook that unblocks the composer must not stop watching before the "+
+			"spawn path stops waiting for it", TrustDialogTimeout, want)
 	}
-
-	a := spawnScripted(t, "echo-guard",
-		"printf '? for shortcuts\\n'\n"+
-			"printf '"+echoed+"\\n'\n"+
-			"read -r _\n"+
-			"printf 'POGO-TYPED-INTO-COMPOSER\\n'\n"+
-			"sleep 30\n")
-
-	watchForTrustDialog(a, 3*time.Second, 50*time.Millisecond)
-
-	if sawWithin(a, "POGO-TYPED-INTO-COMPOSER", 1*time.Second) {
-		t.Error("hook pressed Enter into a live composer after matching the " +
-			"echoed prompt — composerReady must gate it off")
+	if TrustDialogTimeout <= 12*time.Second {
+		t.Errorf("TrustDialogTimeout = %v: back at or below the fixed 12s that "+
+			"let a late-rendering dialog go undismissed", TrustDialogTimeout)
 	}
 }


### PR DESCRIPTION
## Read this first: the primary fix was already on `main`

The ticket asked me to replace the fixed 8s `TrustDialogTimeout` in
`internal/claude/trust_hook.go`. **That already shipped** at `d8e8a2b` —
`fix(claude): handle a late-rendering trust dialog instead of giving up at 8s
(mg-ea45)`, merged 2026-07-23, six days before the GO on this ticket. It sources
the bound from `DefaultNudgeProfile.InitialNudgeTimeout` and adds a
`composerReady` gate, which is exactly the approach the public plan comment
describes. The triage (mg-560d) predates that merge, so the build ticket was
written against a defect that no longer existed.

I verified this rather than assuming it: `git merge-base --is-ancestor d8e8a2b main`
confirms it, and the shipped code and its race tests match the plan.

So this PR does the work that was actually still outstanding.

## What this changes

**1. `internal/cursor` rides the change (the sibling decision — see below).**
`TrustDialogTimeout` moves from a fixed `12 * time.Second` to the provider's own
cold-start budget (30s) via a shared `initialNudgeTimeout` const, and the loop
body splits into a timing-injectable `watchForTrustDialog` mirroring claude's, so
the four race controls can be ported.

The const is deliberate rather than `TrustDialogTimeout = Provider.Nudge.InitialNudgeTimeout`:
`Provider`'s initializer references `TrustDialogHook`, whose body reads
`TrustDialogTimeout`, and Go's init-dependency analysis is transitive through
function bodies — sourcing it from `Provider` is an initialization cycle. claude
has no such problem because its bound comes from another package. That reasoning
is in the code.

**2. The acceptance control mg-ea45 was missing, added to BOTH packages:** proof
that the watcher terminates on agent exit.

This is the one the ticket called out specifically, and it was genuinely absent —
nothing in either package exercised the `<-a.Done()` arm. It matters because
every other test in these files proves the hook *fires*, and **all of them pass
on an implementation that never stops**. That is precisely the cost of this fix:
the window grew (8s → 60s for claude, 12s → 30s for cursor) and the hook runs
once per spawn, so a watcher outliving its agent is a leak that compounds.

The test drives a scripted agent that renders *neither* marker under a 90-second
budget the test will not sit through, so a prompt return can only have come from
the `a.Done()` arm — and it asserts that premise in both directions rather than
trusting it.

**3. `internal/codex` gets its decision recorded in code**, plus a follow-up
ticket.

## Sibling hooks: cursor taken, codex not

Stating this explicitly as the ticket asked.

**cursor: taken.** It already has a `composerReady` gate, which is the thing that
makes a widened window safe. It rides cleanly and is the same defect shape.

**codex: NOT taken, and this is owed as mg-86e7.** The bound is not the hard
part; the *guard* is. `trustDialogMarker` matches on PTY **text**, and the
harness echoes the task into the TUI — a work item whose body merely quotes the
dialog matches the marker. A short window hid that by expiring before the echo
arrived; a longer one does not. So on an already-trusted directory an unguarded
widened hook would match the echo and press Enter into a live composer.

Codex has no marker to gate on: `Provider.Nudge.PromptReadySentinel` is empty,
because its ratatui composer has no stable ready string — a measured finding
recorded in `internal/agent/provider.go` and the codex nudge-calibration doc.
Establishing one is an **empirical job against a live Codex CLI, not a code
change**. Folding it in would have meant either shipping a widened window with no
false-positive guard, or inventing a sentinel without measuring it. Both are
worse than owing the ticket. The constant now documents this in place, so the
next reader does not simply raise the number.

## Verification

- **Mutation-tested, because a control that cannot fail proves nothing.**
  Deleting the `<-a.Done()` arm fails the new exit test in *both* packages
  (15.03s timeout, both). Restoring the fixed `12s` fails the cursor bound pin.
  Both mutations reverted and re-verified.
- **The late-render case the old code failed** is reproduced, not merely the
  happy path: `TestLateRenderingDialogIsNeverDismissed` gives the hook a budget
  shorter than the dialog's render delay and asserts the dialog is *never*
  answered — it fails by design under the old fixed-guess shape.
- **No stray input into a ready composer:** `TestEchoedTaskIsNotTypedInto` drives
  the real loop against a real PTY with the composer up and an echoed task that
  does match the dialog marker, asserting nothing is sent.
- Full `./build.sh` gate green (exit 0), before and after rebasing onto
  `origin/main`.
- `go test -race` clean on `internal/cursor` and `internal/codex`.
- **Live `~/.pogo/events.log` did not grow from the test run** (mg-ea45 acceptance
  point 3). The 8 lines it gained during the window were all live pogod activity
  — schedules, stall-watch, another polecat's spawn — and none were
  `sentinel_drift`.

## Out of scope, flagged not fixed

`internal/claude` has a **pre-existing race flake** in
`TestModalHook_Case3_RateLimitFiresOnEventsStale` (`modal_hook.go`), surfaced by
`go test -race` on the full package. It is not mine — I confirmed it on a
pristine tree with my change stashed: **2 of 3 runs failed**. It passes when run
alone, so it is an interaction under parallel execution. Not touched here; worth
its own ticket.

## The issue stays open

`Refs drellem2/pogo#91` — deliberately **not** a closing keyword. gh#91 closes
only when CloverRoss confirms their 3-in-3 became 0-in-3, which we committed to
publicly on the issue. A `Resolves`/`Closes` here would auto-close it on merge,
so the protocol's default PR-body wording is overridden on purpose.

Approved triage recommendation: **mg-560d** (result sidecar), plan posted at
https://github.com/drellem2/pogo/issues/91#issuecomment-5122658507
Follow-up filed: **mg-86e7** (codex sibling)
Work item: mg-8792
