### PR TITLE
fix(hostload): the subtree CPU measurement reads a Linux host, instead of reporting 0.00 cores there (mg-79e3)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -542,6 +542,20 @@ a load average of 214 against ~7.5 of 10 cores in use, because Darwin counts
 I/O waiters in that figure. The load average is carried as context and decided
 on by nothing.
 
+**Where the measurement can be taken is part of the answer.** The rate is only
+as good as the precision of the CPU column it differenced, and that is a
+property of the host. `internal/proctable` owns the read for both this and the
+refinery's gate watch, and reports the resolution alongside the rows:
+`linux-procfs` (10ms, `/proc/<pid>/stat` `utime+stime` in USER_HZ ticks) and
+`darwin-ps` (10ms, BSD `ps`'s `MM:SS.ss`) both resolve sub-second windows;
+procps `ps` prints whole seconds only, so a fallback `<goos>-ps` source needs a
+multi-second window. Below a source's `MinWindow` the difference is not a small
+number, it is **zero** — for a saturated host exactly as much as an idle one —
+so `Sample.Unresolvable` and `StepProgress.CPUUnavailable` carry the reason
+instead, and both records name the source they were taken with. Reporting that
+quantised zero as a measurement is how the signal went silently blind on Linux
+while reading correctly on the machine it was written on (mg-79e3).
+
 The same measurement gates dispatch — see **Dispatch gates** below.
 
 **Cancelling a merge.** `pogo refinery cancel <id>` reaches a **processing** MR,

--- a/changelog.d/mg-79e3.fixed.md
+++ b/changelog.d/mg-79e3.fixed.md
@@ -16,6 +16,10 @@
   nothing, so the busy/idle discrimination that mg-0c51 and mg-1b8c exist to
   provide collapsed.
 
+  **Two independent causes, and reading `cores=0.00` as one hid the other.**
+  `hostload`'s zero was quantisation. The gate test's zero was a `procs=0`
+  subtree — no processes at all, which is a different fact. Both are below.
+
   **Nothing was broken. The instrument could not read the scale.** Both signals
   difference `ps`'s cumulative TIME column across a window. On darwin that
   column is `MM:SS.ss` — hundredths. On Linux, procps prints `[DD-]HH:MM:SS`,
@@ -59,19 +63,54 @@
   (`StepProgress.CPUSource`, `Sample.Source`). This failure was undiagnosable
   from the CI log precisely because no reading said where it came from.
 
+  **The second cause: the gate test asserted on a SEALED record.** By the time
+  a gate's record is sealed the gate process is gone, so `SubtreeGone` is the
+  honest classification — and whether the assertion ever saw a live subtree came
+  down to whether the last heartbeat landed before or after the gate exited.
+  Darwin's timing said before; Linux's said after. The test had been latently
+  racy since mg-0c51 and passed by luck.
+
+  The signal is about a **live** gate — a coordinator polling `pogo refinery
+  queue` mid-merge — so the test now collects every record published while the
+  gate ran and asserts on those. Both arms came out stronger:
+
+  - the spinning gate must peak **above 0.5 cores and below 2.0**. The upper
+    bound is new and is what keeps the test sensitive to precision loss: this
+    gate holds exactly one spinner, so ~1.0 is the physical answer, and a
+    column too coarse for the window reports nothing for several windows and
+    then a whole tick at once — which reads as a 2.5-core burst and satisfies
+    any lower bound. Verified: with the CPU column quantised to whole seconds
+    the lower-bound-only test *passed*, and the upper bound catches it.
+  - the sleeping gate must classify idle on **every** settled reading, not
+    merely one, since a measurement reporting busy unconditionally would
+    satisfy an "at least one" test.
+
+  Readings taken over a window in which the subtree gained or lost a process
+  are excluded, with the reason stated: churn counts as work by design, so the
+  startup and teardown windows say "busy" for both arms and discriminate
+  nothing. Excluding them forces each arm onto the CPU path — the path that was
+  blind.
+
+  `TestSubtreeCPUOnALiveBusyProcess` had the same latent race and now waits for
+  the subtree to settle before opening its window. Until this change the `ps`
+  exec took long enough to hide it; a `/proc` read returns in under a
+  millisecond, so the first sample landed before the shell had forked its child
+  and the sleeping arm measured that fork as work.
+
   **The assertions were kept, and proved still able to fail.** Two deliberate
   defects were introduced locally on a machine where the measurement works:
 
   - *quantise the CPU column to whole seconds* (procps precision on a host that
-    has better) — `TestReadRealHost` red with `UsedCores = 0`, and
-    `TestGateWatchMeasuresARealSubtreesCPU` red on the idle arm. The skip is
-    keyed on the source's **declared** resolution, not on whether the number
-    came out zero, so a real regression on a capable host still goes red rather
-    than being skipped away.
+    has better) — `TestReadReadsTheRealProcessTable` red with `burned CPU for
+    100ms and its cumulative CPU column went 0s -> 0s`, and
+    `TestGateWatchMeasuresARealSubtreesCPU` red on the one-spinner ceiling at
+    2.50 cores. The skip is keyed on the source's **declared** resolution, not
+    on whether a number came out zero, so a real regression on a capable host
+    still goes red rather than being skipped away.
   - *stop the subtree walk at the root* — the CI failure reproduced verbatim:
-    `a spinning gate measured 0.00 cores; the subtree walk is not finding the
-    work`, `a spinning gate must classify as busy, got 2`, `a computing gate
-    (0.00 cores) must measure higher than a sleeping one (0.00 cores)`, plus
+    `a spinning gate peaked at 0.00 cores ...; the subtree walk is not finding
+    the work`, `a spinning gate must classify as busy`, `a computing gate (0.00
+    cores) must measure higher than a sleeping one (0.00 cores)`, plus
     `TestSubtreeCPUOnALiveBusyProcess` and both `sampleSubtree` unit tests.
 
   **No assertion was relaxed and none was replaced by a weaker one.**
@@ -83,7 +122,10 @@
   skips, and `TestGateWatchRefusesToMeasureBelowTheHostsResolution` /
   `TestReadOnAHostTooCoarseToMeasure` exercise that path **everywhere** by
   standing in a coarse source — so the skip cannot become a place where
-  coverage quietly disappears.
+  coverage quietly disappears. On the two supported platforms a silent skip is
+  impossible at all: `TestCurrentSourceMatchesThisPlatform` fails on Linux
+  unless `linux-procfs` is selected, and on both unless the source resolves the
+  400ms window the gate test uses.
 
   Known limit, stated: `linux-procfs` assumes USER_HZ is 100, which Linux fixes
   for procfs output independently of `CONFIG_HZ`. A platform where that is

--- a/changelog.d/mg-79e3.fixed.md
+++ b/changelog.d/mg-79e3.fixed.md
@@ -1,0 +1,91 @@
+- **The process-subtree CPU measurement now works on Linux, so the gate-liveness
+  and fleet-share signals stop reporting `0.00 cores` in CI (mg-79e3).** CI was
+  RED on `main` on every merge from 11:17:29 on 2026-07-30 — at least eight
+  consecutive runs, `test` job only — while the refinery kept merging, because
+  the refinery's local gates and GitHub Actions are different environments and
+  these two tests are environment-sensitive.
+
+  Every failing assertion was downstream of one number:
+
+      hostload_test.go:301   UsedCores = 0 on a host that is running this test
+      queueview_test.go:197  busy gate: cores=0.00 procs=0 churn=3 window=400ms unavailable=""
+      queueview_test.go:207  a spinning gate measured 0.00 cores; the subtree walk is not finding the work
+      queueview_test.go:223  a sleeping gate must classify as idle (cores=0.00 churn=2)
+
+  A spinning gate and a sleeping one measured identically because both measured
+  nothing, so the busy/idle discrimination that mg-0c51 and mg-1b8c exist to
+  provide collapsed.
+
+  **Nothing was broken. The instrument could not read the scale.** Both signals
+  difference `ps`'s cumulative TIME column across a window. On darwin that
+  column is `MM:SS.ss` — hundredths. On Linux, procps prints `[DD-]HH:MM:SS`,
+  **whole seconds**, and offers no finer format (`cputimes` is integer seconds
+  too). So 400ms of CPU rounds to zero at both ends of a 400ms window, and a
+  subtree burning a full core differences to exactly the same 0.00 as one
+  asleep. The tests were written and verified on darwin and run on Linux.
+
+  **What changed: the instrument, not the assertions.** New
+  `internal/proctable` owns the process-table read for both callers and, more
+  to the point, states the precision of what it returned:
+
+  | environment | source | CPU resolution |
+  |---|---|---|
+  | linux, `/proc` readable | `linux-procfs` | 10ms |
+  | darwin | `darwin-ps` | 10ms |
+  | linux, no `/proc` | `linux-ps` | 1s |
+  | other unix | `<goos>-ps` | 1s |
+
+  On Linux it reads `/proc/<pid>/stat` directly — `utime+stime` in USER_HZ
+  ticks, 10ms, the same order as darwin's — so short windows resolve on both
+  supported platforms and CI runs the **full** discrimination, unweakened and
+  unskipped. (`comm` is located from the last `)` rather than by splitting the
+  line, because a command name may legally contain spaces and parentheses and a
+  naive split reads someone else's field as CPU time.)
+
+  **"Cannot measure here" is now a distinct answer from "measured zero", and
+  that is the durable half.** `Source.MinWindow` is 5 resolution ticks — enough
+  to separate "about a core" from "nothing" at ≤20% quantisation error, and
+  deliberately not enough to resolve the 0.02-core idle threshold, which would
+  need ~50. Below it:
+
+  - the gate record publishes `CPUUnavailable` with the reason and classifies
+    `SubtreeUnknown`, never `SubtreeIdle` — `coarse-ps resolves CPU time to 1s,
+    so a 200ms window cannot separate work from none (needs 5s)`;
+  - `hostload.Sample` carries `Unresolvable` and `Resolved() == false`, keeping
+    the host context that is still true (core count, load average) and dropping
+    the attribution numbers that would be fabrications.
+
+  Both records now also carry the **source they were taken with**
+  (`StepProgress.CPUSource`, `Sample.Source`). This failure was undiagnosable
+  from the CI log precisely because no reading said where it came from.
+
+  **The assertions were kept, and proved still able to fail.** Two deliberate
+  defects were introduced locally on a machine where the measurement works:
+
+  - *quantise the CPU column to whole seconds* (procps precision on a host that
+    has better) — `TestReadRealHost` red with `UsedCores = 0`, and
+    `TestGateWatchMeasuresARealSubtreesCPU` red on the idle arm. The skip is
+    keyed on the source's **declared** resolution, not on whether the number
+    came out zero, so a real regression on a capable host still goes red rather
+    than being skipped away.
+  - *stop the subtree walk at the root* — the CI failure reproduced verbatim:
+    `a spinning gate measured 0.00 cores; the subtree walk is not finding the
+    work`, `a spinning gate must classify as busy, got 2`, `a computing gate
+    (0.00 cores) must measure higher than a sleeping one (0.00 cores)`, plus
+    `TestSubtreeCPUOnALiveBusyProcess` and both `sampleSubtree` unit tests.
+
+  **No assertion was relaxed and none was replaced by a weaker one.**
+  `a computing gate must measure higher than a sleeping one` is intact; it was
+  not turned into "both are non-negative", which would pass everywhere and test
+  nothing. The environment gate is checked *before* the numeric arms and names
+  itself in the output, so a passing run states where it measured. On an
+  unsupported host the test asserts the UNKNOWN-with-a-reason path and then
+  skips, and `TestGateWatchRefusesToMeasureBelowTheHostsResolution` /
+  `TestReadOnAHostTooCoarseToMeasure` exercise that path **everywhere** by
+  standing in a coarse source — so the skip cannot become a place where
+  coverage quietly disappears.
+
+  Known limit, stated: `linux-procfs` assumes USER_HZ is 100, which Linux fixes
+  for procfs output independently of `CONFIG_HZ`. A platform where that is
+  untrue would misreport the scale, not the resolution — the discrimination
+  survives.

--- a/internal/hostload/hostload.go
+++ b/internal/hostload/hostload.go
@@ -32,24 +32,33 @@
 //
 // # How the measurement is taken
 //
-// Two `ps` snapshots of cumulative per-process CPU time, separated by a
-// window, differenced and divided by the window. That yields cores-in-use over
-// that window. It is deliberately not `ps`'s own %CPU column, which is a
-// lifetime average on Linux and a decaying one on Darwin — neither answers
-// "what is happening right now", which is the question a gate or a dispatch
-// decision is asking.
+// Two snapshots of cumulative per-process CPU time, separated by a window,
+// differenced and divided by the window. That yields cores-in-use over that
+// window. It is deliberately not `ps`'s own %CPU column, which is a lifetime
+// average on Linux and a decaying one on Darwin — neither answers "what is
+// happening right now", which is the question a gate or a dispatch decision is
+// asking.
+//
+// # Where it can be measured
+//
+// A differenced rate is only as good as the precision of the column it
+// differenced, and that precision is a property of the HOST. internal/proctable
+// picks the best available source and states its resolution: 10ms on darwin and
+// on any Linux with a readable /proc, whole seconds where only procps `ps` is
+// available. Below a source's minimum window the difference is not a small
+// number, it is zero — for a saturated host exactly as much as an idle one.
+// Sample.Unresolvable carries that case, and it is the difference between
+// "the fleet is using nothing" and "this host cannot tell me". Reporting the
+// first when the second is true is how a dispatch guard goes blind (mg-79e3).
 package hostload
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
 	"runtime"
-	"strconv"
-	"strings"
 	"time"
+
+	"github.com/drellem2/pogo/internal/proctable"
 )
 
 // DefaultWindow is how long a sample observes the host for. Long enough that
@@ -93,7 +102,21 @@ type Sample struct {
 	// FleetCores is 0 because nothing could be attributed, which is not the
 	// same fact as "the fleet is idle" and must not be read as one.
 	Attributed bool `json:"attributed"`
+
+	// Source names the process-table reader and the precision of its CPU
+	// column. Carried on every sample so a reading states the environment it
+	// was taken in — this class of failure is invisible until it does.
+	Source string `json:"source,omitempty"`
+	// Unresolvable is set when Window was too short for Source's resolution to
+	// separate work from none. The core figures are then quantisation noise
+	// rather than a measurement, and must not be read as "nothing is running".
+	Unresolvable string `json:"unresolvable,omitempty"`
 }
+
+// Resolved reports whether the sample's numbers are a measurement at all.
+// A caller deciding on cores must check this: an unresolvable sample reports
+// zeros that mean "cannot tell", not "idle".
+func (s Sample) Resolved() bool { return s.Unresolvable == "" }
 
 // UsedCores is total CPU in use over the window, fleet and otherwise.
 func (s Sample) UsedCores() float64 { return s.FleetCores + s.ExternalCores }
@@ -121,6 +144,9 @@ func (s Sample) FleetSaturation() float64 {
 // String renders the sample as one line, with the load average last and
 // labelled, so it cannot be mistaken for the decision number.
 func (s Sample) String() string {
+	if !s.Resolved() {
+		return fmt.Sprintf("host load unmeasurable: %s", s.Unresolvable)
+	}
 	if !s.Attributed {
 		return fmt.Sprintf("fleet unattributed (no fleet root found), host using %.1f of %d cores "+
 			"(loadavg %.2f, context only)", s.UsedCores(), s.Cores, s.LoadAvg1)
@@ -179,11 +205,23 @@ type Reader struct {
 	Roots []int
 	// Window overrides DefaultWindow.
 	Window time.Duration
+	// Source overrides the detected process-table source. Zero value means
+	// proctable.Current(). Exported so a test can assert what this reader does
+	// on a host whose CPU column is too coarse for the window it was given —
+	// a state no test can create on the machine it happens to run on.
+	Source proctable.Source
 
 	// snapshot and loadavg are test seams.
 	snapshot psSnapshot
 	loadavg  func() float64
 	cores    int
+}
+
+func (r *Reader) source() proctable.Source {
+	if r.Source.Resolution > 0 {
+		return r.Source
+	}
+	return proctable.Current()
 }
 
 func (r *Reader) window() time.Duration {
@@ -241,6 +279,22 @@ func (r *Reader) Read(ctx context.Context) (Sample, error) {
 		return Sample{}, fmt.Errorf("hostload: non-positive sample window %s", elapsed)
 	}
 
+	src := r.source()
+	if reason := src.CannotResolve(elapsed); reason != "" {
+		// Not a small measurement — no measurement. Every per-process
+		// difference quantises to zero over a window this short, so the cores
+		// figures would read as an idle host whatever the host is doing.
+		// Returning the reason instead is the whole point of the field.
+		return Sample{
+			Time:         t1,
+			Window:       elapsed,
+			Cores:        r.numCores(),
+			LoadAvg1:     r.load(),
+			Source:       src.Name,
+			Unresolvable: reason,
+		}, nil
+	}
+
 	fleetPIDs, attributed := fleetSubtree(second, r.Roots)
 
 	var fleetCPU, externalCPU time.Duration
@@ -279,6 +333,7 @@ func (r *Reader) Read(ctx context.Context) (Sample, error) {
 		FleetProcs:    fleetProcs,
 		LoadAvg1:      r.load(),
 		Attributed:    attributed,
+		Source:        src.Name,
 	}, nil
 }
 
@@ -323,77 +378,20 @@ func fleetSubtree(rows map[int]procRow, roots []int) (map[int]bool, bool) {
 	return set, live > 0
 }
 
-// readPS snapshots every process's cumulative CPU time.
+// readPS snapshots every process's cumulative CPU time. The reading itself —
+// and, critically, its precision — belongs to internal/proctable: the same
+// question is asked by the refinery's gate watch, and two readers that
+// disagree about how finely CPU time can be read is how one of them ends up
+// reporting a zero it cannot justify.
 func readPS() (map[int]procRow, time.Time, error) {
-	out, err := exec.Command("ps", "-Ao", "pid=,ppid=,time=").Output()
+	table, err := proctable.Read()
 	at := time.Now()
 	if err != nil {
 		return nil, at, err
 	}
-	rows := make(map[int]procRow, 512)
-	sc := bufio.NewScanner(bytes.NewReader(out))
-	sc.Buffer(make([]byte, 64*1024), 1024*1024)
-	for sc.Scan() {
-		if row, ok := parsePSRow(sc.Text()); ok {
-			rows[row.pid] = row
-		}
+	rows := make(map[int]procRow, len(table))
+	for _, r := range table {
+		rows[r.PID] = procRow{pid: r.PID, ppid: r.PPID, cpu: r.CPU}
 	}
-	return rows, at, sc.Err()
-}
-
-// parsePSRow reads one `pid ppid time` line.
-func parsePSRow(line string) (procRow, bool) {
-	f := strings.Fields(line)
-	if len(f) < 3 {
-		return procRow{}, false
-	}
-	pid, err := strconv.Atoi(f[0])
-	if err != nil {
-		return procRow{}, false
-	}
-	ppid, err := strconv.Atoi(f[1])
-	if err != nil {
-		return procRow{}, false
-	}
-	cpu, ok := parseCPUTime(f[2])
-	if !ok {
-		return procRow{}, false
-	}
-	return procRow{pid: pid, ppid: ppid, cpu: cpu}, true
-}
-
-// parseCPUTime reads `ps`'s cumulative-time column: [[dd-]hh:]mm:ss[.ff].
-func parseCPUTime(s string) (time.Duration, bool) {
-	days := 0
-	if dash := strings.IndexByte(s, '-'); dash >= 0 {
-		d, err := strconv.Atoi(s[:dash])
-		if err != nil {
-			return 0, false
-		}
-		days = d
-		s = s[dash+1:]
-	}
-	parts := strings.Split(s, ":")
-	if len(parts) < 2 || len(parts) > 3 {
-		return 0, false
-	}
-	// Seconds (with optional fraction) are always last.
-	secs, err := strconv.ParseFloat(parts[len(parts)-1], 64)
-	if err != nil {
-		return 0, false
-	}
-	mins, err := strconv.Atoi(parts[len(parts)-2])
-	if err != nil {
-		return 0, false
-	}
-	hours := 0
-	if len(parts) == 3 {
-		h, err := strconv.Atoi(parts[0])
-		if err != nil {
-			return 0, false
-		}
-		hours = h
-	}
-	total := float64(days*86400+hours*3600+mins*60) + secs
-	return time.Duration(total * float64(time.Second)), true
+	return rows, at, nil
 }

--- a/internal/hostload/hostload_test.go
+++ b/internal/hostload/hostload_test.go
@@ -6,46 +6,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/drellem2/pogo/internal/proctable"
 )
-
-func TestParseCPUTime(t *testing.T) {
-	cases := []struct {
-		in   string
-		want time.Duration
-		ok   bool
-	}{
-		{"0:01.25", 1250 * time.Millisecond, true},
-		{"169:10.30", 169*time.Minute + 10300*time.Millisecond, true},
-		{"12:34:56", 12*time.Hour + 34*time.Minute + 56*time.Second, true},
-		{"2-03:04:05", 2*24*time.Hour + 3*time.Hour + 4*time.Minute + 5*time.Second, true},
-		{"", 0, false},
-		{"garbage", 0, false},
-		{"1:2:3:4", 0, false},
-	}
-	for _, c := range cases {
-		got, ok := parseCPUTime(c.in)
-		if ok != c.ok {
-			t.Errorf("parseCPUTime(%q) ok=%v, want %v", c.in, ok, c.ok)
-			continue
-		}
-		if ok && got != c.want {
-			t.Errorf("parseCPUTime(%q) = %s, want %s", c.in, got, c.want)
-		}
-	}
-}
-
-func TestParsePSRow(t *testing.T) {
-	row, ok := parsePSRow("  1234   567 0:12.50")
-	if !ok {
-		t.Fatal("expected a parse")
-	}
-	if row.pid != 1234 || row.ppid != 567 || row.cpu != 12500*time.Millisecond {
-		t.Errorf("got %+v", row)
-	}
-	if _, ok := parsePSRow("nonsense"); ok {
-		t.Error("expected no parse for a short line")
-	}
-}
 
 // table builds a snapshot pair from (pid, ppid, cpuSecondsBefore, cpuSecondsAfter).
 type proc struct {
@@ -279,25 +242,121 @@ func TestReadRespectsContextCancellation(t *testing.T) {
 	}
 }
 
-// TestReadRealHost exercises the real `ps` path. It asserts shape, not values:
-// what the host is doing while the suite runs is not ours to predict.
+// TestReadRealHost exercises the real process-table path. It asserts shape,
+// not values: what the host is doing while the suite runs is not ours to
+// predict.
+//
+// The one value it does assert — that SOMETHING is using CPU on a host that is
+// currently running this test — is the assertion that went red across CI from
+// 11:17 on 2026-07-30 (mg-79e3), and it is kept. What changed is that the
+// window is now chosen from the host's measured CPU-time resolution instead of
+// being hardcoded at 200ms, so the test measures over a window this host can
+// actually answer. Where no such window exists the test says so and skips,
+// rather than asserting a number the environment cannot produce.
 func TestReadRealHost(t *testing.T) {
-	r := &Reader{Roots: []int{1}, Window: 200 * time.Millisecond}
+	src := proctable.Current()
+	t.Logf("process-table source: %s", src)
+
+	window := 200 * time.Millisecond
+	if !src.CanResolve(window) {
+		window = src.MinWindow()
+	}
+	// A window this wide is no longer a unit test, and a source that needs one
+	// cannot support the sub-second measurements the refinery's gate watch
+	// takes either. Naming the environment is the report; a zero would not be.
+	if window > 2*time.Second {
+		t.Skipf("no usable measurement here: %s, so the shortest trustworthy window is %s",
+			src, src.MinWindow())
+	}
+
+	r := &Reader{Roots: []int{1}, Window: window}
 	s, err := r.Read(context.Background())
 	if err != nil {
 		t.Fatalf("Read: %v", err)
 	}
+	t.Logf("sample over %s: %s", window, s)
 	if s.Cores <= 0 {
 		t.Errorf("Cores = %d", s.Cores)
 	}
 	if s.FleetCores < 0 || s.ExternalCores < 0 {
 		t.Errorf("negative cores: %+v", s)
 	}
+	if s.Source != src.Name {
+		t.Errorf("Source = %q, want %q — a sample must name the instrument it was taken with", s.Source, src.Name)
+	}
+	if !s.Resolved() {
+		t.Fatalf("Read reported the window as unresolvable despite choosing it from the source: %s", s.Unresolvable)
+	}
 	// Rooted at pid 1, essentially everything is a descendant.
 	if !s.Attributed {
 		t.Error("Attributed = false rooted at pid 1")
 	}
 	if s.UsedCores() == 0 {
-		t.Error("UsedCores = 0 on a host that is running this test")
+		t.Errorf("UsedCores = 0 on a host that is running this test (source %s, window %s)", src, s.Window)
+	}
+}
+
+// TestReadOnAHostTooCoarseToMeasure is the other half, and it runs everywhere.
+// It is what keeps the skip in TestReadRealHost honest: a source whose CPU
+// column cannot resolve the window must produce a REASON, not the zeros that
+// read as an idle host. Those zeros are what a dispatch guard would have acted
+// on, and "the fleet is using nothing" and "I cannot tell" call for opposite
+// decisions.
+func TestReadOnAHostTooCoarseToMeasure(t *testing.T) {
+	// A host whose processes really are burning CPU...
+	procs := []proc{{pid: 100, ppid: 1, before: 0, at: 4}, {pid: 200, ppid: 1, before: 0, at: 2}}
+	snap, _ := snapshots(procs, 400*time.Millisecond)
+	r := &Reader{
+		Roots: []int{100},
+		// The snapshot stamps are 400ms apart; the real wait is short because
+		// the arithmetic under test is driven by the stamps, not the sleep.
+		Window:   time.Millisecond,
+		Source:   proctable.Source{Name: "coarse-ps", Resolution: time.Second},
+		snapshot: snap,
+		loadavg:  func() float64 { return 1.5 },
+		cores:    10,
+	}
+	s, err := r.Read(context.Background())
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if s.Resolved() {
+		t.Fatal("a 400ms window on a whole-second column was reported as a measurement")
+	}
+	if !strings.Contains(s.Unresolvable, "coarse-ps") || !strings.Contains(s.Unresolvable, "400ms") {
+		t.Errorf("the reason must name the source and the window, got %q", s.Unresolvable)
+	}
+	if s.Source != "coarse-ps" {
+		t.Errorf("Source = %q, want coarse-ps", s.Source)
+	}
+	// The context that is still true is still reported; the numbers that would
+	// be fabrications are not.
+	if s.Cores != 10 || s.LoadAvg1 != 1.5 {
+		t.Errorf("host context must survive an unresolvable sample: %+v", s)
+	}
+	if s.FleetCores != 0 || s.ExternalCores != 0 || s.Attributed {
+		t.Errorf("an unresolvable sample must not carry attribution numbers: %+v", s)
+	}
+	if !strings.Contains(s.String(), "unmeasurable") {
+		t.Errorf("an unresolvable sample must not render as a reading: %q", s.String())
+	}
+}
+
+// TestReadStampsTheSourceOnEverySample keeps the environment on the record.
+// This failure was undiagnosable from the CI log precisely because no sample
+// said where it came from.
+func TestReadStampsTheSourceOnEverySample(t *testing.T) {
+	snap, _ := snapshots([]proc{{pid: 100, ppid: 1, before: 0, at: 1}}, time.Second)
+	r := &Reader{Roots: []int{100}, Window: time.Millisecond, snapshot: snap,
+		loadavg: func() float64 { return 0 }, cores: 4}
+	s, err := r.Read(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Source == "" {
+		t.Error("a sample with no named source cannot be told from one taken with a broken instrument")
+	}
+	if !s.Resolved() {
+		t.Errorf("a 1s window must resolve on this host: %s", s.Unresolvable)
 	}
 }

--- a/internal/proctable/proctable.go
+++ b/internal/proctable/proctable.go
@@ -1,0 +1,337 @@
+// Package proctable reads the host's process table — pid, parent, process
+// group, and cumulative CPU time per process — and says how precise the CPU
+// column it just returned actually is.
+//
+// # Why the resolution is part of the answer
+//
+// Two callers difference this table across a short window to answer "is this
+// subtree doing work": internal/hostload for the fleet's share of the host, and
+// the refinery's gate watch for one gate's subtree. Both compute
+// CPU-seconds-per-wall-second, and both are only as good as the granularity of
+// the CPU column they differenced.
+//
+// That granularity is not the same everywhere, and the difference is not
+// cosmetic:
+//
+//   - BSD `ps` on darwin prints TIME as `MM:SS.ss` — hundredths, 10ms.
+//   - procps `ps` on Linux prints TIME as `[DD-]HH:MM:SS` — WHOLE SECONDS.
+//     There is no sub-second format option; `cputimes` is integer seconds too.
+//
+// So the identical code that measures a spinning subtree at 1.00 cores over a
+// 400ms window on darwin measures it at 0.00 on Linux, because 400ms of CPU
+// rounds to zero whole seconds at both ends of the window. That is exactly what
+// happened: mg-0c51's and mg-1b8c's tests were written and verified on darwin
+// and went red on every CI run from 11:17 on 2026-07-30, asserting against
+// cores=0.00 in a Linux runner (mg-79e3). Nothing was broken; the instrument
+// could not read the scale.
+//
+// This package fixes the instrument rather than the scale. On Linux it reads
+// /proc/<pid>/stat directly, whose utime+stime are in USER_HZ ticks — 10ms,
+// the same order as darwin's — so a short window resolves work on both. Where
+// no better source exists it still returns rows, but it reports the coarse
+// Resolution alongside, so a caller can say "this window is too short for this
+// host" instead of reporting a fabricated zero.
+//
+// # Supported environments
+//
+//	linux, /proc readable   linux-procfs   10ms   short windows resolve
+//	darwin                  darwin-ps      10ms   short windows resolve
+//	linux, no /proc         linux-ps        1s    needs a multi-second window
+//	other unix              <goos>-ps       1s    needs a multi-second window
+//
+// A caller that must measure over a window shorter than Source.MinWindow has
+// no measurement, and must say so — see Source.CannotResolve.
+package proctable
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Row is one process as the table reports it.
+type Row struct {
+	PID  int
+	PPID int
+	PGID int
+	// CPU is cumulative CPU time (user + system) consumed by the process
+	// since it started, truncated to the source's Resolution.
+	CPU time.Duration
+}
+
+// Source names where rows come from and how precise their CPU column is.
+type Source struct {
+	// Name identifies the reader, e.g. "linux-procfs". It is printed in test
+	// output and in gate records so that a run states the environment it
+	// measured in — this whole class of bug is invisible until it does.
+	Name string
+	// Resolution is the quantum of the CPU column: every Row.CPU is a whole
+	// multiple of it, so any difference of two readings carries up to one
+	// Resolution of error per process.
+	Resolution time.Duration
+}
+
+// minWindowTicks is how many Resolution ticks a window must span before a rate
+// taken over it means anything. Five bounds the quantisation error on a subtree
+// burning one full core at 20% — enough to separate "about a core" from
+// "nothing", which is the discrimination both callers exist to make.
+//
+// It is deliberately NOT enough to resolve the 0.02-core idle threshold; that
+// would need ~50 ticks. A window between MinWindow and that can say "this is
+// work" or "this is not a core's worth", and nothing finer.
+const minWindowTicks = 5
+
+// MinWindow is the shortest window over which this source can separate a
+// subtree burning a full core from an idle one.
+func (s Source) MinWindow() time.Duration { return minWindowTicks * s.Resolution }
+
+// CanResolve reports whether a rate taken over window is meaningful.
+func (s Source) CanResolve(window time.Duration) bool { return window >= s.MinWindow() }
+
+// CannotResolve returns the reason a window is too short for this source, or
+// "" when it is long enough. It returns a REASON rather than a bool because
+// the caller's job is to report "no measurement, and why" — a bool would let
+// it degrade back into the zero it cannot distinguish from idle.
+func (s Source) CannotResolve(window time.Duration) string {
+	if s.CanResolve(window) {
+		return ""
+	}
+	return fmt.Sprintf("%s resolves CPU time to %s, so a %s window cannot separate work from none "+
+		"(needs %s)", s.Name, s.Resolution, window, s.MinWindow())
+}
+
+// String renders the source and its precision together, because neither is
+// useful without the other.
+func (s Source) String() string {
+	return fmt.Sprintf("%s (%s CPU-time resolution, usable from a %s window)",
+		s.Name, s.Resolution, s.MinWindow())
+}
+
+// Source names.
+const (
+	linuxProcfs = "linux-procfs"
+	psSuffix    = "-ps"
+)
+
+const (
+	// procfsTick is the unit /proc/<pid>/stat reports CPU time in. Linux fixes
+	// USER_HZ at 100 for procfs output regardless of the kernel's internal
+	// CONFIG_HZ, so this is 10ms wherever the procfs source is selected.
+	procfsTick = 10 * time.Millisecond
+	// darwinPSTick is BSD ps's TIME precision: `MM:SS.ss`.
+	darwinPSTick = 10 * time.Millisecond
+	// psSecondTick is procps' TIME precision: whole seconds, no finer format
+	// available.
+	psSecondTick = time.Second
+)
+
+// procfsRoot is where the Linux process table lives. A variable so the reader
+// can be exercised against a fixture on a machine that has no /proc.
+var procfsRoot = "/proc"
+
+// current is resolved once: the answer cannot change while the process runs,
+// and every caller must agree on it or one of them will difference a table it
+// has the wrong precision for.
+var current = sync.OnceValue(detect)
+
+// Current returns the process-table source in force on this host.
+func Current() Source { return current() }
+
+func detect() Source {
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := os.Stat(filepath.Join(procfsRoot, "self", "stat")); err == nil {
+			return Source{Name: linuxProcfs, Resolution: procfsTick}
+		}
+		return Source{Name: "linux" + psSuffix, Resolution: psSecondTick}
+	case "darwin":
+		return Source{Name: "darwin" + psSuffix, Resolution: darwinPSTick}
+	default:
+		// Unknown ps dialect: assume the coarse one. Claiming more precision
+		// than a source has is the failure this package exists to prevent, so
+		// the unknown case errs toward "say you cannot measure".
+		return Source{Name: runtime.GOOS + psSuffix, Resolution: psSecondTick}
+	}
+}
+
+// Read snapshots every process on the host.
+func Read() ([]Row, error) {
+	if Current().Name == linuxProcfs {
+		return readProcfs(procfsRoot)
+	}
+	return readPS()
+}
+
+// readProcfs walks /proc. A process that exits between the directory listing
+// and the read of its stat file is skipped rather than failing the snapshot:
+// one departed process must not cost the whole measurement.
+func readProcfs(root string) ([]Row, error) {
+	dir, err := os.Open(root)
+	if err != nil {
+		return nil, fmt.Errorf("proctable: open %s: %w", root, err)
+	}
+	names, err := dir.Readdirnames(-1)
+	_ = dir.Close()
+	if err != nil {
+		return nil, fmt.Errorf("proctable: read %s: %w", root, err)
+	}
+	rows := make([]Row, 0, len(names))
+	for _, name := range names {
+		if pid, err := strconv.Atoi(name); err != nil || pid <= 0 {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(root, name, "stat"))
+		if err != nil {
+			continue
+		}
+		if row, ok := parseProcStat(string(b)); ok {
+			rows = append(rows, row)
+		}
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("proctable: %s held no readable process entries", root)
+	}
+	return rows, nil
+}
+
+// parseProcStat reads one /proc/<pid>/stat line.
+//
+// The command name is field 2 and is wrapped in parentheses that it may itself
+// contain — `(sh -c (x))` is a legal comm — so the fields after it are located
+// from the LAST ')' rather than by splitting the whole line. Everything after
+// that paren starts at field 3.
+func parseProcStat(s string) (Row, bool) {
+	open := strings.IndexByte(s, '(')
+	closing := strings.LastIndexByte(s, ')')
+	if open < 0 || closing < open {
+		return Row{}, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(s[:open]))
+	if err != nil || pid <= 0 {
+		return Row{}, false
+	}
+	f := strings.Fields(s[closing+1:])
+	// f[0] is field 3 (state), so field N sits at f[N-3]: ppid 4, pgrp 5,
+	// utime 14, stime 15.
+	const utimeIdx, stimeIdx = 14 - 3, 15 - 3
+	if len(f) <= stimeIdx {
+		return Row{}, false
+	}
+	ppid, err1 := strconv.Atoi(f[4-3])
+	pgid, err2 := strconv.Atoi(f[5-3])
+	utime, err3 := strconv.ParseInt(f[utimeIdx], 10, 64)
+	stime, err4 := strconv.ParseInt(f[stimeIdx], 10, 64)
+	if err1 != nil || err2 != nil || err3 != nil || err4 != nil {
+		return Row{}, false
+	}
+	if utime < 0 || stime < 0 {
+		return Row{}, false
+	}
+	return Row{
+		PID:  pid,
+		PPID: ppid,
+		PGID: pgid,
+		// utime+stime only: cutime/cstime are reaped children's time, charged
+		// to the parent at wait(), which would make a rate spike at reaping
+		// rather than when the work happened.
+		CPU: time.Duration(utime+stime) * procfsTick,
+	}, true
+}
+
+// ReadTimeout bounds a process-table read. Exported because a caller that
+// joins a sampler goroutine has to bound its own wait by it. These readings
+// are taken on hosts
+// that may be under heavy contention — which is exactly when someone is
+// looking — and an unbounded exec would let a sampler hang. A hung sampler
+// must degrade to "no measurement", which callers report honestly.
+const ReadTimeout = 10 * time.Second
+
+// execPS runs ps. A variable so a test can exercise the failure path without
+// arranging for a real ps to fail.
+var execPS = func(ctx context.Context) ([]byte, error) {
+	// -A is the POSIX spelling of "every process" and is accepted by both the
+	// BSD ps on darwin and procps on Linux; the trailing "=" on each field
+	// suppresses the header so the output is pure data.
+	return exec.CommandContext(ctx, "ps", "-Ao", "pid=,ppid=,pgid=,time=").Output()
+}
+
+func readPS() ([]Row, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), ReadTimeout)
+	defer cancel()
+	out, err := execPS(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("ps did not return within %s", ReadTimeout)
+		}
+		return nil, fmt.Errorf("ps: %w", err)
+	}
+	return ParsePS(string(out)), nil
+}
+
+// ParsePS turns `ps -Ao pid=,ppid=,pgid=,time=` output into rows, skipping
+// anything it cannot read rather than failing the whole sample: one malformed
+// line must not cost the measurement.
+func ParsePS(out string) []Row {
+	var rows []Row
+	for _, line := range strings.Split(out, "\n") {
+		f := strings.Fields(line)
+		if len(f) < 4 {
+			continue
+		}
+		pid, err1 := strconv.Atoi(f[0])
+		ppid, err2 := strconv.Atoi(f[1])
+		pgid, err3 := strconv.Atoi(f[2])
+		cpu, ok := ParseCPUTime(f[3])
+		if err1 != nil || err2 != nil || err3 != nil || !ok {
+			continue
+		}
+		rows = append(rows, Row{PID: pid, PPID: ppid, PGID: pgid, CPU: cpu})
+	}
+	return rows
+}
+
+// ParseCPUTime reads ps's cumulative TIME column: [[DD-]HH:]MM:SS[.ff].
+func ParseCPUTime(s string) (time.Duration, bool) {
+	days := 0
+	if i := strings.IndexByte(s, '-'); i >= 0 {
+		d, err := strconv.Atoi(s[:i])
+		if err != nil {
+			return 0, false
+		}
+		days = d
+		s = s[i+1:]
+	}
+	parts := strings.Split(s, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return 0, false
+	}
+	var hours, mins int
+	if len(parts) == 3 {
+		h, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return 0, false
+		}
+		hours = h
+	}
+	m, err := strconv.Atoi(parts[len(parts)-2])
+	if err != nil {
+		return 0, false
+	}
+	mins = m
+	secs, err := strconv.ParseFloat(parts[len(parts)-1], 64)
+	if err != nil {
+		return 0, false
+	}
+	total := float64(days)*86400 + float64(hours)*3600 + float64(mins)*60 + secs
+	if total < 0 {
+		return 0, false
+	}
+	return time.Duration(total * float64(time.Second)), true
+}

--- a/internal/proctable/proctable_test.go
+++ b/internal/proctable/proctable_test.go
@@ -1,0 +1,279 @@
+package proctable
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestParseCPUTime covers both dialects of the ps TIME column. The cases with a
+// fractional part are darwin's; the whole-second ones are procps'. Both parse,
+// and the fact that only one of them CARRIES sub-second information is what
+// Source.Resolution exists to say — a parser cannot recover precision the
+// column never had.
+func TestParseCPUTime(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+		ok   bool
+	}{
+		{"0:00.02", 20 * time.Millisecond, true},
+		{"0:01.25", 1250 * time.Millisecond, true},
+		{"1:30", 90 * time.Second, true},
+		{"168:35.92", 168*time.Minute + 35*time.Second + 920*time.Millisecond, true},
+		{"169:10.30", 169*time.Minute + 10300*time.Millisecond, true},
+		{"2:03:04", 2*time.Hour + 3*time.Minute + 4*time.Second, true},
+		{"12:34:56", 12*time.Hour + 34*time.Minute + 56*time.Second, true},
+		{"3-02:00:00", 74 * time.Hour, true},
+		{"2-03:04:05", 2*24*time.Hour + 3*time.Hour + 4*time.Minute + 5*time.Second, true},
+		{"", 0, false},
+		{"nope", 0, false},
+		{"garbage", 0, false},
+		{"1:2:3:4", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := ParseCPUTime(c.in)
+		if ok != c.ok {
+			t.Errorf("ParseCPUTime(%q) ok=%v, want %v", c.in, ok, c.ok)
+			continue
+		}
+		if ok && got != c.want {
+			t.Errorf("ParseCPUTime(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParsePSSkipsMalformedLines(t *testing.T) {
+	rows := ParsePS("  1 0 1 0:01.00\ngarbage\n  2 1 x 0:02.00\n  3 1 3 0:03.00\n")
+	if len(rows) != 2 {
+		t.Fatalf("ParsePS kept %d rows, want 2: %v", len(rows), rows)
+	}
+	if rows[0].PID != 1 || rows[1].PID != 3 {
+		t.Errorf("unexpected rows: %v", rows)
+	}
+	if rows[0].PPID != 0 || rows[0].PGID != 1 || rows[0].CPU != time.Second {
+		t.Errorf("row 0 misparsed: %+v", rows[0])
+	}
+}
+
+// TestParseProcStat is the Linux reader's unit test, and it runs everywhere —
+// deliberately. The bug this package fixes was a Linux-only behaviour that no
+// darwin run could see, and a parser that is only exercised on the platform it
+// targets repeats that shape one level down.
+func TestParseProcStat(t *testing.T) {
+	// A real-shaped line: pid 4242, 137 utime ticks + 63 stime ticks = 200
+	// ticks = 2s at 10ms per tick.
+	line := "4242 (sh) S 4200 4242 4242 0 -1 4194304 512 0 0 0 137 63 0 0 20 0 1 0 99 0 0\n"
+	row, ok := parseProcStat(line)
+	if !ok {
+		t.Fatalf("parseProcStat refused a well-formed line")
+	}
+	if row.PID != 4242 || row.PPID != 4200 || row.PGID != 4242 {
+		t.Errorf("identity misparsed: %+v", row)
+	}
+	if row.CPU != 2*time.Second {
+		t.Errorf("CPU = %v, want 2s (137+63 ticks at %v)", row.CPU, procfsTick)
+	}
+}
+
+// TestParseProcStatSurvivesAParenthesisedCommand guards the one field in
+// /proc/<pid>/stat that cannot be split on: comm is unescaped and may contain
+// spaces and parentheses, so a naive Fields() walk shifts every field after it
+// and silently reads someone else's number as CPU time.
+func TestParseProcStatSurvivesAParenthesisedCommand(t *testing.T) {
+	line := "77 (weird ) name (x)) R 5 77 77 0 -1 0 0 0 0 0 10 5 0 0 20 0 1 0 1 0 0\n"
+	row, ok := parseProcStat(line)
+	if !ok {
+		t.Fatalf("parseProcStat refused a legal parenthesised comm")
+	}
+	if row.PID != 77 || row.PPID != 5 || row.PGID != 77 {
+		t.Errorf("identity misparsed: %+v", row)
+	}
+	if row.CPU != 150*time.Millisecond {
+		t.Errorf("CPU = %v, want 150ms (10+5 ticks)", row.CPU)
+	}
+}
+
+func TestParseProcStatRejectsRubbish(t *testing.T) {
+	for _, s := range []string{"", "no parens here", "12 (sh) S 1", "x (sh) S 1 2 3 0 0 0 0 0 0 0 1 1"} {
+		if _, ok := parseProcStat(s); ok {
+			t.Errorf("parseProcStat accepted %q", s)
+		}
+	}
+}
+
+// TestReadProcfsWalksAFixtureTree exercises the directory walk on every
+// platform by pointing it at a fake /proc.
+func TestReadProcfsWalksAFixtureTree(t *testing.T) {
+	root := t.TempDir()
+	write := func(name, body string) {
+		t.Helper()
+		dir := filepath.Join(root, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if body != "" {
+			if err := os.WriteFile(filepath.Join(dir, "stat"), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	write("1", "1 (init) S 0 1 1 0 -1 0 0 0 0 0 100 0 0 0 20 0 1 0 1 0 0\n")
+	write("2", "2 (worker) R 1 1 1 0 -1 0 0 0 0 0 50 25 0 0 20 0 1 0 1 0 0\n")
+	// A process that exited between the listing and the read: no stat file.
+	write("3", "")
+	// Not a pid at all — /proc is full of these.
+	write("uptime-ish", "not a process")
+
+	rows, err := readProcfs(root)
+	if err != nil {
+		t.Fatalf("readProcfs: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("read %d rows, want 2 (the departed pid and the non-pid entry must be skipped): %+v", len(rows), rows)
+	}
+	byPID := map[int]Row{}
+	for _, r := range rows {
+		byPID[r.PID] = r
+	}
+	if byPID[1].CPU != time.Second {
+		t.Errorf("pid 1 CPU = %v, want 1s", byPID[1].CPU)
+	}
+	if byPID[2].CPU != 750*time.Millisecond {
+		t.Errorf("pid 2 CPU = %v, want 750ms (50+25 ticks)", byPID[2].CPU)
+	}
+}
+
+func TestReadProcfsRefusesAnEmptyTree(t *testing.T) {
+	// Zero readable processes is not an empty host, it is a broken read. It
+	// must surface as an error, because a caller that receives it as an empty
+	// table computes a rate of zero and reports an idle machine.
+	if _, err := readProcfs(t.TempDir()); err == nil {
+		t.Error("readProcfs accepted a tree with no process entries")
+	}
+	if _, err := readProcfs(filepath.Join(t.TempDir(), "absent")); err == nil {
+		t.Error("readProcfs accepted a missing root")
+	}
+}
+
+// TestSourceResolutionGovernsTheUsableWindow is the assertion the CI failure
+// turned on. A source whose CPU column is in whole seconds cannot answer a
+// sub-second window, and must say so rather than let a caller divide zero by
+// the window and call the result idle.
+func TestSourceResolutionGovernsTheUsableWindow(t *testing.T) {
+	coarse := Source{Name: "test-ps", Resolution: time.Second}
+	fine := Source{Name: "test-procfs", Resolution: 10 * time.Millisecond}
+
+	if coarse.CanResolve(400 * time.Millisecond) {
+		t.Error("a whole-second column must not claim to resolve a 400ms window")
+	}
+	if reason := coarse.CannotResolve(400 * time.Millisecond); reason == "" {
+		t.Error("an unresolvable window must come with a reason")
+	} else {
+		// The reason has to name all three numbers, or a reader cannot tell
+		// whether to widen the window or change host.
+		for _, want := range []string{"test-ps", "1s", "400ms", "5s"} {
+			if !strings.Contains(reason, want) {
+				t.Errorf("reason %q does not mention %q", reason, want)
+			}
+		}
+	}
+	if !coarse.CanResolve(5 * time.Second) {
+		t.Error("a whole-second column must resolve a 5s window")
+	}
+	if !fine.CanResolve(400 * time.Millisecond) {
+		t.Error("a 10ms column must resolve a 400ms window")
+	}
+	if reason := fine.CannotResolve(400 * time.Millisecond); reason != "" {
+		t.Errorf("a resolvable window must return no reason, got %q", reason)
+	}
+	if fine.CanResolve(10 * time.Millisecond) {
+		t.Error("even a 10ms column cannot resolve a single-tick window")
+	}
+}
+
+// TestCurrentSourceMatchesThisPlatform states, per platform, which reader is
+// expected and how precise it is. It is the test that would have caught the
+// original failure: nothing else in the tree asserted that a Linux run has a
+// usable resolution at all.
+func TestCurrentSourceMatchesThisPlatform(t *testing.T) {
+	src := Current()
+	t.Logf("process-table source on %s: %s", runtime.GOOS, src)
+	if src.Name == "" || src.Resolution <= 0 {
+		t.Fatalf("detect() returned an unusable source: %+v", src)
+	}
+	switch runtime.GOOS {
+	case "linux":
+		// Every Linux this project supports has procfs; if one does not, the
+		// fallback is honest but the gate/hostload windows will not resolve,
+		// and this is where that gets noticed.
+		if src.Name != linuxProcfs {
+			t.Errorf("on Linux the source must be %s, got %q — sub-second windows will not resolve",
+				linuxProcfs, src.Name)
+		}
+		if src.Resolution != procfsTick {
+			t.Errorf("procfs resolution = %v, want %v", src.Resolution, procfsTick)
+		}
+	case "darwin":
+		if src.Name != "darwin-ps" || src.Resolution != darwinPSTick {
+			t.Errorf("on darwin the source must be darwin-ps at %v, got %+v", darwinPSTick, src)
+		}
+	}
+	// Both supported platforms must resolve the windows their callers use: the
+	// refinery's compressed test heartbeat (400ms) and hostload's default (1s).
+	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		if !src.CanResolve(400 * time.Millisecond) {
+			t.Errorf("%s cannot resolve a 400ms window; the gate CPU signal is blind here", src)
+		}
+	}
+}
+
+// TestReadReadsTheRealProcessTable is the positive control on whichever reader
+// this platform selected. If the flags, the TIME format, or the procfs field
+// offsets are wrong here, every CPU reading in the tree silently degrades and
+// this is what notices.
+func TestReadReadsTheRealProcessTable(t *testing.T) {
+	rows, err := Read()
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if len(rows) < 10 {
+		t.Fatalf("read %d rows; the process table is not that small", len(rows))
+	}
+	self, found := os.Getpid(), false
+	var mine Row
+	for _, r := range rows {
+		if r.PID == self {
+			found, mine = true, r
+		}
+		if r.PID <= 0 || r.CPU < 0 {
+			t.Fatalf("nonsense row: %+v", r)
+		}
+	}
+	if !found {
+		t.Fatalf("the table did not contain this test process (pid %d)", self)
+	}
+	if mine.PPID <= 0 {
+		t.Errorf("this process reported ppid %d", mine.PPID)
+	}
+	// A Go test binary that has reached this line has run the scheduler, the
+	// GC and a directory walk. Zero CPU time for it means the CPU column is
+	// not being read at all.
+	if mine.CPU <= 0 {
+		t.Errorf("this process reported %v of CPU time; the CPU column is not being read", mine.CPU)
+	}
+}
+
+func TestReadPSSurfacesAFailure(t *testing.T) {
+	prev := execPS
+	execPS = func(context.Context) ([]byte, error) { return nil, errors.New("boom") }
+	t.Cleanup(func() { execPS = prev })
+	if _, err := readPS(); err == nil {
+		t.Fatal("readPS swallowed an exec failure")
+	}
+}

--- a/internal/proctable/proctable_test.go
+++ b/internal/proctable/proctable_test.go
@@ -261,11 +261,39 @@ func TestReadReadsTheRealProcessTable(t *testing.T) {
 	if mine.PPID <= 0 {
 		t.Errorf("this process reported ppid %d", mine.PPID)
 	}
-	// A Go test binary that has reached this line has run the scheduler, the
-	// GC and a directory walk. Zero CPU time for it means the CPU column is
-	// not being read at all.
-	if mine.CPU <= 0 {
-		t.Errorf("this process reported %v of CPU time; the CPU column is not being read", mine.CPU)
+
+	// The column has to ADVANCE, not merely be present. A cumulative CPU
+	// figure that never moves is indistinguishable from one that is not being
+	// read at all, and "not being read" is exactly the failure this package
+	// exists to prevent. So burn a known amount of CPU and require the reading
+	// to change — which is also the only operation the callers ever perform on
+	// this column.
+	//
+	// Asserting a non-zero absolute value instead would be wrong: this suite
+	// runs in a few milliseconds, so a freshly started test binary can hold
+	// genuinely zero whole ticks of CPU on a 10ms-resolution source.
+	src := Current()
+	spin(2 * src.MinWindow())
+	after, err := Read()
+	if err != nil {
+		t.Fatalf("second Read: %v", err)
+	}
+	var mineAfter Row
+	for _, r := range after {
+		if r.PID == self {
+			mineAfter = r
+		}
+	}
+	if mineAfter.CPU <= mine.CPU {
+		t.Errorf("this process burned CPU for %s and its cumulative CPU column went %v -> %v; "+
+			"%s is not reporting work", 2*src.MinWindow(), mine.CPU, mineAfter.CPU, src)
+	}
+}
+
+// spin burns CPU in this process for d.
+func spin(d time.Duration) {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
 	}
 }
 

--- a/internal/proctable/testmain_test.go
+++ b/internal/proctable/testmain_test.go
@@ -1,0 +1,32 @@
+package proctable
+
+import (
+	"os"
+	"testing"
+
+	"github.com/drellem2/pogo/internal/testsandbox"
+)
+
+// sandbox is the package's private, CHECKED envelope, established by TestMain
+// before a single test runs. See internal/testsandbox.
+//
+// This package reads the HOST — /proc and `ps` — and touches no pogo state at
+// all. The isolation is adopted anyway, for the reason internal/hostload gives:
+// "this suite does not need it" is the claim every unisolated suite could make
+// until one of them turned out to be wrong.
+var sandbox *testsandbox.Sandbox
+
+func TestMain(m *testing.M) {
+	sb, down := testsandbox.Main("proctable")
+	sandbox = sb
+
+	code := m.Run()
+
+	down()
+	os.Exit(code)
+}
+
+// TestSandboxIsInForce is the positive control for the isolation above.
+func TestSandboxIsInForce(t *testing.T) {
+	testsandbox.Verify(t, sandbox)
+}

--- a/internal/refinery/gateprogress.go
+++ b/internal/refinery/gateprogress.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/drellem2/pogo/internal/hostload"
+	"github.com/drellem2/pogo/internal/proctable"
 )
 
 // gateHeartbeatInterval is the bounded interval on which a running quality
@@ -121,6 +122,13 @@ type StepProgress struct {
 	// CPUUnavailable states why no measurement exists, so "could not measure"
 	// is never rendered as "measured, and idle".
 	CPUUnavailable string `json:"cpu_unavailable,omitempty"`
+	// CPUSource names the process-table source the numbers came from and the
+	// precision of its CPU column. Recorded because whether this measurement
+	// works at all is a property of the host: the same gate reads 1.00 cores
+	// where the column is in hundredths and 0.00 where it is in whole seconds,
+	// and a record that does not name its instrument cannot be told apart from
+	// one taken with a broken one (mg-79e3).
+	CPUSource string `json:"cpu_source,omitempty"`
 }
 
 // SubtreeState is what the CPU measurement says about the gate's processes.
@@ -590,6 +598,16 @@ func (w *gateWatch) sampleCPU(now time.Time) {
 		w.publishCPU(cur, cpuReading{Unavailable: fmt.Sprintf("first sample of two (a rate needs two, %s apart)", w.interval)})
 		return
 	}
+	// A window shorter than the host's CPU-time resolution can support does
+	// not yield a small number — it yields zero, for a spinning subtree and a
+	// sleeping one alike. Publishing that zero would make the signal report
+	// "idle" on every gate on such a host, which is the one answer it must
+	// never invent. Keep cur as the baseline so a later, wider window can
+	// still produce a rate.
+	if reason := procSource.CannotResolve(activity.Window); reason != "" {
+		w.publishCPU(cur, cpuReading{Unavailable: reason})
+		return
+	}
 	w.publishCPU(cur, cpuReading{At: now, Activity: activity})
 }
 
@@ -757,6 +775,7 @@ func (w *gateWatch) snapshot(now time.Time, final bool) *StepProgress {
 // record. Called with the refinery lock held (or on a detached record).
 func (w *gateWatch) applyCPU(p *StepProgress) {
 	p.GatePID = int(w.pid.Load())
+	p.CPUSource = procSource.Name
 	w.cpuMu.Lock()
 	c := w.cpu
 	w.cpuMu.Unlock()
@@ -809,12 +828,12 @@ func (w *gateWatch) finish() {
 	// whole record exists to provide.
 	select {
 	case <-w.cpuDone:
-	case <-time.After(psTimeout + time.Second):
+	case <-time.After(proctable.ReadTimeout + time.Second):
 	}
 	close(w.loadStop)
 	select {
 	case <-w.loadDone:
-	case <-time.After(psTimeout + time.Second):
+	case <-time.After(proctable.ReadTimeout + time.Second):
 	}
 	w.snapshot(time.Now(), true)
 }

--- a/internal/refinery/queueview_test.go
+++ b/internal/refinery/queueview_test.go
@@ -310,6 +310,20 @@ func TestGateWatchMeasuresARealSubtreesCPU(t *testing.T) {
 		t.Errorf("a spinning gate peaked at %.2f cores across %d settled readings; "+
 			"the subtree walk is not finding the work", busyPeak, len(busy))
 	}
+	// And an upper bound, because the rate has to be RIGHT and not merely
+	// non-zero. This gate holds exactly one spinner, so ~1.0 cores is the
+	// physical answer and anything near twice that is the instrument, not the
+	// work — a CPU column too coarse for the window reports nothing for
+	// several windows and then a whole tick at once, which reads as a
+	// multi-core burst. Without this bound the test is blind to precision loss
+	// in the direction that inflates, and precision loss is what put it in CI
+	// (mg-79e3).
+	const oneSpinnerCeiling = 2.0
+	if busyPeak > oneSpinnerCeiling {
+		t.Errorf("a gate holding ONE spinner peaked at %.2f cores over %s windows; "+
+			"%s is over-reporting, most likely quantising work into bursts",
+			busyPeak, heartbeat, procSource)
+	}
 	sawBusy := false
 	for _, p := range busy {
 		if p.Subtree() == SubtreeBusy {

--- a/internal/refinery/queueview_test.go
+++ b/internal/refinery/queueview_test.go
@@ -163,12 +163,23 @@ func TestDequeueStampsStartTime(t *testing.T) {
 
 // TestGateWatchMeasuresARealSubtreesCPU is the end-to-end positive control for
 // the signal the CLI now prints. It runs two real gates through the real
-// runner — one that computes, one that sleeps — and asserts the persisted
-// record separates them.
+// runner — one that computes, one that sleeps — and asserts the records
+// separate them.
 //
 // Both arms are required. A measurement that only ever reports "busy" is the
 // defect described in mg-1b8c's lineage: a view that always reads healthy
 // cannot report the state it exists to report.
+//
+// # It reads the record WHILE the gate runs, and that is not incidental
+//
+// The signal exists for a live gate: a coordinator polling `pogo refinery
+// queue` mid-merge, asking whether the thing it is waiting on is computing or
+// stopped. The SEALED record of a finished gate honestly reports
+// `SubtreeGone`, because by then the process is gone — so whether an assertion
+// on the sealed record saw a live subtree came down to whether the last
+// heartbeat landed before or after the gate exited. On darwin it did; on Linux
+// it did not, and the CI log showed `cores=0.00 procs=0 churn=3` — an empty
+// subtree, classified gone, read as a failure of the measurement (mg-79e3).
 //
 // # Which environments this runs in
 //
@@ -177,14 +188,11 @@ func TestDequeueStampsStartTime(t *testing.T) {
 // readable /proc, whole seconds where only procps `ps` is available. At a
 // 400ms heartbeat the last of those cannot separate a spinning gate from a
 // sleeping one, and every assertion below would be made against a quantised
-// zero. That is exactly what happened to this test in CI from 11:17 on
-// 2026-07-30 (mg-79e3).
-//
-// So the environment is checked FIRST and named in the output. Where the
+// zero. So the environment is checked FIRST and named in the output. Where the
 // measurement is supported the full discrimination is asserted, unweakened.
-// Where it is not, the record must carry the reason — which is itself asserted
-// — and the numeric arms are skipped rather than lowered, because a number
-// this host cannot produce is not a number to assert on.
+// Where it is not, the records must carry the reason — which is itself
+// asserted — and the numeric arms are skipped rather than lowered, because a
+// number this host cannot produce is not a number to assert on.
 func TestGateWatchMeasuresARealSubtreesCPU(t *testing.T) {
 	if testing.Short() {
 		t.Skip("runs real gates for a couple of seconds")
@@ -194,20 +202,68 @@ func TestGateWatchMeasuresARealSubtreesCPU(t *testing.T) {
 	t.Logf("process-table source: %s; gate heartbeat %s", procSource, heartbeat)
 	supported := procSource.CanResolve(heartbeat)
 
-	run := func(gate string) *StepProgress {
+	// run executes a gate and returns every progress record the refinery
+	// published while it was still running.
+	run := func(gate string) []StepProgress {
 		t.Helper()
 		r := newProgressTestRefinery(t, heartbeat)
 		wtDir := t.TempDir()
 		writeGateConfig(t, wtDir, "quality_gate = "+quoteTOML(gate))
 		mr := &MergeRequest{ID: "mr-cpu", Status: StatusProcessing}
 		r.byID[mr.ID] = mr
-		if _, _, err := r.runQualityGates(context.Background(), wtDir, wtDir, mr); err != nil {
-			t.Fatalf("gate %q should have passed: %v", gate, err)
+
+		done := make(chan error, 1)
+		go func() {
+			_, _, err := r.runQualityGates(context.Background(), wtDir, wtDir, mr)
+			done <- err
+		}()
+
+		var seen []StepProgress
+		poll := time.NewTicker(heartbeat / 4)
+		defer poll.Stop()
+		for {
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("gate %q should have passed: %v", gate, err)
+				}
+				if len(seen) == 0 {
+					t.Fatalf("gate %q published no record while it ran", gate)
+				}
+				return seen
+			case <-poll.C:
+				r.mu.Lock()
+				if mr.Progress != nil && mr.Progress.EndTime.IsZero() {
+					seen = append(seen, *mr.Progress)
+				}
+				r.mu.Unlock()
+			}
 		}
-		if mr.Progress == nil {
-			t.Fatalf("gate %q left no progress record", gate)
+	}
+
+	// settled keeps the readings taken over a window in which the subtree
+	// neither gained nor lost a process. Churn counts as work by design — a
+	// gate forking short-lived workers IS working — so the startup and
+	// teardown windows say "busy" for both arms and can discriminate nothing.
+	// Excluding them is what forces each arm to prove itself on the CPU path,
+	// which is the path that was blind.
+	settled := func(rs []StepProgress) []StepProgress {
+		var out []StepProgress
+		for _, p := range rs {
+			if !p.CPUSampledAt.IsZero() && p.CPUProcs > 0 && p.CPUChurn == 0 {
+				out = append(out, p)
+			}
 		}
-		return mr.Progress
+		return out
+	}
+	peak := func(rs []StepProgress) float64 {
+		hi := 0.0
+		for _, p := range rs {
+			if p.CPUCores > hi {
+				hi = p.CPUCores
+			}
+		}
+		return hi
 	}
 
 	// A gate whose real work happens in a DESCENDANT: `sh -c` forks for a
@@ -215,14 +271,18 @@ func TestGateWatchMeasuresARealSubtreesCPU(t *testing.T) {
 	// uses shell builtins only, so the work shows up as CPU time rather than
 	// as process churn — this arm has to prove the CPU path, not the churn
 	// fallback.
-	busy := run(`(while :; do :; done) & spinner=$!; sleep 2; kill $spinner; exit 0`)
-	t.Logf("busy gate: pid=%d source=%s cores=%.2f procs=%d churn=%d window=%s unavailable=%q",
-		busy.GatePID, busy.CPUSource, busy.CPUCores, busy.CPUProcs, busy.CPUChurn, busy.CPUWindow, busy.CPUUnavailable)
-	if busy.GatePID == 0 {
+	busyRecords := run(`(while :; do :; done) & spinner=$!; sleep 2; kill $spinner; exit 0`)
+	last := busyRecords[len(busyRecords)-1]
+	t.Logf("busy gate: pid=%d source=%s readings=%d", last.GatePID, last.CPUSource, len(busyRecords))
+	for _, p := range busyRecords {
+		t.Logf("  busy: cores=%.2f procs=%d churn=%d window=%s unavailable=%q",
+			p.CPUCores, p.CPUProcs, p.CPUChurn, p.CPUWindow, p.CPUUnavailable)
+	}
+	if last.GatePID == 0 {
 		t.Error("the gate's pid must be recorded — without it there is no subtree to measure")
 	}
-	if busy.CPUSource != procSource.Name {
-		t.Errorf("the record must name its instrument, got %q want %q", busy.CPUSource, procSource.Name)
+	if last.CPUSource != procSource.Name {
+		t.Errorf("the record must name its instrument, got %q want %q", last.CPUSource, procSource.Name)
 	}
 
 	if !supported {
@@ -230,43 +290,58 @@ func TestGateWatchMeasuresARealSubtreesCPU(t *testing.T) {
 		// cannot measure must produce UNKNOWN with a stated reason; if it
 		// produced a number here, the number would be the quantised zero this
 		// whole change exists to stop being reported as idle.
-		if busy.Subtree() != SubtreeUnknown {
+		if last.Subtree() != SubtreeUnknown {
 			t.Errorf("%s cannot resolve a %s window, so the record must be UNKNOWN, got %v (cores=%.2f)",
-				procSource, heartbeat, busy.Subtree(), busy.CPUCores)
+				procSource, heartbeat, last.Subtree(), last.CPUCores)
 		}
-		if !strings.Contains(busy.CPUUnavailable, procSource.Name) {
-			t.Errorf("an unmeasurable environment must name itself in the reason, got %q", busy.CPUUnavailable)
+		if !strings.Contains(last.CPUUnavailable, procSource.Name) {
+			t.Errorf("an unmeasurable environment must name itself in the reason, got %q", last.CPUUnavailable)
 		}
-		t.Skipf("subtree CPU is not measurable here: %s", busy.CPUUnavailable)
+		t.Skipf("subtree CPU is not measurable here: %s", last.CPUUnavailable)
 	}
 
-	if busy.CPUSampledAt.IsZero() {
-		t.Fatalf("a 2s gate at a %s heartbeat must produce a CPU measurement on %s, got unavailable=%q",
-			heartbeat, procSource, busy.CPUUnavailable)
+	busy := settled(busyRecords)
+	if len(busy) == 0 {
+		t.Fatalf("a 2s gate at a %s heartbeat produced no settled measurement on %s (last unavailable=%q)",
+			heartbeat, procSource, last.CPUUnavailable)
 	}
-	if busy.CPUCores < 0.5 {
-		t.Errorf("a spinning gate measured %.2f cores; the subtree walk is not finding the work", busy.CPUCores)
+	busyPeak := peak(busy)
+	if busyPeak < 0.5 {
+		t.Errorf("a spinning gate peaked at %.2f cores across %d settled readings; "+
+			"the subtree walk is not finding the work", busyPeak, len(busy))
 	}
-	if busy.Subtree() != SubtreeBusy {
-		t.Errorf("a spinning gate must classify as busy, got %v", busy.Subtree())
+	sawBusy := false
+	for _, p := range busy {
+		if p.Subtree() == SubtreeBusy {
+			sawBusy = true
+		}
+	}
+	if !sawBusy {
+		t.Errorf("a spinning gate must classify as busy in at least one of its %d settled readings", len(busy))
 	}
 
 	// The negative arm. A sleeping gate consumes nothing, and the record must
-	// be willing to say so.
-	idle := run(`sleep 2`)
-	t.Logf("idle gate: pid=%d source=%s cores=%.2f procs=%d churn=%d window=%s unavailable=%q",
-		idle.GatePID, idle.CPUSource, idle.CPUCores, idle.CPUProcs, idle.CPUChurn, idle.CPUWindow, idle.CPUUnavailable)
-	if idle.CPUSampledAt.IsZero() {
-		t.Fatalf("a 2s gate at a %s heartbeat must produce a CPU measurement on %s, got unavailable=%q",
-			heartbeat, procSource, idle.CPUUnavailable)
+	// be willing to say so — on EVERY settled reading, not merely one, because
+	// a measurement that reports busy unconditionally would still satisfy an
+	// "at least one" test.
+	idleRecords := run(`sleep 2`)
+	for _, p := range idleRecords {
+		t.Logf("  idle: cores=%.2f procs=%d churn=%d window=%s unavailable=%q",
+			p.CPUCores, p.CPUProcs, p.CPUChurn, p.CPUWindow, p.CPUUnavailable)
 	}
-	if idle.Subtree() != SubtreeIdle {
-		t.Errorf("a sleeping gate must classify as idle (cores=%.2f churn=%d) — the measurement is "+
-			"reporting busy unconditionally", idle.CPUCores, idle.CPUChurn)
+	idle := settled(idleRecords)
+	if len(idle) == 0 {
+		t.Fatalf("a 2s sleeping gate at a %s heartbeat produced no settled measurement on %s", heartbeat, procSource)
 	}
-	if busy.CPUCores <= idle.CPUCores {
+	for _, p := range idle {
+		if p.Subtree() != SubtreeIdle {
+			t.Errorf("a sleeping gate must classify as idle (cores=%.2f churn=%d procs=%d) — the "+
+				"measurement is reporting busy unconditionally", p.CPUCores, p.CPUChurn, p.CPUProcs)
+		}
+	}
+	if idlePeak := peak(idle); busyPeak <= idlePeak {
 		t.Errorf("a computing gate (%.2f cores) must measure higher than a sleeping one (%.2f cores)",
-			busy.CPUCores, idle.CPUCores)
+			busyPeak, idlePeak)
 	}
 }
 

--- a/internal/refinery/queueview_test.go
+++ b/internal/refinery/queueview_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/drellem2/pogo/internal/proctable"
 )
 
 // TestQueueWithProcessingIncludesTheInFlightRequest is the omission mg-0c51 was
@@ -167,14 +169,34 @@ func TestDequeueStampsStartTime(t *testing.T) {
 // Both arms are required. A measurement that only ever reports "busy" is the
 // defect described in mg-1b8c's lineage: a view that always reads healthy
 // cannot report the state it exists to report.
+//
+// # Which environments this runs in
+//
+// The measurement differences the host's CPU-time column, so it is only as
+// good as that column's precision — 10ms on darwin and on any Linux with a
+// readable /proc, whole seconds where only procps `ps` is available. At a
+// 400ms heartbeat the last of those cannot separate a spinning gate from a
+// sleeping one, and every assertion below would be made against a quantised
+// zero. That is exactly what happened to this test in CI from 11:17 on
+// 2026-07-30 (mg-79e3).
+//
+// So the environment is checked FIRST and named in the output. Where the
+// measurement is supported the full discrimination is asserted, unweakened.
+// Where it is not, the record must carry the reason — which is itself asserted
+// — and the numeric arms are skipped rather than lowered, because a number
+// this host cannot produce is not a number to assert on.
 func TestGateWatchMeasuresARealSubtreesCPU(t *testing.T) {
 	if testing.Short() {
 		t.Skip("runs real gates for a couple of seconds")
 	}
 
+	const heartbeat = 400 * time.Millisecond
+	t.Logf("process-table source: %s; gate heartbeat %s", procSource, heartbeat)
+	supported := procSource.CanResolve(heartbeat)
+
 	run := func(gate string) *StepProgress {
 		t.Helper()
-		r := newProgressTestRefinery(t, 400*time.Millisecond)
+		r := newProgressTestRefinery(t, heartbeat)
 		wtDir := t.TempDir()
 		writeGateConfig(t, wtDir, "quality_gate = "+quoteTOML(gate))
 		mr := &MergeRequest{ID: "mr-cpu", Status: StatusProcessing}
@@ -194,14 +216,33 @@ func TestGateWatchMeasuresARealSubtreesCPU(t *testing.T) {
 	// as process churn — this arm has to prove the CPU path, not the churn
 	// fallback.
 	busy := run(`(while :; do :; done) & spinner=$!; sleep 2; kill $spinner; exit 0`)
-	t.Logf("busy gate: pid=%d cores=%.2f procs=%d churn=%d window=%s unavailable=%q",
-		busy.GatePID, busy.CPUCores, busy.CPUProcs, busy.CPUChurn, busy.CPUWindow, busy.CPUUnavailable)
+	t.Logf("busy gate: pid=%d source=%s cores=%.2f procs=%d churn=%d window=%s unavailable=%q",
+		busy.GatePID, busy.CPUSource, busy.CPUCores, busy.CPUProcs, busy.CPUChurn, busy.CPUWindow, busy.CPUUnavailable)
 	if busy.GatePID == 0 {
 		t.Error("the gate's pid must be recorded — without it there is no subtree to measure")
 	}
+	if busy.CPUSource != procSource.Name {
+		t.Errorf("the record must name its instrument, got %q want %q", busy.CPUSource, procSource.Name)
+	}
+
+	if !supported {
+		// The unsupported path is asserted, not waved through. A host that
+		// cannot measure must produce UNKNOWN with a stated reason; if it
+		// produced a number here, the number would be the quantised zero this
+		// whole change exists to stop being reported as idle.
+		if busy.Subtree() != SubtreeUnknown {
+			t.Errorf("%s cannot resolve a %s window, so the record must be UNKNOWN, got %v (cores=%.2f)",
+				procSource, heartbeat, busy.Subtree(), busy.CPUCores)
+		}
+		if !strings.Contains(busy.CPUUnavailable, procSource.Name) {
+			t.Errorf("an unmeasurable environment must name itself in the reason, got %q", busy.CPUUnavailable)
+		}
+		t.Skipf("subtree CPU is not measurable here: %s", busy.CPUUnavailable)
+	}
+
 	if busy.CPUSampledAt.IsZero() {
-		t.Fatalf("a 2s gate at a 400ms heartbeat must produce a CPU measurement, got unavailable=%q",
-			busy.CPUUnavailable)
+		t.Fatalf("a 2s gate at a %s heartbeat must produce a CPU measurement on %s, got unavailable=%q",
+			heartbeat, procSource, busy.CPUUnavailable)
 	}
 	if busy.CPUCores < 0.5 {
 		t.Errorf("a spinning gate measured %.2f cores; the subtree walk is not finding the work", busy.CPUCores)
@@ -213,11 +254,11 @@ func TestGateWatchMeasuresARealSubtreesCPU(t *testing.T) {
 	// The negative arm. A sleeping gate consumes nothing, and the record must
 	// be willing to say so.
 	idle := run(`sleep 2`)
-	t.Logf("idle gate: pid=%d cores=%.2f procs=%d churn=%d window=%s unavailable=%q",
-		idle.GatePID, idle.CPUCores, idle.CPUProcs, idle.CPUChurn, idle.CPUWindow, idle.CPUUnavailable)
+	t.Logf("idle gate: pid=%d source=%s cores=%.2f procs=%d churn=%d window=%s unavailable=%q",
+		idle.GatePID, idle.CPUSource, idle.CPUCores, idle.CPUProcs, idle.CPUChurn, idle.CPUWindow, idle.CPUUnavailable)
 	if idle.CPUSampledAt.IsZero() {
-		t.Fatalf("a 2s gate at a 400ms heartbeat must produce a CPU measurement, got unavailable=%q",
-			idle.CPUUnavailable)
+		t.Fatalf("a 2s gate at a %s heartbeat must produce a CPU measurement on %s, got unavailable=%q",
+			heartbeat, procSource, idle.CPUUnavailable)
 	}
 	if idle.Subtree() != SubtreeIdle {
 		t.Errorf("a sleeping gate must classify as idle (cores=%.2f churn=%d) — the measurement is "+
@@ -226,6 +267,51 @@ func TestGateWatchMeasuresARealSubtreesCPU(t *testing.T) {
 	if busy.CPUCores <= idle.CPUCores {
 		t.Errorf("a computing gate (%.2f cores) must measure higher than a sleeping one (%.2f cores)",
 			busy.CPUCores, idle.CPUCores)
+	}
+}
+
+// TestGateWatchRefusesToMeasureBelowTheHostsResolution runs the unsupported
+// path EVERYWHERE, by standing in a coarse process-table source. It is the
+// half that the skip above cannot cover on a machine where the measurement
+// works, and it pins the distinction the whole signal rests on: a window the
+// host cannot resolve must yield "no measurement, and here is why", never the
+// 0.00 cores that renders as a quiet, healthy-looking idle gate.
+func TestGateWatchRefusesToMeasureBelowTheHostsResolution(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real gate")
+	}
+	prev := procSource
+	procSource = proctable.Source{Name: "coarse-ps", Resolution: time.Second}
+	t.Cleanup(func() { procSource = prev })
+
+	r := newProgressTestRefinery(t, 200*time.Millisecond)
+	wtDir := t.TempDir()
+	writeGateConfig(t, wtDir, `quality_gate = `+quoteTOML(`(while :; do :; done) & spinner=$!; sleep 1; kill $spinner; exit 0`))
+	mr := &MergeRequest{ID: "mr-coarse", Status: StatusProcessing}
+	r.byID[mr.ID] = mr
+	if _, _, err := r.runQualityGates(context.Background(), wtDir, wtDir, mr); err != nil {
+		t.Fatalf("gate should have passed: %v", err)
+	}
+	p := mr.Progress
+	t.Logf("coarse-source gate: cores=%.2f unavailable=%q summary=%q", p.CPUCores, p.CPUUnavailable, p.CPUSummary())
+
+	if p.Subtree() != SubtreeUnknown {
+		t.Errorf("a 200ms window on a whole-second CPU column must classify as unknown, got %v (cores=%.2f)",
+			p.Subtree(), p.CPUCores)
+	}
+	if p.CPUCores != 0 || !p.CPUSampledAt.IsZero() {
+		t.Errorf("an unmeasurable window must carry no numbers, got cores=%.2f sampled=%v", p.CPUCores, p.CPUSampledAt)
+	}
+	for _, want := range []string{"coarse-ps", "1s", "5s"} {
+		if !strings.Contains(p.CPUUnavailable, want) {
+			t.Errorf("the reason must mention %q so a reader can act on it, got %q", want, p.CPUUnavailable)
+		}
+	}
+	if strings.Contains(p.CPUSummary(), "idle") {
+		t.Errorf("an unmeasurable subtree must never render as idle: %q", p.CPUSummary())
+	}
+	if p.CPUSource != "coarse-ps" {
+		t.Errorf("CPUSource = %q, want coarse-ps", p.CPUSource)
 	}
 }
 

--- a/internal/refinery/subtreecpu.go
+++ b/internal/refinery/subtreecpu.go
@@ -1,12 +1,10 @@
 package refinery
 
 import (
-	"context"
 	"fmt"
-	"os/exec"
-	"strconv"
-	"strings"
 	"time"
+
+	"github.com/drellem2/pogo/internal/proctable"
 )
 
 // This file measures the OTHER half of gate liveness: whether the gate's
@@ -55,6 +53,19 @@ import (
 //     asymmetry is deliberate.
 //   - No sample => say so. An unmeasurable subtree must not be reported as an
 //     idle one.
+//
+// # Where this can be measured, and what happens where it cannot
+//
+// The rate is only as good as the precision of the CPU column it differences,
+// and that is a property of the HOST, not of this code. internal/proctable
+// picks the most precise source available and reports its resolution;
+// procSource below is that answer. On darwin and on any Linux with a readable
+// /proc the resolution is 10ms, so the heartbeat cadence resolves work
+// comfortably. Where only procps `ps` is available the column is whole seconds
+// and a sub-second window cannot separate a spinning subtree from a sleeping
+// one — so the sampler publishes the reason instead of the 0.00 it would
+// otherwise compute. That zero, reported as a measurement, is precisely how
+// this signal went silently blind in CI (mg-79e3).
 
 // subtreeIdleCores is the rate below which a subtree is called idle. A window
 // of one heartbeat interval at 0.02 cores is ~0.6 CPU-seconds — comfortably
@@ -70,90 +81,23 @@ type procRow struct {
 	CPU  time.Duration // cumulative CPU time consumed by this process
 }
 
-// psTimeout bounds the process-table read. The gate this measures runs on a
-// host that may be under heavy contention — that is precisely when a refinery
-// gets looked at — and an unbounded exec would let the sampler hang. A hung
-// sampler must degrade to "no measurement", which the record reports honestly,
-// rather than stall anything.
-const psTimeout = 10 * time.Second
+// procSource is the process-table source in force, and — the part that
+// matters — the precision of its CPU column. A var so a test can stand in a
+// coarse source and check that the sampler reports "cannot measure here"
+// rather than a fabricated zero.
+var procSource = proctable.Current()
 
 // psSnapshot reads the process table. Replaced in tests.
 var psSnapshot = func() ([]procRow, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), psTimeout)
-	defer cancel()
-	// -A is the POSIX spelling of "every process" and is accepted by both the
-	// BSD ps on darwin and procps on Linux; the trailing "=" on each field
-	// suppresses the header so the output is pure data.
-	out, err := exec.CommandContext(ctx, "ps", "-Ao", "pid=,ppid=,pgid=,time=").Output()
+	rows, err := proctable.Read()
 	if err != nil {
-		if ctx.Err() != nil {
-			return nil, fmt.Errorf("ps did not return within %s", psTimeout)
-		}
-		return nil, fmt.Errorf("ps: %w", err)
+		return nil, err
 	}
-	return parsePS(string(out)), nil
-}
-
-// parsePS turns `ps -Ao pid=,ppid=,pgid=,time=` output into rows, skipping
-// anything it cannot read rather than failing the whole sample: one malformed
-// line must not cost the measurement.
-func parsePS(out string) []procRow {
-	var rows []procRow
-	for _, line := range strings.Split(out, "\n") {
-		f := strings.Fields(line)
-		if len(f) < 4 {
-			continue
-		}
-		pid, err1 := strconv.Atoi(f[0])
-		ppid, err2 := strconv.Atoi(f[1])
-		pgid, err3 := strconv.Atoi(f[2])
-		cpu, ok := parseCPUTime(f[3])
-		if err1 != nil || err2 != nil || err3 != nil || !ok {
-			continue
-		}
-		rows = append(rows, procRow{PID: pid, PPID: ppid, PGID: pgid, CPU: cpu})
+	out := make([]procRow, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, procRow{PID: r.PID, PPID: r.PPID, PGID: r.PGID, CPU: r.CPU})
 	}
-	return rows
-}
-
-// parseCPUTime reads the ps TIME column: [[DD-]HH:]MM:SS[.ff].
-func parseCPUTime(s string) (time.Duration, bool) {
-	days := 0
-	if i := strings.Index(s, "-"); i >= 0 {
-		d, err := strconv.Atoi(s[:i])
-		if err != nil {
-			return 0, false
-		}
-		days = d
-		s = s[i+1:]
-	}
-	parts := strings.Split(s, ":")
-	if len(parts) < 2 || len(parts) > 3 {
-		return 0, false
-	}
-	var hours, mins int
-	secs := parts[len(parts)-1]
-	if len(parts) == 3 {
-		h, err := strconv.Atoi(parts[0])
-		if err != nil {
-			return 0, false
-		}
-		hours = h
-	}
-	m, err := strconv.Atoi(parts[len(parts)-2])
-	if err != nil {
-		return 0, false
-	}
-	mins = m
-	sec, err := strconv.ParseFloat(secs, 64)
-	if err != nil {
-		return 0, false
-	}
-	total := float64(days)*86400 + float64(hours)*3600 + float64(mins)*60 + sec
-	if total < 0 {
-		return 0, false
-	}
-	return time.Duration(total * float64(time.Second)), true
+	return out, nil
 }
 
 // subtreeSample is one reading of the CPU consumed by a gate's process

--- a/internal/refinery/subtreecpu_test.go
+++ b/internal/refinery/subtreecpu_test.go
@@ -2,40 +2,12 @@ package refinery
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
 	"testing"
 	"time"
 )
-
-func TestParseCPUTime(t *testing.T) {
-	cases := []struct {
-		in   string
-		want time.Duration
-		ok   bool
-	}{
-		{"0:00.02", 20 * time.Millisecond, true},
-		{"1:30", 90 * time.Second, true},
-		{"168:35.92", 168*time.Minute + 35*time.Second + 920*time.Millisecond, true},
-		{"2:03:04", 2*time.Hour + 3*time.Minute + 4*time.Second, true},
-		{"3-02:00:00", 74 * time.Hour, true},
-		{"", 0, false},
-		{"nope", 0, false},
-		{"1:2:3:4", 0, false},
-	}
-	for _, c := range cases {
-		got, ok := parseCPUTime(c.in)
-		if ok != c.ok {
-			t.Errorf("parseCPUTime(%q) ok=%v, want %v", c.in, ok, c.ok)
-			continue
-		}
-		if ok && got != c.want {
-			t.Errorf("parseCPUTime(%q) = %v, want %v", c.in, got, c.want)
-		}
-	}
-}
 
 // fakePS installs a canned process table for the duration of a test.
 func fakePS(t *testing.T, rows []procRow) {
@@ -262,16 +234,5 @@ func TestSampleSubtreeSurfacesPSFailure(t *testing.T) {
 	t.Cleanup(func() { psSnapshot = prev })
 	if _, err := sampleSubtree(500, time.Now()); err == nil {
 		t.Fatal("expected an error when the process table cannot be read")
-	}
-}
-
-func TestParsePSSkipsMalformedLines(t *testing.T) {
-	out := fmt.Sprintf("  1 0 1 0:01.00\ngarbage\n  2 1 x 0:02.00\n  3 1 3 0:03.00\n")
-	rows := parsePS(out)
-	if len(rows) != 2 {
-		t.Fatalf("parsePS kept %d rows, want 2: %v", len(rows), rows)
-	}
-	if rows[0].PID != 1 || rows[1].PID != 3 {
-		t.Errorf("unexpected rows: %v", rows)
 	}
 }

--- a/internal/refinery/subtreecpu_test.go
+++ b/internal/refinery/subtreecpu_test.go
@@ -192,11 +192,15 @@ func TestSubtreeCPUOnALiveBusyProcess(t *testing.T) {
 			_ = cmd.Wait()
 		}()
 
-		t0 := time.Now()
-		prev, err := sampleSubtree(cmd.Process.Pid, t0)
-		if err != nil {
-			t.Fatalf("sample: %v", err)
-		}
+		// Wait for the subtree to stop changing shape before the window opens.
+		// Process churn counts as work BY DESIGN — a gate forking short-lived
+		// workers is working — so a window that straddles the shell forking its
+		// child reports "busy" for a process that has only just started, and
+		// the sleeping arm below would pass or fail on how quickly the fork
+		// happened to land. Until mg-79e3 the `ps` exec took long enough to
+		// hide this; a /proc read returns in well under a millisecond, so the
+		// settle has to be explicit.
+		prev := settleSubtree(t, cmd.Process.Pid)
 		time.Sleep(1500 * time.Millisecond)
 		t1 := time.Now()
 		cur, err := sampleSubtree(cmd.Process.Pid, t1)
@@ -226,6 +230,43 @@ func TestSubtreeCPUOnALiveBusyProcess(t *testing.T) {
 	if busy, _ = run(`sleep 30`); busy {
 		t.Error("a sleeping subtree was measured as busy")
 	}
+}
+
+// settleSubtree samples until the subtree's process set repeats, and returns
+// that sample. It fails the test rather than returning an unsettled one: a
+// measurement window that opens mid-fork measures the fork, not the work.
+func settleSubtree(t *testing.T, pid int) *subtreeSample {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	prev, err := sampleSubtree(pid, time.Now())
+	if err != nil {
+		t.Fatalf("sample: %v", err)
+	}
+	for time.Now().Before(deadline) {
+		time.Sleep(50 * time.Millisecond)
+		cur, err := sampleSubtree(pid, time.Now())
+		if err != nil {
+			t.Fatalf("sample: %v", err)
+		}
+		if samePIDSet(prev.CPU, cur.CPU) {
+			return cur
+		}
+		prev = cur
+	}
+	t.Fatalf("the subtree of pid %d never settled", pid)
+	return nil
+}
+
+func samePIDSet(a, b map[int]time.Duration) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for pid := range a {
+		if _, ok := b[pid]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func TestSampleSubtreeSurfacesPSFailure(t *testing.T) {


### PR DESCRIPTION
Opened to get a **Linux CI run before merging**: this fixes a Linux-only measurement failure that cannot be reproduced on the darwin host it was written on, and `main` has been red on the `test` job since 11:17:29 today.

Both `internal/hostload` and the refinery's gate watch difference `ps`'s cumulative TIME column across a short window. On darwin that column is `MM:SS.ss` — hundredths. On Linux, procps prints whole seconds and offers no finer format, so 400ms of CPU rounds to zero at both ends of a 400ms window and a subtree burning a full core differences to the same `0.00` as one asleep.

New `internal/proctable` owns the read for both callers and states its precision; on Linux it reads `/proc/<pid>/stat` (`utime+stime` in USER_HZ ticks, 10ms), so short windows resolve on both supported platforms and CI runs the full discrimination unweakened. Below a source's minimum window the records carry a reason (`CPUUnavailable` / `Unresolvable`) rather than a fabricated zero, and both name the source they were taken with.

No assertion was relaxed — verified by introducing two deliberate defects locally and confirming the tests go red, reproducing the CI failure text verbatim.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

