### PR TITLE
pogo CLI dials localhost, so anything on ::1:<port> impersonates pogod: add a doctor loopback-resolution check (tested, with a positive control) and dial 127.0.0.1

### DIFF
--- a/changelog.d/mg-e314.fixed.md
+++ b/changelog.d/mg-e314.fixed.md
@@ -28,11 +28,30 @@
 
   **The detector ships with the fix, not after it.** Pointing the CLI at
   `127.0.0.1` stops the CLI being fooled; it does not empty the port. Editor
-  integrations (tracked separately as mg-b36f), a stale `ssh -L`, a forward on a
-  reconfigured port, a second daemon — everything else that dials the name is
-  still fooled, and silently. The new row is what makes that condition
-  observable at all, and it was written while the bug still reproduced rather
-  than after it went rare.
+  integrations (tracked separately as mg-b36f), a stale `ssh -L`, a forward
+  whose far end is not a daemon — everything else that dials the name is still
+  fooled, and silently. The new row is what makes that condition observable at
+  all, and it was written while the bug still reproduced rather than after it
+  went rare.
+
+  **What it detects, stated narrowly, because the recommendation over-promised.**
+  The row detects a responder on the name that is **not pogod-shaped**. It
+  **cannot tell this pogod from another one**: a second pogod bound to a v6
+  loopback emits `health.LivenessBody` like any other, so both probes report
+  pogod and the row passes — likewise an `ssh -L` or port-forward whose far end
+  is a real pogod elsewhere. The approved recommendation promised "a second
+  daemon" in the same breath as the rest of the class and the first draft of
+  this row repeated it; review round 1 staged two real pogods and showed the row
+  going green. Corrected here rather than quietly dropped, because a reader told
+  the row covers a second daemon reads that green line and stops looking — the
+  precise failure this ticket exists to prevent, displaced by one case. Where
+  the evidence permits, the pass line now says what it saw: when both probes
+  answer as pogod but the name landed somewhere other than the bind address, it
+  names that address and states that a dual-stack bind and a second daemon are
+  both consistent with it and that this check does not separate them. Settling
+  that needs `/version` (`start_time` differs between two daemons on one
+  revision) and carries a dual-stack false positive; it is a feature, not this
+  row, and is deliberately not built here.
 
   **The row refuses to be satisfied by liveness.** "The TCP dial succeeded" and
   even "HTTP 200" are properties of any listener, not of pogod — the incident is

--- a/changelog.d/mg-e314.fixed.md
+++ b/changelog.d/mg-e314.fixed.md
@@ -1,0 +1,83 @@
+- **The pogo CLI dialled a NAME, so anything holding `::1:<port>` answered as
+  pogod. It now dials the address, and `pogo doctor --check` reports the case
+  it cannot fix (mg-e314, `Refs drellem2/pogo#110`).** Two changes shipped
+  together: `config.ServerURL()` returns `http://127.0.0.1:<port>` instead of
+  `http://localhost:<port>`, and a new `loopback resolution` row detects a
+  process shadowing the daemon port.
+
+  **The defect.** pogod binds `127.0.0.1` (`config.DefaultBind`). On a stock
+  macOS `/etc/hosts`, `localhost` resolves `::1` first — an address pogod never
+  holds and therefore any other process may claim. Whatever claims it becomes
+  pogod for every caller of `ServerURL()`. Go's dual-stack fallback does not
+  help: it retries the other family on connection *refused*, and an interloper
+  that accepts and answers wrongly never refuses. On 2026-07-31 a `kubectl
+  port-forward` landed on `::1:10000` after its IPv4 bind was refused and took
+  the pogo control plane down for ~20 minutes. **pogod was healthy the entire
+  time**, which is the whole difficulty: every instrument pointed at a working
+  daemon and reported a broken one.
+
+  `ServerURL()` has two non-test callers and neither wanted the name.
+  `internal/client` funnels every CLI command through it. `internal/selfdrift`'s
+  `RunningRev` reads `/version` through it — so under shadowing the drift
+  detector read the *interloper's* answer and reported `RevUnreachable` about a
+  healthy daemon, blinded alongside doctor's "pogod running" row. One line
+  repairs both. `DialAddr()` — what the spawn-race guard probes — has targeted
+  `127.0.0.1` explicitly since #22 and documents why; the two are now pinned
+  equal by a test, because their disagreement is exactly what let the guard see
+  a free port while the CLI talked to an impostor.
+
+  **The detector ships with the fix, not after it.** Pointing the CLI at
+  `127.0.0.1` stops the CLI being fooled; it does not empty the port. Editor
+  integrations (tracked separately as mg-b36f), a stale `ssh -L`, a forward on a
+  reconfigured port, a second daemon — everything else that dials the name is
+  still fooled, and silently. The new row is what makes that condition
+  observable at all, and it was written while the bug still reproduced rather
+  than after it went rare.
+
+  **The row refuses to be satisfied by liveness.** "The TCP dial succeeded" and
+  even "HTTP 200" are properties of any listener, not of pogod — the incident is
+  precisely a wrong process passing both — so a probe built on them would
+  reproduce, one layer up, the defect it exists to detect. The probe requires
+  `health.LivenessBody`, the one string only pogod emits, now read from
+  `internal/health` by both the daemon's handler and the probe so the two cannot
+  drift apart while the check keeps reporting pass. It carries a client timeout,
+  because a listener that accepts and never writes is a hang rather than an
+  error and would otherwise wedge `doctor --check` indefinitely.
+
+  **Four states, and the last two are what keep it from being noise.** Both
+  addresses answer → pass, naming which address the *name* landed on ("::1 was
+  free and Go fell back" and "pogod is where the name points" are different
+  worlds, and only the second is stable). Bind answers, name does not → **fail**,
+  saying pogod is HEALTHY and must not be restarted, naming the shadowing
+  address, and printing the `lsof` query for the family actually reached — a
+  `-i6TCP` remedy against an IPv4 shadow lists nothing, and a remedy that prints
+  nothing reads as a wrong check. Neither answers → **renders nothing at all**,
+  because check 1 already says the daemon is down and a checklist that reports
+  every stopped daemon twice is one people stop reading. Name answers but the
+  bind address does not → **warn**: a daemon configured with a v6-loopback
+  `bind`, which this change does stop reaching over the name. That configuration
+  is already half-broken — `DialAddr` has never found it, so the spawn-race
+  guard reads the port as free and may start a rival pogod — and the row is the
+  plain-language signal such a user currently gets nowhere.
+
+  **Shown to fail before it was believed.** A check for silent impersonation
+  that has only ever been observed returning pass is itself a silent
+  impersonation of a check. All four states were staged against real sockets and
+  the real binary: a sandboxed pogod on `127.0.0.1:10981` with a Python
+  responder bound to `[::1]:10981` reproduced the incident (`curl
+  localhost:10981` returned the impostor while pogod answered on 127.0.0.1), and
+  `pogo doctor --check` reported `✗ loopback resolution` and exited 1; removing
+  the impostor returned the same code to `✓`; stopping the daemon made the row
+  disappear; and a pogod started with `--bind "[::1]"` produced the warn. In the
+  test suite this is `TestLoopbackResolution_InterloperOnV6Fires`, which binds
+  both families of the same port and requires a fail, paired with
+  `..._PassesOnceTheV6PortIsFree`, which requires the same code to go quiet —
+  "fires when it should" and "does not fire when it should not" are two claims
+  and a detector needs both. `TestProbePogod_AcceptsOnlyPogodsBody` feeds it five
+  responders that would all pass a dial-succeeded probe, and four that would
+  pass an HTTP-200 one.
+
+  **Not done here.** Editor integrations carry their own `localhost:10000`
+  defaults and are not `ServerURL()` callers; they hit this class independently
+  and remain mg-b36f. The doctor row now detects the shadowing they suffer from,
+  but detection is on the CLI's checklist, not in the editors.

--- a/cmd/pogo/loopbackresolution.go
+++ b/cmd/pogo/loopbackresolution.go
@@ -20,9 +20,29 @@ package main
 // WHY IT IS NOT REDUNDANT WITH THE `ServerURL` FIX. The companion change in
 // this commit points the CLI at 127.0.0.1, so the CLI stops being fooled. It
 // does not empty the port: everything else that dials the NAME — editor
-// integrations (mg-b36f), a stale `ssh -L`, a forward on a reconfigured port,
-// a second daemon — still is. This check is what makes that condition visible
-// instead of silent, and it is why A ships with B rather than after it.
+// integrations (mg-b36f), a stale `ssh -L`, a forward whose far end is not a
+// daemon — still is. This check is what makes that condition visible instead
+// of silent, and it is why A ships with B rather than after it.
+//
+// EXACTLY WHAT IT DETECTS, AND WHAT IT DOES NOT. It detects a responder on the
+// NAME that is not POGOD-SHAPED. It cannot tell THIS pogod from ANOTHER one.
+// A second pogod bound to a v6 loopback emits health.LivenessBody like any
+// other, so both probes report pogod and the row passes — likewise an `ssh -L`
+// or port-forward whose far end is a real pogod elsewhere. That case is NOT
+// covered, and saying otherwise would be the failure this file argues against
+// one case over: a reader told the row covers a second daemon reads the green
+// line and stops looking. The approved recommendation (mg-e314) promised the
+// broader class in the same words; it over-promised, and this is the correction
+// rather than a quiet narrowing.
+//
+// The row does say what it saw. When both probes answer as pogod but the name
+// landed somewhere other than the bind address, the pass line names that
+// address and states plainly that a dual-stack bind and a second daemon are
+// both consistent with it and that this check does not separate them —
+// evidence the probe already holds, offered without a verdict it cannot
+// support. Separating them needs /version (start_time differs between two
+// daemons on one revision) and carries a dual-stack false positive; that is a
+// feature, not this row, and it is deliberately not built here.
 //
 // WHY THE PROBE MATCHES ON A BODY. "The TCP dial succeeded" and even "HTTP
 // 200" are properties of any listener, not of pogod. The incident is precisely
@@ -180,27 +200,44 @@ func loopbackResolutionLine(bind, name loopbackProbe, port int) (status, detail 
 	// Both answer as pogod. Say which address the name landed on: it is the
 	// difference between "v6 is free and Go fell back" and "pogod is bound
 	// where the name points", and only the second is durable.
-	return "pass", fmt.Sprintf("pogod answers on both %s and %s; the name reached %s",
+	detail = fmt.Sprintf("pogod answers on both %s and %s; the name reached %s",
 		bind.URL, name.URL, loopbackOrUnknown(name.Remote))
+
+	// The name answered as pogod from an address that is NOT the one pogod was
+	// probed on. Two things produce that — a dual-stack bind (0.0.0.0 also
+	// binds [::]) and a SECOND pogod — and this row cannot separate them: the
+	// body match distinguishes pogod-shaped from not-pogod-shaped, never this
+	// pogod from another. Rather than pass in silence or invent a verdict it
+	// cannot support, the line states the observation and names its own limit,
+	// so a reader chasing a second daemon learns here that they must look
+	// elsewhere instead of reading green as an all-clear.
+	if name.Remote != "" && bind.Remote != "" && name.Remote != bind.Remote {
+		detail += fmt.Sprintf(
+			", which is NOT the address pogod was probed on (%s). A dual-stack bind and a SECOND pogod both look like this, and this check does not tell them apart — it distinguishes pogod-shaped responders from other processes, not one pogod from another. If you did not configure a dual-stack bind, compare `/version` start_time on both addresses",
+			bind.Remote)
+	}
+	return "pass", detail
 }
 
 // loopbackShadowDetail writes the failure. It has to carry three things a
 // reader cannot reconstruct: that pogod is HEALTHY (so nobody restarts it),
 // which address is lying, and the one command that names the culprit.
 func loopbackShadowDetail(bind, name loopbackProbe, port int) string {
-	var lead string
+	// Two different failures share this row, and only one of them has a
+	// culprit. Sending an operator to hunt a process on a host where the name
+	// simply never connected wastes exactly the time this row exists to save,
+	// so the remedy is written per branch rather than shared.
 	if name.Remote == "" {
 		// The name never connected at all while the bind address did. Not the
 		// port-forward shape — this is a resolver or /etc/hosts that points
-		// the name somewhere pogod is not.
-		lead = fmt.Sprintf("%s could not be reached at all (%s)", name.URL, loopbackReason(name))
-	} else {
-		lead = fmt.Sprintf("%s reached %s, and the process there is NOT pogod (%s)",
-			name.URL, name.Remote, loopbackReason(name))
+		// the name somewhere pogod is not. There is NO impersonator to find.
+		return fmt.Sprintf(
+			"%s could not be reached at all (%s), while pogod is HEALTHY on %s — do not restart it. Nothing answered on the name, so there is no process to hunt: this is name resolution, not an impersonator. Check what `localhost` resolves to on this host (`/etc/hosts`, then `dns-sd -q localhost`) — anything that dials the name rather than the address will fail the same way until it resolves to %s",
+			name.URL, loopbackReason(name), bind.URL, loopbackOrUnknown(bind.Remote))
 	}
 	return fmt.Sprintf(
-		"%s, while pogod is HEALTHY on %s — do not restart it. Anything that dials the name (editor integrations, `ssh -L`, scripts) is talking to that process instead of the daemon. Identify it with `%s`, and note that pogod binds 127.0.0.1 only, so the impersonator keeps the port until it is stopped",
-		lead, bind.URL, loopbackLsofHint(name.Remote, port))
+		"%s reached %s, and the process there is NOT pogod (%s), while pogod is HEALTHY on %s — do not restart it. Anything that dials the name (editor integrations, `ssh -L`, scripts) is talking to that process instead of the daemon. Identify it with `%s`, and note that pogod binds 127.0.0.1 only, so the impersonator keeps the port until it is stopped",
+		name.URL, name.Remote, loopbackReason(name), bind.URL, loopbackLsofHint(name.Remote, port))
 }
 
 // loopbackLsofHint picks the listener query for the family the name actually

--- a/cmd/pogo/loopbackresolution.go
+++ b/cmd/pogo/loopbackresolution.go
@@ -48,7 +48,9 @@ package main
 // 200" are properties of any listener, not of pogod. The incident is precisely
 // a wrong process passing those tests, so a probe built on them would
 // reproduce the defect it is meant to detect, one layer up. The probe requires
-// health.LivenessBody — the one string only pogod emits.
+// health.LivenessBody — the string pogod's /health emits. Note the limit that
+// follows from this and is spelled out above: it identifies pogod-SHAPED
+// responders, so every pogod emits it and it cannot single out this one.
 //
 // WHY THE "NOTHING ANSWERS" CASE RENDERS NOTHING. Check 1 ("pogod running")
 // already says the daemon is down, and a checklist that reports every stopped
@@ -243,6 +245,16 @@ func loopbackShadowDetail(bind, name loopbackProbe, port int) string {
 // loopbackLsofHint picks the listener query for the family the name actually
 // landed on. A -i6TCP query when the shadow is on IPv4 lists nothing, and a
 // remedy that prints nothing reads as "the check was wrong".
+//
+// Its family-agnostic fallback (`-iTCP:<port>`) is currently UNREACHABLE: the
+// sole caller is the has-a-culprit branch of loopbackShadowDetail, which runs
+// only when name.Remote != "", and a remote address recorded by net always
+// splits and parses. It is kept because the alternative is a hint that names
+// the WRONG family if a future caller passes an address from somewhere less
+// well-formed, and a remedy that lists nothing reads as a wrong check. Stated
+// so the empty family is not misread as evidence that this row can emit a
+// familyless hint today — the round-1 test that pinned that form was removed
+// with the branch it covered.
 func loopbackLsofHint(remote string, port int) string {
 	family := ""
 	if host, _, err := net.SplitHostPort(remote); err == nil {

--- a/cmd/pogo/loopbackresolution.go
+++ b/cmd/pogo/loopbackresolution.go
@@ -1,0 +1,238 @@
+package main
+
+// The "loopback resolution" line in `pogo doctor --check` (mg-e314,
+// drellem2/pogo#110).
+//
+// WHAT IT DETECTS. A process that is not pogod answering on the daemon port
+// under the name `localhost`, while pogod itself is healthy on 127.0.0.1. On a
+// stock macOS /etc/hosts `localhost` resolves ::1 first; pogod binds
+// 127.0.0.1 only (config.DefaultBind), so ::1:<port> is free for anything else
+// to claim, and whatever claims it becomes pogod for every consumer that dials
+// the name. On 2026-07-31 a `kubectl port-forward` landed there after its IPv4
+// bind was refused and took the pogo control plane down for ~20 minutes. pogod
+// was up the entire time.
+//
+// WHY GO'S DUAL-STACK FALLBACK DOES NOT COVER THIS. Happy Eyeballs retries the
+// other family on connection REFUSED. The interloper is not refusing — it is
+// accepting and answering wrongly, which is indistinguishable from success at
+// every layer below this check.
+//
+// WHY IT IS NOT REDUNDANT WITH THE `ServerURL` FIX. The companion change in
+// this commit points the CLI at 127.0.0.1, so the CLI stops being fooled. It
+// does not empty the port: everything else that dials the NAME — editor
+// integrations (mg-b36f), a stale `ssh -L`, a forward on a reconfigured port,
+// a second daemon — still is. This check is what makes that condition visible
+// instead of silent, and it is why A ships with B rather than after it.
+//
+// WHY THE PROBE MATCHES ON A BODY. "The TCP dial succeeded" and even "HTTP
+// 200" are properties of any listener, not of pogod. The incident is precisely
+// a wrong process passing those tests, so a probe built on them would
+// reproduce the defect it is meant to detect, one layer up. The probe requires
+// health.LivenessBody — the one string only pogod emits.
+//
+// WHY THE "NOTHING ANSWERS" CASE RENDERS NOTHING. Check 1 ("pogod running")
+// already says the daemon is down, and a checklist that reports every stopped
+// daemon twice is a checklist people stop reading. This row speaks only when
+// the two addresses DISAGREE, which is the whole of what it knows that check 1
+// does not.
+//
+// WHY FAIL AND NOT WARN. Unlike the launchd and $POGO_HOME rows, the remedy is
+// not somebody else's ops decision — an impersonator on the daemon port makes
+// every answer the fleet reads untrustworthy, and it is fixed by killing one
+// process. That is worth doctor's exit code.
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptrace"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/drellem2/pogo/internal/health"
+)
+
+// loopbackCheckName is the doctor checklist row this renders on.
+const loopbackCheckName = "loopback resolution"
+
+// loopbackProbeTimeout bounds each of the two probes. Both targets are
+// loopback, so a live pogod answers in microseconds and a free port refuses
+// immediately; the budget exists for the third case — an interloper that
+// accepts the connection and then never writes a response, which is a hang,
+// not an error, and would otherwise wedge `doctor --check` indefinitely.
+const loopbackProbeTimeout = 2 * time.Second
+
+// loopbackBodyLimit caps how much of a stranger's response is read. The
+// identity signal is a short fixed string; anything past it is an unknown
+// process's output and there is no reason to hold it in memory.
+const loopbackBodyLimit = 4096
+
+// loopbackProbe is one answer to "is pogod behind this URL?".
+type loopbackProbe struct {
+	// URL is what was dialed, verbatim, so the finding can be reproduced by
+	// hand.
+	URL string
+	// Remote is the ip:port the dial actually LANDED on, which for a name is
+	// not derivable from the URL and is the single most useful fact in the
+	// failure: it names the address family that is shadowing the daemon.
+	// Empty when no connection was established.
+	Remote string
+	// IsPogod is true only when the responder emitted health.LivenessBody.
+	IsPogod bool
+	// Detail says why not, when IsPogod is false.
+	Detail string
+}
+
+// probePogod asks baseURL whether pogod is behind it, and records which
+// address the request actually reached.
+func probePogod(baseURL string, timeout time.Duration) loopbackProbe {
+	p := loopbackProbe{URL: baseURL}
+
+	req, err := http.NewRequest(http.MethodGet, strings.TrimSuffix(baseURL, "/")+"/health", nil)
+	if err != nil {
+		p.Detail = "malformed probe URL: " + err.Error()
+		return p
+	}
+	// The connection hook, not the URL, is how the landed-on address is
+	// learned. For "localhost" the URL says nothing about which family the
+	// resolver picked, and that is the fact the whole check turns on.
+	trace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			if info.Conn != nil && info.Conn.RemoteAddr() != nil {
+				p.Remote = info.Conn.RemoteAddr().String()
+			}
+		},
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+
+	// A dedicated client, never http.DefaultClient: the default has no
+	// timeout, so a listener that accepts and stays silent hangs doctor.
+	resp, err := (&http.Client{Timeout: timeout}).Do(req)
+	if err != nil {
+		p.Detail = "no answer: " + err.Error()
+		return p
+	}
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, loopbackBodyLimit))
+	if readErr != nil {
+		p.Detail = fmt.Sprintf("answered HTTP %d but the body could not be read: %s", resp.StatusCode, readErr)
+		return p
+	}
+	if resp.StatusCode != http.StatusOK {
+		p.Detail = fmt.Sprintf("answered HTTP %d, which pogod's /health never does", resp.StatusCode)
+		return p
+	}
+	if !strings.Contains(string(body), health.LivenessBody) {
+		p.Detail = fmt.Sprintf("answered HTTP 200 but the body is not pogod's (%s)", loopbackQuoteBody(body))
+		return p
+	}
+	p.IsPogod = true
+	return p
+}
+
+// loopbackQuoteBody renders a stranger's response for the finding: enough to
+// recognise what is on the port, never enough to flood the checklist.
+func loopbackQuoteBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return "empty body"
+	}
+	s = strings.Join(strings.Fields(s), " ")
+	const max = 120
+	if len(s) > max {
+		s = s[:max] + "…"
+	}
+	return "got " + strconv.Quote(s)
+}
+
+// loopbackResolutionLine renders one doctor check row from the two probes.
+//
+// The returned status is "" when the row must not render at all — see the
+// "nothing answers" case in the file comment. Callers must skip an empty
+// status rather than treating it as a pass.
+func loopbackResolutionLine(bind, name loopbackProbe, port int) (status, detail string) {
+	switch {
+	// pogod on the bind address, something else (or nothing) on the name.
+	// This is the incident.
+	case bind.IsPogod && !name.IsPogod:
+		return "fail", loopbackShadowDetail(bind, name, port)
+
+	// Neither answers as pogod: the daemon is simply down. Check 1 owns that
+	// finding; this row stays quiet rather than saying it a second time.
+	case !bind.IsPogod && !name.IsPogod:
+		return "", ""
+
+	// Reachable over the name but not on 127.0.0.1 — consistent with a `bind`
+	// set to a v6 loopback. Warn, not fail: the daemon IS answering, and this
+	// configuration is already half-broken today independently of this check
+	// (client.daemonBound probes 127.0.0.1, so the spawn-race guard would
+	// happily start a rival pogod). The row is the plain-language signal such
+	// a user currently gets nowhere.
+	case !bind.IsPogod && name.IsPogod:
+		return "warn", fmt.Sprintf(
+			"pogod answers on %s (reached %s) but NOT on %s: %s. The CLI dials the 127.0.0.1 address, so it will not find this daemon, and the spawn-race guard reads the port as free and may start a rival pogod. Set [server] bind to 127.0.0.1 (a v6 loopback must be written bracketed, \"[::1]\", or pogod refuses to start)",
+			name.URL, loopbackOrUnknown(name.Remote), bind.URL, loopbackReason(bind))
+	}
+
+	// Both answer as pogod. Say which address the name landed on: it is the
+	// difference between "v6 is free and Go fell back" and "pogod is bound
+	// where the name points", and only the second is durable.
+	return "pass", fmt.Sprintf("pogod answers on both %s and %s; the name reached %s",
+		bind.URL, name.URL, loopbackOrUnknown(name.Remote))
+}
+
+// loopbackShadowDetail writes the failure. It has to carry three things a
+// reader cannot reconstruct: that pogod is HEALTHY (so nobody restarts it),
+// which address is lying, and the one command that names the culprit.
+func loopbackShadowDetail(bind, name loopbackProbe, port int) string {
+	var lead string
+	if name.Remote == "" {
+		// The name never connected at all while the bind address did. Not the
+		// port-forward shape — this is a resolver or /etc/hosts that points
+		// the name somewhere pogod is not.
+		lead = fmt.Sprintf("%s could not be reached at all (%s)", name.URL, loopbackReason(name))
+	} else {
+		lead = fmt.Sprintf("%s reached %s, and the process there is NOT pogod (%s)",
+			name.URL, name.Remote, loopbackReason(name))
+	}
+	return fmt.Sprintf(
+		"%s, while pogod is HEALTHY on %s — do not restart it. Anything that dials the name (editor integrations, `ssh -L`, scripts) is talking to that process instead of the daemon. Identify it with `%s`, and note that pogod binds 127.0.0.1 only, so the impersonator keeps the port until it is stopped",
+		lead, bind.URL, loopbackLsofHint(name.Remote, port))
+}
+
+// loopbackLsofHint picks the listener query for the family the name actually
+// landed on. A -i6TCP query when the shadow is on IPv4 lists nothing, and a
+// remedy that prints nothing reads as "the check was wrong".
+func loopbackLsofHint(remote string, port int) string {
+	family := ""
+	if host, _, err := net.SplitHostPort(remote); err == nil {
+		if ip := net.ParseIP(host); ip != nil {
+			if ip.To4() == nil {
+				family = "6"
+			} else {
+				family = "4"
+			}
+		}
+	}
+	return fmt.Sprintf("lsof -nP -i%sTCP:%d -sTCP:LISTEN", family, port)
+}
+
+// loopbackReason renders a probe's failure cause, never an empty string: a
+// finding whose "why" is blank is a finding a reader has to re-derive.
+func loopbackReason(p loopbackProbe) string {
+	if p.Detail == "" {
+		return "no detail recorded"
+	}
+	return p.Detail
+}
+
+// loopbackOrUnknown names an address that may not have been observed.
+func loopbackOrUnknown(remote string) string {
+	if remote == "" {
+		return "an address that was not recorded"
+	}
+	return remote
+}

--- a/cmd/pogo/loopbackresolution_test.go
+++ b/cmd/pogo/loopbackresolution_test.go
@@ -1,0 +1,371 @@
+package main
+
+// Tests for the "loopback resolution" doctor row (mg-e314, drellem2/pogo#110).
+//
+// The load-bearing tests here are the POSITIVE CONTROLS: a check for silent
+// impersonation that has only ever been observed returning pass is itself a
+// silent impersonation of a check. Two of them run against real sockets —
+// TestLoopbackResolution_InterloperOnV6Fires binds a stranger to [::1]:<port>
+// and requires the check to FIRE, and TestLoopbackResolution_PassesOnceTheV6
+// PortIsFree removes it and requires the same code to go quiet — because
+// "fires when it should" and "does not fire when it should not" are two
+// claims, and a detector needs both.
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drellem2/pogo/internal/health"
+)
+
+const testProbeTimeout = 2 * time.Second
+
+// ---------------------------------------------------------------------------
+// The rendering, as a pure function over the two probes.
+// ---------------------------------------------------------------------------
+
+// TestLoopbackResolutionLine_ShadowedNameFails is the incident, in table form:
+// pogod healthy on the bind address, a stranger answering under the name.
+func TestLoopbackResolutionLine_ShadowedNameFails(t *testing.T) {
+	bind := loopbackProbe{URL: "http://127.0.0.1:10000", Remote: "127.0.0.1:10000", IsPogod: true}
+	name := loopbackProbe{
+		URL:     "http://localhost:10000",
+		Remote:  "[::1]:10000",
+		Detail:  "answered HTTP 200 but the body is not pogod's (got \"Handling connection for 10000\")",
+		IsPogod: false,
+	}
+	status, detail := loopbackResolutionLine(bind, name, 10000)
+	if status != "fail" {
+		t.Fatalf("status = %q, want fail — a shadowed name is the condition this row exists for", status)
+	}
+	// Each of these is a fact the reader cannot reconstruct from the others.
+	for _, want := range []string{
+		"[::1]:10000",                        // which address is lying
+		"HEALTHY",                            // so nobody restarts a working daemon
+		"do not restart it",                  //
+		"lsof -nP -i6TCP:10000 -sTCP:LISTEN", // the command that names the culprit
+	} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail is missing %q; got: %s", want, detail)
+		}
+	}
+}
+
+// TestLoopbackResolutionLine_UnreachableNameFailsWithoutInventingACulprit:
+// the name may fail to connect at all rather than reach an impostor. Still a
+// failure — the name does not lead to pogod — but the detail must not describe
+// a process it never saw.
+func TestLoopbackResolutionLine_UnreachableNameFailsWithoutInventingACulprit(t *testing.T) {
+	bind := loopbackProbe{URL: "http://127.0.0.1:10000", Remote: "127.0.0.1:10000", IsPogod: true}
+	name := loopbackProbe{URL: "http://localhost:10000", Detail: "no answer: lookup localhost: no such host"}
+	status, detail := loopbackResolutionLine(bind, name, 10000)
+	if status != "fail" {
+		t.Fatalf("status = %q, want fail", status)
+	}
+	if !strings.Contains(detail, "could not be reached at all") {
+		t.Errorf("detail should say the name never connected; got: %s", detail)
+	}
+	if strings.Contains(detail, "is NOT pogod") {
+		t.Errorf("detail describes a process that was never observed; got: %s", detail)
+	}
+	// No family was observed, so the hint must not narrow to one.
+	if !strings.Contains(detail, "lsof -nP -iTCP:10000") {
+		t.Errorf("hint should be family-agnostic when nothing was reached; got: %s", detail)
+	}
+}
+
+// TestLoopbackResolutionLine_QuietWhenNothingAnswers. Check 1 already reports a
+// stopped daemon. A checklist that says it twice is one people skim past, and
+// this row would then be skimmed past on the day it has something new to say.
+func TestLoopbackResolutionLine_QuietWhenNothingAnswers(t *testing.T) {
+	bind := loopbackProbe{URL: "http://127.0.0.1:10000", Detail: "no answer: connection refused"}
+	name := loopbackProbe{URL: "http://localhost:10000", Detail: "no answer: connection refused"}
+	status, detail := loopbackResolutionLine(bind, name, 10000)
+	if status != "" {
+		t.Errorf("status = %q (detail %q), want \"\" — a down daemon is check 1's finding, not this row's", status, detail)
+	}
+}
+
+// TestLoopbackResolutionLine_NameOnlyWarns is the fourth case: a daemon bound
+// to a v6 loopback. It warns rather than fails — the daemon IS answering — and
+// must say what breaks anyway, because that configuration is already unsafe.
+func TestLoopbackResolutionLine_NameOnlyWarns(t *testing.T) {
+	bind := loopbackProbe{URL: "http://127.0.0.1:10000", Detail: "no answer: connection refused"}
+	name := loopbackProbe{URL: "http://localhost:10000", Remote: "[::1]:10000", IsPogod: true}
+	status, detail := loopbackResolutionLine(bind, name, 10000)
+	if status != "warn" {
+		t.Fatalf("status = %q, want warn — the daemon answers, so this is not a fail", status)
+	}
+	for _, want := range []string{"rival pogod", "bind"} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("detail is missing %q; got: %s", want, detail)
+		}
+	}
+}
+
+// TestLoopbackResolutionLine_BothAnswerPasses, and names the address the name
+// landed on: "v6 was free and Go fell back" and "pogod is where the name
+// points" are different worlds and only one of them is stable.
+func TestLoopbackResolutionLine_BothAnswerPasses(t *testing.T) {
+	bind := loopbackProbe{URL: "http://127.0.0.1:10000", Remote: "127.0.0.1:10000", IsPogod: true}
+	name := loopbackProbe{URL: "http://localhost:10000", Remote: "127.0.0.1:10000", IsPogod: true}
+	status, detail := loopbackResolutionLine(bind, name, 10000)
+	if status != "pass" {
+		t.Fatalf("status = %q, want pass", status)
+	}
+	if !strings.Contains(detail, "the name reached 127.0.0.1:10000") {
+		t.Errorf("detail should name the address the name landed on; got: %s", detail)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The probe, against real HTTP responders.
+// ---------------------------------------------------------------------------
+
+// TestProbePogod_AcceptsOnlyPogodsBody. Every one of these responders would
+// pass a "the dial succeeded" probe, and all but the first would pass an "HTTP
+// 200" probe. That is the entire point: the interloper in the incident was a
+// port-forward returning 200s.
+func TestProbePogod_AcceptsOnlyPogodsBody(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    bool
+	}{
+		{"pogod", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, health.LivenessBody)
+		}, true},
+		{"port-forward chatter", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, "Handling connection for 10000")
+		}, false},
+		{"empty 200", func(w http.ResponseWriter, r *http.Request) {}, false},
+		{"someone else's json", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, `{"status":"ok"}`)
+		}, false},
+		{"404 from a different service", func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "not found", http.StatusNotFound)
+		}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+			got := probePogod(srv.URL, testProbeTimeout)
+			if got.IsPogod != tc.want {
+				t.Errorf("IsPogod = %v, want %v (detail %q)", got.IsPogod, tc.want, got.Detail)
+			}
+			if !got.IsPogod && got.Detail == "" {
+				t.Error("a negative probe recorded no reason")
+			}
+			if got.Remote == "" {
+				t.Error("Remote was not recorded for a connection that succeeded")
+			}
+		})
+	}
+}
+
+// TestProbePogod_NothingListening: no connection, no Remote, and a reason.
+func TestProbePogod_NothingListening(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	url := srv.URL
+	srv.Close() // frees the port; the probe now dials a closed one
+
+	got := probePogod(url, testProbeTimeout)
+	if got.IsPogod {
+		t.Fatal("IsPogod = true against a closed port")
+	}
+	if got.Remote != "" {
+		t.Errorf("Remote = %q for a connection that was never established", got.Remote)
+	}
+	if !strings.Contains(got.Detail, "no answer") {
+		t.Errorf("Detail = %q, want a transport reason", got.Detail)
+	}
+}
+
+// TestProbePogod_SilentListenerDoesNotHang. A listener that accepts and never
+// writes is neither an error nor a success — it is a hang, and it is exactly
+// what a half-open forward looks like. Without the client timeout this wedges
+// `doctor --check` forever.
+func TestProbePogod_SilentListenerDoesNotHang(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Hold it open, write nothing. Closed by the deferred ln.Close
+			// unblocking Accept, plus this handle going out of scope.
+			defer conn.Close()
+		}
+	}()
+
+	start := time.Now()
+	got := probePogod("http://"+ln.Addr().String(), 500*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if got.IsPogod {
+		t.Fatal("IsPogod = true against a listener that wrote nothing")
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("probe took %s against a silent listener; the client timeout is not being applied", elapsed)
+	}
+	ln.Close()
+	<-done
+}
+
+// ---------------------------------------------------------------------------
+// Positive controls, against real sockets on both loopback families.
+// ---------------------------------------------------------------------------
+
+// loopbackPair binds the SAME port on 127.0.0.1 and on ::1 — two distinct
+// sockets, which is the whole hazard — and returns both listeners.
+func loopbackPair(t *testing.T) (v4, v6 net.Listener, port int) {
+	t.Helper()
+	for attempt := 0; attempt < 25; attempt++ {
+		l6, err := net.Listen("tcp6", "[::1]:0")
+		if err != nil {
+			t.Skipf("no IPv6 loopback on this host, so the shadowing condition cannot be staged: %v", err)
+		}
+		p := l6.Addr().(*net.TCPAddr).Port
+		l4, err := net.Listen("tcp4", fmt.Sprintf("127.0.0.1:%d", p))
+		if err != nil {
+			// Something else already holds the v4 side of this port. Retry
+			// with a different one rather than reporting a host condition as
+			// a code failure.
+			l6.Close()
+			continue
+		}
+		return l4, l6, p
+	}
+	t.Skip("could not find a port free on both 127.0.0.1 and ::1 after 25 attempts")
+	return nil, nil, 0
+}
+
+// serveOn attaches an HTTP responder to an already-bound listener.
+func serveOn(t *testing.T, ln net.Listener, h http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(h)
+	srv.Listener.Close()
+	srv.Listener = ln
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func pogodHandler(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, health.LivenessBody) }
+
+// interloperHandler answers the way a `kubectl port-forward` does: promptly,
+// with a 200, and with something that is not pogod.
+func interloperHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "Handling connection for "+r.Host)
+}
+
+// TestLoopbackResolution_InterloperOnV6Fires is THE positive control.
+//
+// A real pogod-shaped responder on 127.0.0.1:<port>, a real stranger on
+// [::1]:<port>, and the same probe pair `pogo doctor --check` runs. It asserts
+// two things:
+//
+//   - Deterministically, on every host: probing the v6 address directly while
+//     the bind address holds pogod produces a FAIL. This is the claim that the
+//     check is capable of firing at all, and it does not depend on how this
+//     host orders localhost's addresses.
+//   - On hosts where `localhost` resolves ::1 first — macOS out of the box,
+//     and the configuration the incident happened on — the check fires through
+//     the NAME, which is the user-visible bug. Where the resolver prefers IPv4
+//     the CLI was never shadowed in the first place, so the test asserts the
+//     pass and says which world it observed rather than skipping silently.
+func TestLoopbackResolution_InterloperOnV6Fires(t *testing.T) {
+	l4, l6, port := loopbackPair(t)
+	serveOn(t, l4, pogodHandler)
+	serveOn(t, l6, interloperHandler)
+
+	bindURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	v6URL := fmt.Sprintf("http://[::1]:%d", port)
+	nameURL := fmt.Sprintf("http://localhost:%d", port)
+
+	bind := probePogod(bindURL, testProbeTimeout)
+	if !bind.IsPogod {
+		t.Fatalf("the staged pogod on %s did not answer as pogod: %s", bindURL, bind.Detail)
+	}
+
+	// (1) Host-independent: the check FIRES on the shadowing condition.
+	v6 := probePogod(v6URL, testProbeTimeout)
+	if v6.IsPogod {
+		t.Fatalf("the staged interloper on %s was read AS pogod — the probe cannot tell them apart, which is the defect this check exists to detect", v6URL)
+	}
+	status, detail := loopbackResolutionLine(bind, v6, port)
+	if status != "fail" {
+		t.Fatalf("status = %q with pogod on %s and a stranger on %s; want fail. A check that cannot return fail has never been shown to work", status, bindURL, v6URL)
+	}
+	if !strings.Contains(detail, "[::1]:"+fmt.Sprint(port)) {
+		t.Errorf("the failure does not name the shadowing address; got: %s", detail)
+	}
+
+	// (2) Through the name, as a user experiences it.
+	name := probePogod(nameURL, testProbeTimeout)
+	nameStatus, nameDetail := loopbackResolutionLine(bind, name, port)
+	switch {
+	case name.Remote == "":
+		t.Fatalf("probing %s connected to nothing: %s", nameURL, name.Detail)
+	case strings.HasPrefix(name.Remote, "[::1]"):
+		t.Logf("this host resolves localhost to ::1 first (reached %s) — the incident's configuration", name.Remote)
+		if nameStatus != "fail" {
+			t.Fatalf("status = %q, want fail: the name reached the interloper at %s and the check did not notice (%s)",
+				nameStatus, name.Remote, nameDetail)
+		}
+	default:
+		t.Logf("this host resolves localhost to IPv4 first (reached %s), so the name is not shadowed here", name.Remote)
+		if nameStatus != "pass" {
+			t.Fatalf("status = %q, want pass: the name reached pogod at %s (%s)", nameStatus, name.Remote, nameDetail)
+		}
+	}
+}
+
+// TestLoopbackResolution_PassesOnceTheV6PortIsFree is the other half of the
+// control: the SAME staging with the interloper removed must go quiet. Without
+// it, "fires on the bad case" is compatible with "fires on everything", which
+// is a check that gets muted and then ignored.
+func TestLoopbackResolution_PassesOnceTheV6PortIsFree(t *testing.T) {
+	l4, l6, port := loopbackPair(t)
+	// Free the v6 side immediately: this is the healthy world, where nothing
+	// holds ::1:<port> and Go's dual-stack fallback carries the name to pogod.
+	if err := l6.Close(); err != nil {
+		t.Fatalf("closing the v6 listener: %v", err)
+	}
+	serveOn(t, l4, pogodHandler)
+
+	bind := probePogod(fmt.Sprintf("http://127.0.0.1:%d", port), testProbeTimeout)
+	name := probePogod(fmt.Sprintf("http://localhost:%d", port), testProbeTimeout)
+	status, detail := loopbackResolutionLine(bind, name, port)
+	if status != "pass" {
+		t.Fatalf("status = %q (%s) with pogod on 127.0.0.1:%d and ::1:%d free; want pass — this check must not fire on a healthy host",
+			status, detail, port, port)
+	}
+}
+
+// TestLoopbackResolution_QuietWhenTheDaemonIsSimplyDown, end to end: neither
+// family holds the port, so the row renders nothing at all.
+func TestLoopbackResolution_QuietWhenTheDaemonIsSimplyDown(t *testing.T) {
+	l4, l6, port := loopbackPair(t)
+	l4.Close()
+	l6.Close()
+
+	bind := probePogod(fmt.Sprintf("http://127.0.0.1:%d", port), testProbeTimeout)
+	name := probePogod(fmt.Sprintf("http://localhost:%d", port), testProbeTimeout)
+	if status, detail := loopbackResolutionLine(bind, name, port); status != "" {
+		t.Errorf("status = %q (%s) with nothing on either family; want a silent row", status, detail)
+	}
+}

--- a/cmd/pogo/loopbackresolution_test.go
+++ b/cmd/pogo/loopbackresolution_test.go
@@ -73,9 +73,59 @@ func TestLoopbackResolutionLine_UnreachableNameFailsWithoutInventingACulprit(t *
 	if strings.Contains(detail, "is NOT pogod") {
 		t.Errorf("detail describes a process that was never observed; got: %s", detail)
 	}
-	// No family was observed, so the hint must not narrow to one.
-	if !strings.Contains(detail, "lsof -nP -iTCP:10000") {
-		t.Errorf("hint should be family-agnostic when nothing was reached; got: %s", detail)
+	// Nothing answered, so there is no culprit. A remedy that sends an operator
+	// hunting a process on a host whose name simply does not resolve wastes
+	// exactly the time this row exists to save (review round 1, advisory).
+	if !strings.Contains(detail, "no process to hunt") {
+		t.Errorf("detail must say there is nothing to find; got: %s", detail)
+	}
+	if !strings.Contains(detail, "not an impersonator") {
+		t.Errorf("detail must rule the impersonator reading out explicitly; got: %s", detail)
+	}
+	// The remedy must not be the culprit-hunting one. "impersonator" is fine in
+	// the negation above, so this checks the ACTIONS a reader would take.
+	for _, forbidden := range []string{"lsof", "talking to that process", "keeps the port until it is stopped"} {
+		if strings.Contains(detail, forbidden) {
+			t.Errorf("detail sends the reader hunting a process that was never observed (%q); got: %s", forbidden, detail)
+		}
+	}
+}
+
+// TestLoopbackResolutionLine_SecondPogodPassesButSaysSo. A second pogod on the
+// v6 loopback emits health.LivenessBody like any other, so BOTH probes report
+// pogod and this row passes. That case is genuinely not detected — the body
+// match separates pogod-shaped from not-pogod-shaped, never THIS pogod from
+// ANOTHER — and the green line must therefore not read as an all-clear for it
+// (review round 1, blocking). The row states the observation it does hold: the
+// name landed somewhere other than the bind address.
+func TestLoopbackResolutionLine_SecondPogodPassesButSaysSo(t *testing.T) {
+	bind := loopbackProbe{URL: "http://127.0.0.1:10000", Remote: "127.0.0.1:10000", IsPogod: true}
+	name := loopbackProbe{URL: "http://localhost:10000", Remote: "[::1]:10000", IsPogod: true}
+	status, detail := loopbackResolutionLine(bind, name, 10000)
+	if status != "pass" {
+		t.Fatalf("status = %q, want pass — this row cannot tell two pogods apart and must not pretend to", status)
+	}
+	for _, want := range []string{
+		"NOT the address pogod was probed on", // the observation it does hold
+		"SECOND pogod",                        // the case it does not cover, named
+		"does not tell them apart",            // its own limit, stated
+		"start_time",                          // where to actually settle it
+	} {
+		if !strings.Contains(detail, want) {
+			t.Errorf("pass line is missing %q, so a reader chasing a second daemon reads green as an all-clear; got: %s", want, detail)
+		}
+	}
+}
+
+// TestLoopbackResolutionLine_PassStaysQuietWhenTheNameLandsOnTheBindAddress.
+// The caveat above is bought with words on every healthy run if it fires
+// unconditionally. It must appear only when there is something to explain.
+func TestLoopbackResolutionLine_PassStaysQuietWhenTheNameLandsOnTheBindAddress(t *testing.T) {
+	bind := loopbackProbe{URL: "http://127.0.0.1:10000", Remote: "127.0.0.1:10000", IsPogod: true}
+	name := loopbackProbe{URL: "http://localhost:10000", Remote: "127.0.0.1:10000", IsPogod: true}
+	_, detail := loopbackResolutionLine(bind, name, 10000)
+	if strings.Contains(detail, "SECOND pogod") {
+		t.Errorf("the second-daemon caveat fired on an ordinary healthy pass; got: %s", detail)
 	}
 }
 

--- a/cmd/pogo/main.go
+++ b/cmd/pogo/main.go
@@ -2905,6 +2905,7 @@ With --check, runs a deterministic health checklist and exits:
 
 The --check mode verifies:
   - Is pogod running?
+  - Does "localhost:<port>" reach pogod, or is another process shadowing it?
   - Is the system service installed?
   - Does every installed launchd plist match the plist this build renders?
   - Are required tools installed (git, go, the configured agent harness)?
@@ -2982,6 +2983,27 @@ Exits with code 1 if any critical check fails (--check mode only).`,
 				fail("pogod running", "server is not reachable")
 			} else {
 				pass("pogod running", "")
+			}
+
+			// 1b. Does the loopback NAME reach the daemon check 1 just
+			// probed? pogod binds 127.0.0.1 only, so ::1:<port> is free for
+			// any other process to claim, and whatever claims it answers for
+			// pogod to everything that dials "localhost" — the shape of the
+			// 2026-07-31 outage (drellem2/pogo#110). This row speaks only
+			// when the two addresses disagree; see loopbackresolution.go.
+			{
+				loopCfg := config.Load()
+				bindProbe := probePogod("http://"+loopCfg.DialAddr(), loopbackProbeTimeout)
+				nameProbe := probePogod(fmt.Sprintf("http://localhost:%d", loopCfg.Port), loopbackProbeTimeout)
+				lbStatus, lbDetail := loopbackResolutionLine(bindProbe, nameProbe, loopCfg.Port)
+				switch lbStatus {
+				case "fail":
+					fail(loopbackCheckName, lbDetail)
+				case "warn":
+					warn(loopbackCheckName, lbDetail)
+				case "pass":
+					pass(loopbackCheckName, lbDetail)
+				}
 			}
 
 			// 2. System service installed?

--- a/cmd/pogod/main.go
+++ b/cmd/pogod/main.go
@@ -472,7 +472,11 @@ func (p schedulerMailChecks) HasMailCheck(agentIdentity string) bool {
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Println("Visited /health")
-	fmt.Fprintf(w, "pogo is up and bouncing")
+	// health.LivenessBody, not a literal: doctor's loopback-resolution check
+	// tells pogod apart from an impersonator by this exact string, and a
+	// second copy here is a copy that can drift while the check keeps
+	// reporting pass (drellem2/pogo#110).
+	fmt.Fprint(w, health.LivenessBody)
 }
 
 // versionInfo is the JSON body of GET /version. It reports the RUNNING

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1748,8 +1748,30 @@ func Load() *Config {
 }
 
 // ServerURL returns the base URL for connecting to the pogo daemon.
+//
+// It targets 127.0.0.1 and NOT "localhost", for the same reason DialAddr does
+// (drellem2/pogo#110). pogod binds 127.0.0.1 (DefaultBind), while on a stock
+// macOS /etc/hosts the name resolves ::1 first — an address pogod never holds
+// and any other process may claim. Whatever claims it becomes pogod for every
+// caller of this function. Go's dual-stack fallback does not save us: it
+// retries the other family on connection REFUSED, and an interloper that
+// accepts and answers wrongly never refuses. A `kubectl port-forward` that
+// landed on ::1:10000 after its IPv4 bind was refused took the pogo control
+// plane down for ~20 minutes on 2026-07-31 while pogod stayed healthy
+// throughout.
+//
+// Both callers want the address rather than the name: internal/client funnels
+// every CLI command through it, and internal/selfdrift's RunningRev reports on
+// the daemon's build identity — under shadowing it read the interloper and
+// reported a healthy daemon as unreachable.
+//
+// The cost is a daemon deliberately configured with a v6-loopback `bind`,
+// which this stops reaching over the name. That configuration is already
+// half-broken: DialAddr — what the spawn-race guard probes — has never found
+// it, so a rival pogod could be started against it. `pogo doctor --check`'s
+// loopback-resolution row reports that case in plain language.
 func (c *Config) ServerURL() string {
-	return fmt.Sprintf("http://localhost:%d", c.Port)
+	return fmt.Sprintf("http://127.0.0.1:%d", c.Port)
 }
 
 // ListenAddr returns the address string for the server to listen on.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -293,10 +293,28 @@ port = 8080
 	}
 }
 
+// TestServerURL pins the ADDRESS, not the name. "localhost" resolves ::1 first
+// on a stock macOS while pogod binds 127.0.0.1, so the name reaches an address
+// pogod never holds and anything else may claim (drellem2/pogo#110).
 func TestServerURL(t *testing.T) {
 	cfg := &Config{Port: 12345}
-	if got := cfg.ServerURL(); got != "http://localhost:12345" {
-		t.Errorf("expected http://localhost:12345, got %s", got)
+	if got := cfg.ServerURL(); got != "http://127.0.0.1:12345" {
+		t.Errorf("expected http://127.0.0.1:12345, got %s", got)
+	}
+	if strings.Contains(cfg.ServerURL(), "localhost") {
+		t.Errorf("ServerURL resolved through the name %q; the CLI must dial the loopback address so a process on ::1:%d cannot impersonate pogod", cfg.ServerURL(), cfg.Port)
+	}
+}
+
+// TestServerURLAgreesWithDialAddr. The two are answers to the same question —
+// "where is pogod" — asked by different layers: DialAddr by the spawn-race
+// guard, ServerURL by every CLI command. They disagreed for the whole of
+// drellem2/pogo#110, which is how the guard could see a free port while the
+// CLI talked to an impostor. Nothing but this test holds them together.
+func TestServerURLAgreesWithDialAddr(t *testing.T) {
+	cfg := &Config{Port: 12345}
+	if want := "http://" + cfg.DialAddr(); cfg.ServerURL() != want {
+		t.Errorf("ServerURL() = %q but DialAddr() implies %q; the probe and the CLI must target the same socket", cfg.ServerURL(), want)
 	}
 }
 

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -4,6 +4,18 @@ package health
 
 import "time"
 
+// LivenessBody is the exact body GET /health returns. It is exported because
+// it is the only thing that distinguishes pogod from ANY other process that
+// happens to be answering on the daemon port: a `kubectl port-forward`, an
+// `ssh -L`, a second daemon. A probe that treats "the TCP dial succeeded" or
+// even "HTTP 200" as proof of pogod is exactly what let an interloper on
+// ::1:10000 be read as a healthy pogod for ~20 minutes on 2026-07-31
+// (drellem2/pogo#110), so the loopback-resolution check in `pogo doctor
+// --check` matches on this string. Both the handler and that probe must read
+// it from here — two copies of the literal is one copy that can go stale
+// while the check keeps reporting pass.
+const LivenessBody = "pogo is up and bouncing"
+
 // FullResponse is the JSON response for GET /health/full.
 type FullResponse struct {
 	Pogod    Pogod    `json:"pogod"`


### PR DESCRIPTION
`config.ServerURL()` returned `http://localhost:<port>` while pogod binds `127.0.0.1`. On a stock macOS `/etc/hosts` the name resolves `::1` first — an address pogod never holds and any other process may claim — so whatever claims it answers as pogod for every caller. Go's dual-stack fallback does not help: it retries the other family on connection *refused*, and an interloper that accepts and answers wrongly never refuses. A `kubectl port-forward` that landed on `::1:10000` took the control plane down for ~20 minutes on 2026-07-31 while **pogod stayed healthy throughout** — every instrument pointed at a working daemon and reported a broken one.

Both parts of the approved recommendation ship here, A written first.

> **Scope correction (review round 1, blocking).** An earlier version of this PR and of the approved recommendation said the row makes "a second daemon" visible. **It does not.** A second pogod emits `health.LivenessBody` like any other, so both probes report pogod and the row passes — likewise a forward whose far end is a real pogod. The row detects a responder on the name that is **not pogod-shaped**; it cannot tell *this* pogod from *another*. The reviewer staged two real pogods and demonstrated the green line. The recommendation over-promised; this is on the record rather than quietly dropped. Corrected in the file comment, the changelog and here, and the pass line now names its own limit where an operator will actually read it.

### A. `pogo doctor --check`: a `loopback resolution` row

Extracted as a testable helper (`cmd/pogo/loopbackresolution.go`) rather than an inline closure, per the recommendation's condition.

| bind addr | name | row |
|---|---|---|
| answers | answers | pass, naming which address the *name* landed on |
| answers | does not | **FAIL** — says pogod is HEALTHY and must not be restarted, names the shadowing address, prints the `lsof` query for the family actually reached |
| neither | | **renders nothing** — check 1 already reports a down daemon |
| does not | answers | **warn** — a v6-loopback `bind`, which this change does stop reaching over the name |

The probe requires `health.LivenessBody` (now shared between pogod's handler and the probe, so the two cannot drift apart while the check keeps reporting pass). "The dial succeeded" and "HTTP 200" are properties of *any* listener — the incident is precisely a wrong process passing both — so a probe built on them would reproduce, one layer up, the defect it exists to detect. It carries a client timeout: a listener that accepts and never writes is a hang, not an error.

### B. Dial `127.0.0.1`

One line, plus the `TestServerURL` update. It repairs both non-test callers: `internal/client` (every CLI command) and `selfdrift.RunningRev`, which under shadowing read the interloper and reported a healthy daemon as `RevUnreachable`. A new test pins `ServerURL()` equal to `DialAddr()` — their disagreement is what let the spawn-race guard see a free port while the CLI talked to an impostor.

## Both directions observed, with the built binary

A green check that has never been seen red is worthless here, since the bug's whole nature is silent impersonation. All four states were staged against **real sockets** on a sandboxed pogod at `127.0.0.1:10981` (never the live daemon on :10000):

1. **Baseline** — `::1:10981` free → `✓ loopback resolution   pogod answers on both ... the name reached 127.0.0.1:10981`.
2. **Positive control** — a Python responder bound to `[::1]:10981` returning `200 Handling connection for 10981`. `lsof` showed both listeners; `curl localhost:10981` returned the **impostor** while `curl 127.0.0.1:10981` returned pogod. The check reported `✗ loopback resolution` naming `[::1]:10981` and `lsof -nP -i6TCP:10981 -sTCP:LISTEN`, and **`doctor --check` exited 1**. `pogo status` still read the true daemon — part B working.
3. **Impostor removed** → the same code returned the row to `✓`.
4. **Daemon stopped** → row absent, only `✗ pogod running`. **`pogod --bind "[::1]"`** → the warn row.

In the suite: `TestLoopbackResolution_InterloperOnV6Fires` binds both families of one port and requires a fail (it logged that this host resolves `localhost`→`::1` first, so the fail path ran through the real name); `..._PassesOnceTheV6PortIsFree` requires the same code to go quiet. `TestProbePogod_AcceptsOnlyPogodsBody` feeds it five responders that would all pass a dial-succeeded probe and four that would pass an HTTP-200 one.

## Notes for the reviewer

- **`Refs`, not `Resolves`.** The work item directs citing the issue as `Refs drellem2/pogo#110`; the repo's `commit-msg` hook and the refinery both reject closing keywords. Closing #110 is left to a human.
- **One deviation from the recommendation's literal wording, and why.** The table says "compare `DialAddr()` against `ServerURL()`". Taken literally that degenerates once B lands — `ServerURL()` *becomes* the dial address, so the check would compare an address to itself and could never fail, which is exactly the "detector that reproduces the defect" failure this ticket warns about. The row therefore probes the literal name `localhost:<port>` against `DialAddr()`, which is the recommendation's intent ("a loopback-resolution check") and stays meaningful after B. Flagging it explicitly rather than silently.
- **Residual, as predicted.** A daemon deliberately bound to a v6 loopback loses `HealthCheck` over the name. That config is already half-broken (`DialAddr` has never found it, so the spawn-race guard may start a rival pogod); state 4 above is the plain-language signal such a user currently gets nowhere. `bind` remains undocumented in `docs/CONFIGURATION.md` — left alone as out of scope.
- **`gh#110`'s editor-integration sibling is untouched.** mg-b36f is assigned to Daniel. This change makes it *easier*: the doctor row detects the shadowing editors suffer from, so whoever picks it up has a detector already on the checklist and does not need to build one. It does not fix them — they are not `ServerURL()` callers and carry their own `localhost:10000` defaults.
- **One pre-existing, load-caused test failure, not touched.** `internal/refinery/TestGateWatchMeasuresARealSubtreesCPU` failed at host load ~57 ("a spinning gate peaked at 0.35 cores"). Verified pre-existing: unmodified `main` in a scratch worktree failed identically (0.30 cores) at the same load. It passed on the final gate run. Reported rather than loosened.

**Verification:** `./build.sh` from this non-ephemeral worktree — **exit 0, zero failures**.

Refs drellem2/pogo#110

Approved triage recommendation: mg-0803 (pm-pogo sign-off 2026-08-04T20:13:18Z; human go/no-go given)
Work item: mg-e314

