### PR TITLE
pogo refinery timestamps: render UTC with a trailing Z across history/show/queue (drellem2/pogo#109)

### DIFF
--- a/changelog.d/mg-6f5e.fixed.md
+++ b/changelog.d/mg-6f5e.fixed.md
@@ -1,0 +1,66 @@
+- **`pogo refinery` timestamps render as labelled UTC across `history`, `show`
+  and `queue`, and an unresolved entry says so instead of printing a year-one
+  date (mg-6f5e).** Reported as drellem2/pogo#109: on a Europe/London host,
+  `refinery history` printed `done=04:06` for a merge that really happened at
+  `02:06:27Z`. A reader who assumed the bare digits matched the shell's `+0100`
+  decoded them as an hour **in the future** relative to a `02:11Z` "now" — which
+  reads as an impossible clock or a bogus merge record, not as a missing label.
+  That is a bad failure mode for the one surface a coordinator uses to confirm
+  that work actually shipped.
+
+  **It is broader than reported, and does not need the `+0200` the reporter
+  suspected.** A Go `time.Time` renders in whatever `Location` it was
+  deserialized into, and the two `refinery history` paths deserialize
+  differently: the retained window is unmarshalled from `refinery-state.json`,
+  whose RFC3339 carries the offset it was *stored* with, while `--since` is
+  reconstructed from `events.log`, which is written `.UTC()`. Formatted with a
+  layout carrying no zone designator and no normalisation, the command therefore
+  disagreed with **itself** by an hour, through a documented flag, on any
+  non-UTC host:
+
+      pogo refinery history            -> done=2026-08-04 21:17
+      pogo refinery history --since=2d -> done=2026-08-04 20:17
+
+  Same merge request, same host, one hour apart.
+
+  **Z-suffixed UTC rather than the explicit local offset the report also
+  offered.** A `Z` timestamp cannot be misread by a reader in any zone; a local
+  one is unambiguous only to someone who already knows the host's offset, which
+  an agent, a log reader, or a future reader at a different offset does not. UTC
+  is also what the artifacts a reader correlates these against are already in —
+  `events.log`, the refinery mail-item epoch ids, `auditsuccessors.go` — so it
+  removes the arithmetic instead of relabelling it. `.Local().Format(RFC3339)`,
+  matching `schedule list`, was considered and rejected: it widens a fixed-width
+  table column by ~11 characters and leaves the reader converting.
+
+  **The whole `refinery *` family, and no further.** `history`, `show` and
+  `queue` all move; a history-only fix would leave the family half-labelled, and
+  a reader who learns "refinery prints UTC now" will confidently misread
+  whichever surface was left bare — worse than today's uniform distrust.
+  `--json` is deliberately untouched and was never defective: it emits RFC3339,
+  which carries the offset.
+
+  **A zero time renders `-`, not `0001-01-01`.** The `--since` path is the only
+  one that emits non-terminal rows, and a `StatusProcessing` row has no done
+  time at all. It was printing a year-one date, which reads as a corrupt record
+  rather than as an absent one — the same class of wrong conclusion the missing
+  zone label produced.
+
+  **The tests assert the disagreement, not the suffix.** A test that only
+  checked for a trailing `Z` would pass on output that still disagreed with
+  itself, so the fixtures build the *same instant* in the two `Location`s the
+  two history paths actually produce and require the rendered rows to be
+  byte-identical. They also assert the digits are not merely relabelled: if the
+  `.UTC()` conversion were dropped the layout would still print a `Z` and the
+  digits would still read `21:17`, which is worse than printing them bare
+  because the label would assert something false. The history row was extracted
+  into `formatHistoryRow` to make the line a reader actually sees reachable from
+  a test.
+
+  **The mg-0235 waiver is deleted, which is the event it was written for.** That
+  recurrence check held these five calls in a `gh109Waiver` map while this fix
+  sat at a human go/no-go gate, and it was built to be *exhausted* rather than
+  respected — an entry matching nothing fails the test. With the fix landed the
+  map is removed rather than emptied: a waiver map with no entries is an
+  invitation to add one. Every rendered time layout in `cmd/pogo` now carries a
+  zone designator with no waived lines.

--- a/cmd/pogo/main.go
+++ b/cmd/pogo/main.go
@@ -4012,19 +4012,7 @@ Examples:
 					return
 				}
 				for _, mr := range rows {
-					// StatusLabel, not Status: a bare `failed` is what invited
-					// thirty-one dispatches for defects that did not exist on
-					// 2026-08-05 (mg-e5c2). `failed(infrastructure)` is triageable
-					// without reading the error column.
-					line := fmt.Sprintf("%-12s  branch=%-30s  author=%-15s  status=%-24s  done=%s",
-						mr.ID, mr.Branch, mr.Author, mr.StatusLabel(), mr.DoneTime.Format("2006-01-02 15:04"))
-					if mr.AttemptCount > 1 {
-						line += fmt.Sprintf("  attempts=%d", mr.AttemptCount)
-					}
-					if mr.Error != "" {
-						line += fmt.Sprintf("  error=%s", mr.Error)
-					}
-					fmt.Println(line)
+					fmt.Println(formatHistoryRow(mr))
 				}
 			}
 
@@ -4131,12 +4119,12 @@ Examples:
 					fmt.Printf("Post-merge: FAILED — %s\n", mr.PostMergeError)
 				}
 				fmt.Printf("Repo:      %s\n", mr.RepoPath)
-				fmt.Printf("Submitted: %s\n", mr.SubmitTime.Format("2006-01-02 15:04:05"))
+				fmt.Printf("Submitted: %s\n", refineryTimeSecond(mr.SubmitTime))
 				if !mr.StartTime.IsZero() {
-					fmt.Printf("Started:   %s\n", mr.StartTime.Format("2006-01-02 15:04:05"))
+					fmt.Printf("Started:   %s\n", refineryTimeSecond(mr.StartTime))
 				}
 				if !mr.DoneTime.IsZero() {
-					fmt.Printf("Done:      %s\n", mr.DoneTime.Format("2006-01-02 15:04:05"))
+					fmt.Printf("Done:      %s\n", refineryTimeSecond(mr.DoneTime))
 				}
 				// A queued MR says where it is in line. "Queued for 30
 				// minutes" alone reads as ignored; "waiting, 1 ahead, and

--- a/cmd/pogo/refineryhistory.go
+++ b/cmd/pogo/refineryhistory.go
@@ -5,7 +5,31 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/drellem2/pogo/internal/refinery"
 )
+
+// formatHistoryRow renders one row of `pogo refinery history`.
+//
+// Extracted from the command body by mg-6f5e so the row a reader actually sees
+// is reachable from a test: this row is where drellem2/pogo#109 was reported,
+// and the two windows that feed it (the retained state file and the --since
+// event log) deserialize their times into different Locations. See
+// refinerytime.go for why the done time is rendered as labelled UTC.
+func formatHistoryRow(mr refinery.MergeRequest) string {
+	// StatusLabel, not Status: a bare `failed` is what invited thirty-one
+	// dispatches for defects that did not exist on 2026-08-05 (mg-e5c2).
+	// `failed(infrastructure)` is triageable without reading the error column.
+	line := fmt.Sprintf("%-12s  branch=%-30s  author=%-15s  status=%-24s  done=%s",
+		mr.ID, mr.Branch, mr.Author, mr.StatusLabel(), refineryTimeMinute(mr.DoneTime))
+	if mr.AttemptCount > 1 {
+		line += fmt.Sprintf("  attempts=%d", mr.AttemptCount)
+	}
+	if mr.Error != "" {
+		line += fmt.Sprintf("  error=%s", mr.Error)
+	}
+	return line
+}
 
 // sinceDateLayouts are the absolute forms accepted by parseSince, tried in
 // order. A bare date is interpreted in the local zone, matching how the rest of

--- a/cmd/pogo/refineryprogress.go
+++ b/cmd/pogo/refineryprogress.go
@@ -169,7 +169,7 @@ func formatQueue(queue []refinery.MergeRequest, now time.Time) string {
 		mr := queue[i]
 		line := fmt.Sprintf("%-12s  repo=%-16s  branch=%-30s  author=%-15s  status=%-10s  submitted=%s",
 			mr.ID, refinery.RepoLane(mr.RepoPath), mr.Branch, mr.Author, mr.StatusLabel(),
-			mr.SubmitTime.Format("2006-01-02 15:04"))
+			refineryTimeMinute(mr.SubmitTime))
 		if mr.Status == refinery.StatusProcessing {
 			fmt.Fprintln(&b, line)
 			for _, l := range progressLines(&mr, now) {

--- a/cmd/pogo/refinerytime.go
+++ b/cmd/pogo/refinerytime.go
@@ -38,6 +38,19 @@ import "time"
 //
 // --json is deliberately untouched and was never defective: it emits RFC3339,
 // which carries the offset.
+//
+// A RESIDUAL DIVERGENCE THAT IS NOT THIS DEFECT, recorded here because the
+// tests below assert the two windows render byte-identically and a reader who
+// then sees them differ on a live host has good reason to suspect a
+// regression. The two sources can hold genuinely DIFFERENT INSTANTS for the
+// same merge request — the state file's done time is stamped when the record is
+// retained, the event log's when the event is appended. Observed on
+// mr-d9pnghqtjv1h244d8430: 2026-08-05T20:14:00.750287+01:00 in the state file
+// against 19:13:58.586140Z in the event log, 2.164s apart and straddling a
+// minute boundary, so the minute-resolution rows read 19:14Z and 19:13Z. That
+// is a provenance difference in the recorded data, not a zone defect, and it is
+// out of scope here: normalising it means changing what one of the two sources
+// records, not how either is rendered.
 
 // refineryTimeMinute renders a refinery timestamp to the minute, as labelled
 // UTC, for the fixed-width table rows of `refinery history` and `refinery
@@ -57,6 +70,13 @@ func refineryTimeMinute(t time.Time) string {
 
 // refineryTimeSecond is refineryTimeMinute at second resolution, for the
 // per-field lines of `refinery show`.
+//
+// Its zero-time branch is currently UNREACHABLE from all three call sites —
+// main.go:4124 and :4127 are already IsZero-guarded, and :4122 renders
+// SubmitTime, which is always set. It is kept for symmetry with
+// refineryTimeMinute, whose guard is load-bearing, and so a fourth call site
+// cannot reintroduce a year-one date. Stated so the "-" is not misread as
+// evidence that `refinery show` can emit one.
 func refineryTimeSecond(t time.Time) string {
 	if t.IsZero() {
 		return "-"

--- a/cmd/pogo/refinerytime.go
+++ b/cmd/pogo/refinerytime.go
@@ -1,0 +1,65 @@
+package main
+
+import "time"
+
+// Timestamp rendering for the `pogo refinery *` family (mg-6f5e,
+// drellem2/pogo#109).
+//
+// THE DEFECT. A Go time.Time renders in whatever Location it was deserialized
+// into, and the refinery's two history paths deserialize differently: the
+// retained window is unmarshalled from ~/.pogo/refinery-state.json, whose
+// RFC3339 carries the offset it was STORED with, while --since is
+// reconstructed from events.log, which is written .UTC(). Formatted with a
+// layout carrying no zone designator and no normalisation, `pogo refinery
+// history` therefore disagreed with ITSELF by an hour on any non-UTC host,
+// through a documented flag:
+//
+//	pogo refinery history            -> done=2026-08-04 21:17
+//	pogo refinery history --since=2d -> done=2026-08-04 20:17
+//
+// WHY UTC WITH A TRAILING Z, and not .Local(). A Z-suffixed timestamp cannot be
+// misread by a reader in any zone. A local one is unambiguous only to someone
+// who already knows the host's offset — which an agent, a log reader, or a
+// future reader at a different offset does not. The second failure mode of the
+// same class cost more than the first: a gate reported as "started 18:51:05",
+// read against a UTC clock showing 18:28, looks like it started IN THE FUTURE,
+// which invites the conclusion that the RECORD IS CORRUPT rather than that a
+// label is missing. UTC is also what the artifacts a reader correlates these
+// against are in — events.log, the refinery mail-item epoch ids, and
+// auditsuccessors — so it removes the arithmetic instead of relabelling it.
+//
+// The in-tree precedent for the pattern is auditsuccessors.go, whose comment
+// records this exact class ("an hour off under BST") being repaired once
+// before; mg-0235 brought refineryprogress and refineryattempts into line and
+// added the recurrence check in timelayoutzone_test.go, which these two
+// functions are written to satisfy rather than to evade: the layout stays an
+// inline literal beside the .UTC() that makes its Z true, because a layout
+// hoisted behind a variable is a hole the static check cannot judge.
+//
+// --json is deliberately untouched and was never defective: it emits RFC3339,
+// which carries the offset.
+
+// refineryTimeMinute renders a refinery timestamp to the minute, as labelled
+// UTC, for the fixed-width table rows of `refinery history` and `refinery
+// queue`.
+//
+// A zero time renders as "-" rather than as 0001-01-01. The --since path
+// reconstructs non-terminal rows from the event log (internal/refinery/
+// historylog.go), and a StatusProcessing row has no done time at all — it was
+// printing a year-one date, which reads as a corrupt record rather than as an
+// absent one.
+func refineryTimeMinute(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.UTC().Format("2006-01-02 15:04Z")
+}
+
+// refineryTimeSecond is refineryTimeMinute at second resolution, for the
+// per-field lines of `refinery show`.
+func refineryTimeSecond(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.UTC().Format("2006-01-02 15:04:05Z")
+}

--- a/cmd/pogo/refinerytime_test.go
+++ b/cmd/pogo/refinerytime_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drellem2/pogo/internal/refinery"
+)
+
+// The acceptance tests for mg-6f5e / drellem2/pogo#109.
+//
+// The criterion is not "a Z appears in the output". It is the two readings the
+// defect actually produced:
+//
+//  1. `pogo refinery history` and `pogo refinery history --since` print the
+//     same merge request's done time an HOUR APART, because the retained
+//     window unmarshals the offset stored in refinery-state.json and the
+//     --since window parses an events.log written in UTC. Same command, same
+//     MR, documented flag.
+//  2. An unresolved row prints `done=0001-01-01 00:00`, which reads as a
+//     corrupt record rather than as an absent time.
+//
+// So the fixtures below build the SAME INSTANT in two Locations and require
+// the rendered rows to be byte-identical, rather than checking each in
+// isolation — a test that only asserted a suffix would pass on output that
+// still disagreed with itself.
+
+// plusOneZone is the offset that made the bug visible: a BST host, whose
+// refinery-state.json therefore stores +01:00 while its events.log stores Z.
+var plusOneZone = time.FixedZone("BST", 3600)
+
+// TestRefineryTimeRendersLabelledUTC covers the two helpers directly.
+func TestRefineryTimeRendersLabelledUTC(t *testing.T) {
+	// One instant, held in the two Locations the two history paths produce.
+	utc := time.Date(2026, 8, 4, 20, 17, 29, 419503000, time.UTC)
+	stored := utc.In(plusOneZone) // reads 21:17 on its own clock
+
+	if got, want := refineryTimeMinute(stored), "2026-08-04 20:17Z"; got != want {
+		t.Errorf("refineryTimeMinute(stored +01:00) = %q, want %q — this is the retained-window\n"+
+			"reading that disagreed with --since by an hour", got, want)
+	}
+	if got, want := refineryTimeMinute(utc), "2026-08-04 20:17Z"; got != want {
+		t.Errorf("refineryTimeMinute(UTC) = %q, want %q", got, want)
+	}
+	if got, want := refineryTimeSecond(stored), "2026-08-04 20:17:29Z"; got != want {
+		t.Errorf("refineryTimeSecond(stored +01:00) = %q, want %q", got, want)
+	}
+	if got, want := refineryTimeSecond(utc), "2026-08-04 20:17:29Z"; got != want {
+		t.Errorf("refineryTimeSecond(UTC) = %q, want %q", got, want)
+	}
+
+	// The whole point of the Z is that it is not the host's clock relabelled.
+	// If the conversion were dropped, the layout would still print a Z and the
+	// digits would be 21:17 — worse than printing them bare, because the label
+	// would assert something false.
+	for _, got := range []string{refineryTimeMinute(stored), refineryTimeSecond(stored)} {
+		if strings.Contains(got, "21:17") {
+			t.Errorf("%q renders the value's stored +01:00 offset and labels it Z", got)
+		}
+	}
+}
+
+// TestRefineryTimeZeroRendersAsAbsent is item 2 of the plan posted on the
+// issue. The --since path is the only one that emits non-terminal rows
+// (internal/refinery/historylog.go sets StatusProcessing and never sets a done
+// time), so an in-flight MR was rendering a year-one date.
+func TestRefineryTimeZeroRendersAsAbsent(t *testing.T) {
+	for name, got := range map[string]string{
+		"minute": refineryTimeMinute(time.Time{}),
+		"second": refineryTimeSecond(time.Time{}),
+	} {
+		if got != "-" {
+			t.Errorf("%s: zero time rendered as %q, want %q", name, got, "-")
+		}
+		if strings.Contains(got, "0001-01-01") {
+			t.Errorf("%s: an unresolved entry still prints a year-one date (%q), which reads as a\n"+
+				"corrupt record rather than as an absent one", name, got)
+		}
+	}
+}
+
+// TestHistoryRowIsIdenticalAcrossTheTwoWindows is the reported defect, stated
+// as a test: the retained window and the --since window hand formatHistoryRow
+// the same instant in different Locations, and the reader must not be able to
+// tell which one they are looking at.
+func TestHistoryRowIsIdenticalAcrossTheTwoWindows(t *testing.T) {
+	done := time.Date(2026, 8, 4, 20, 17, 29, 0, time.UTC)
+
+	// As unmarshalled from ~/.pogo/refinery-state.json, which stores the
+	// offset the daemon was running in.
+	retained := refinery.MergeRequest{
+		ID: "mr-d9p4fjqtjv1h", Branch: "polecat-6f5e", Author: "mg-6f5e",
+		Status: refinery.StatusMerged, DoneTime: done.In(plusOneZone),
+	}
+	// As reconstructed from ~/.pogo/events.log, which is written .UTC().
+	fromLog := retained
+	fromLog.DoneTime = done
+
+	gotRetained := formatHistoryRow(retained)
+	gotFromLog := formatHistoryRow(fromLog)
+
+	if gotRetained != gotFromLog {
+		t.Errorf("`refinery history` and `refinery history --since` disagree about the same MR:\n"+
+			"  retained: %s\n  --since:  %s", gotRetained, gotFromLog)
+	}
+	if !strings.Contains(gotRetained, "done=2026-08-04 20:17Z") {
+		t.Errorf("history row does not render the done time as labelled UTC:\n%s", gotRetained)
+	}
+	if strings.Contains(gotRetained, "21:17") {
+		t.Errorf("history row renders the stored +01:00 offset:\n%s", gotRetained)
+	}
+}
+
+// TestHistoryRowSaysNothingRatherThanYearOne covers the unresolved row on the
+// --since path.
+func TestHistoryRowSaysNothingRatherThanYearOne(t *testing.T) {
+	got := formatHistoryRow(refinery.MergeRequest{
+		ID: "mr-inflight", Branch: "polecat-6f5e", Author: "mg-6f5e",
+		Status: refinery.StatusProcessing,
+	})
+
+	if strings.Contains(got, "0001-01-01") {
+		t.Errorf("an unresolved merge request still prints a year-one done time:\n%s", got)
+	}
+	if !strings.Contains(got, "done=-") {
+		t.Errorf("an unresolved merge request should say its done time is absent:\n%s", got)
+	}
+}
+
+// TestQueueSubmittedTimeIsLabelledUTC covers `pogo refinery queue`, folded in
+// so the family is not left half-labelled: a reader who learns "refinery
+// prints UTC now" would confidently misread whichever surface was left bare,
+// which is worse than today's uniform distrust.
+func TestQueueSubmittedTimeIsLabelledUTC(t *testing.T) {
+	submitted := time.Date(2026, 8, 4, 20, 17, 0, 0, time.UTC)
+	now := submitted.Add(30 * time.Minute)
+
+	out := formatQueue([]refinery.MergeRequest{{
+		ID: "mr-queued", Branch: "polecat-6f5e", Author: "mg-6f5e",
+		Status: refinery.StatusQueued, RepoPath: "/Users/daniel/dev/pogo",
+		SubmitTime: submitted.In(plusOneZone),
+	}}, now)
+
+	if !strings.Contains(out, "submitted=2026-08-04 20:17Z") {
+		t.Errorf("queue submit time is not rendered as labelled UTC:\n%s", out)
+	}
+	if strings.Contains(out, "21:17") {
+		t.Errorf("queue submit time rendered in the record's stored +01:00 offset:\n%s", out)
+	}
+}

--- a/cmd/pogo/timelayoutzone_test.go
+++ b/cmd/pogo/timelayoutzone_test.go
@@ -348,23 +348,17 @@ func TestUnlabeledTimeLayoutScannerFiresOnItsControl(t *testing.T) {
 	}
 }
 
-// gh109Waiver holds the Format calls that mg-6f5e — the drellem2/pogo#109 fix —
-// owns, and which this ticket is explicitly told not to touch: that fix is at a
-// human go/no-go gate and is reviewed separately.
-//
-// The waiver is expected to be EXHAUSTED, not merely respected: the test below
-// fails if an entry stops matching anything, so when mg-6f5e lands, this map
-// tells you to delete it rather than leaving a permanent hole in the check.
-var gh109Waiver = map[string]int{
-	"main.go:mr.DoneTime":               2, // refinery history + refinery show
-	"main.go:mr.SubmitTime":             1, // refinery show
-	"main.go:mr.StartTime":              1, // refinery show
-	"refineryprogress.go:mr.SubmitTime": 1, // refinery queue
-}
+// The gh109Waiver that stood here held the five refinery history/show/queue
+// Format calls mg-0235 was told not to touch while drellem2/pogo#109 sat at a
+// human go/no-go gate. It was written to be EXHAUSTED rather than respected —
+// an entry matching nothing failed the test — and mg-6f5e landing that fix is
+// the event it was waiting for. Deleted rather than emptied: a waiver map with
+// no entries is an invitation to add one.
 
 // TestCmdPogoTimeLayoutsCarryAZoneDesignator is the recurrence check itself: it
 // runs the scanner over the whole of cmd/pogo and requires the population to be
-// empty apart from the separately gated gh#109 lines.
+// empty. There are no waived lines: since mg-6f5e every rendered time layout in
+// this package carries a zone designator.
 func TestCmdPogoTimeLayoutsCarryAZoneDesignator(t *testing.T) {
 	findings, stats, err := scanUnlabeledTimeLayouts(".")
 	if err != nil {
@@ -377,32 +371,10 @@ func TestCmdPogoTimeLayoutsCarryAZoneDesignator(t *testing.T) {
 		t.Fatalf("only %d time layouts found in cmd/pogo — the scan is not reaching the tree it is meant to cover (%s)", stats.TimeLayouts, stats)
 	}
 
-	remaining := make(map[string]int, len(gh109Waiver))
-	for k, v := range gh109Waiver {
-		remaining[k] = v
-	}
-
-	var unwaived []zoneFinding
 	for _, f := range findings {
-		if remaining[f.key()] > 0 {
-			remaining[f.key()]--
-			continue
-		}
-		unwaived = append(unwaived, f)
-	}
-
-	for _, f := range unwaived {
 		t.Errorf("unlabeled time layout: %s\n"+
 			"    A reader cannot tell which zone these digits are in, and two surfaces rendering\n"+
 			"    from differently-deserialized values will disagree by the host's offset.\n"+
 			"    Fix with the in-tree pattern: v.UTC().Format(\"<layout>Z\").", f)
-	}
-
-	for key, left := range remaining {
-		if left > 0 {
-			t.Errorf("gh109Waiver entry %q expected %d more unlabeled call(s) than the tree has — "+
-				"if mg-6f5e (drellem2/pogo#109) has landed, delete the entry; a waiver that matches "+
-				"nothing is a permanent hole in this check.", key, left)
-		}
 	}
 }


### PR DESCRIPTION
`pogo refinery history` disagreed with **itself** by one hour on any non-UTC host, through a documented flag:

```
pogo refinery history            -> done=2026-08-04 21:17
pogo refinery history --since=2d -> done=2026-08-04 20:17
```

Same merge request, same host. A `time.Time` renders in whatever `Location` it was deserialized into: the retained window is unmarshalled from `refinery-state.json` (carrying the offset it was *stored* with), while `--since` is reconstructed from `events.log` (written `.UTC()`). The layout carried no zone designator and no normalisation.

This is broader than the issue as filed — the reporter attributed it to a `+0200` daemon zone, and it does not depend on that at all.

## Change

1. `refinery history`, `show` and `queue` render `.UTC().Format("...Z")` via two helpers in the new `cmd/pogo/refinerytime.go`.
2. A zero time renders `-` rather than `0001-01-01`. The `--since` path is the only one emitting non-terminal rows, and a `StatusProcessing` row has no done time — it was printing a year-one date, which reads as a corrupt record rather than an absent one.
3. The history row was extracted into `formatHistoryRow` so the line a reader actually sees is reachable from a test.

`--json` is deliberately untouched and was never defective: it emits RFC3339, which carries the offset.

**Why UTC-with-`Z` and not the explicit local offset the report also offered.** A `Z` timestamp cannot be misread by a reader in any zone; a local one is unambiguous only to someone who already knows the host's offset. UTC is also what the artifacts a reader correlates against are already in (`events.log`, the refinery mail-item epoch ids, `auditsuccessors.go`), so it removes the arithmetic rather than relabelling it.

## Scope: I kept this to the issue, and here is the accounting

This branch was rescued from a prior polecat's worktree that was killed mid-flight. The rescue briefing warned that three commits riding along with it had widened the change beyond the issue — gate output text, gate-timeout classification, and the unlabeled-layout recurrence check.

**That widening is not in this PR.** Those three commits (mg-9adc, mg-e565, mg-0235) had already landed on `main` independently; I verified each with `git merge-base --is-ancestor`. This branch's diff against `main` is seven files: six of code and tests, all of them the timestamp fix, plus `changelog.d/mg-6f5e.fixed.md`. Nothing needed splitting.

The one change here that *looks* like scope creep is the deletion of `gh109Waiver` from `timelayoutzone_test.go`, and it is the opposite: mg-0235 added that waiver to hold these exact five calls while this fix sat at a human go/no-go gate, and built it to be **exhausted rather than respected** — the test fails if an entry stops matching anything. Landing this fix is the event it was waiting for, so the map is deleted rather than emptied (an empty waiver map is an invitation to add one). `TestCmdPogoTimeLayoutsCarryAZoneDesignator` now passes with no waived lines.

## Tests

Acceptance tests assert the *disagreement*, not the suffix — a test that only checked for a trailing `Z` would pass on output that still disagreed with itself. The fixtures build the same instant in the two `Location`s the two history paths actually produce and require the rendered rows to be byte-identical. They also assert the digits were converted rather than relabelled: dropping the `.UTC()` would still print a `Z` while the digits read `21:17`, which is worse than printing them bare because the label would assert something false.

`go test ./cmd/pogo/` passes.

Live check on this +0100 host — both windows now agree:

```
pogo refinery history            -> done=2026-08-05 17:33Z
pogo refinery history --since=2d -> done=2026-08-05 17:33Z
```

## Two things I found and did not fix

- **`./build.sh` is currently red on `internal/refinery`**, at `TestGateWatchMeasuresARealSubtreesCPU`. It is unrelated to this change and not caused by it: `internal/refinery` is byte-identical to `main` on this branch (`git diff main -- internal/refinery` is empty). The test measures a real subtree's CPU and the box is at load ~48, so a spinning gate peaked at 0.37 cores against the threshold. Flagging rather than touching it.
- **One history row differs between the two windows by a minute** (`19:14Z` vs `19:13Z`). This is *not* a zone defect — the two sources genuinely hold instants 2.16s apart (`20:14:00.750+01:00` vs `19:13:58.586Z`), straddling a minute boundary. A pre-existing data-provenance difference between the state file and the event log, out of scope here.

Refs drellem2/pogo#109

Approved triage recommendation: mg-b4cc
Work item: mg-6f5e

