### PR TITLE
fix: start-orchestration restarts agents and clears StopAll's latch after the drain, and the CLI names what came back

### DIFF
--- a/changelog.d/mg-4b01.fixed.md
+++ b/changelog.d/mg-4b01.fixed.md
@@ -1,0 +1,47 @@
+- **`pogo server start` against a stopped daemon now actually restarts the crew,
+  re-arms crash-respawn, and names what came back (mg-4b01, drellem2/pogo#108).**
+  A full → index-only → full round-trip used to leave a running daemon with no
+  crew agents *and* no working crash-respawn, while the CLI printed
+  "Orchestration restarted" and exited zero. Three symptoms, one defect: the
+  transition did half its job and reported all of it.
+
+  - **`transitionToFull` never touched the agent registry.** It resolved the
+    refinery starter, swapped the refinery, flipped the mode, and returned. There
+    was no agent-side analogue of `SetRefineryStarter`, and `AutoStartAgents` had
+    exactly one non-test caller — the boot path. Two docstrings already claimed
+    the behaviour that was not there. There is now a `SetAgentStarter` hook, wired
+    in `cmd/pogod` beside the refinery one, and the transition **re-runs the
+    auto-start sweep**: the desired state is what the prompt frontmatter declares,
+    the same rule boot applies, not "whatever happened to be running before the
+    stop". `[agents] autostart = false` suppresses it exactly as it suppresses
+    boot — a mode round-trip is not a side door around the config.
+
+  - **`StopAll`'s shutdown latch was one-way.** It was set on stop and cleared
+    nowhere in the tree, so after a single stop-orchestration `restart_on_crash`
+    was inert for the life of the process. It read healthy on every instrument:
+    `Spawn` never consulted the latch, so `pogo agent start` kept working and the
+    fleet looked hand-recoverable — right up until something crashed. `Resume()`
+    now clears it, and `Registry.Generation()` /`RespawnFromGeneration()` make the
+    clear safe: the latch bumps a generation on **both** edges, and a deferred
+    respawn carries the generation it was scheduled in. pogod's `OnExit` hook
+    sleeps 2s before respawning while `StopAll` returns synchronously, so a
+    teardown-scheduled respawn fires *after* the drain returns — and a stop→start
+    inside that window would have cleared the latch in time to admit it. The
+    generation closes that by construction rather than by timing.
+
+  - **The CLI reported success regardless.** It now prints the daemon's report:
+    which crew agents started, which were already running, which are parked
+    (down on purpose, not casualties), which **failed** and why — and states
+    that polecats are not restored, so their absence is not read as more of the
+    same bug. When nothing started it says why: autostart disabled, or no prompt
+    declaring `auto_start = true`. A crew agent that *errored* on spawn exits
+    non-zero; restoring zero agents because none are eligible stays exit 0. The
+    `--json` form carries the whole report under `report`, and
+    `POST /server/start-orchestration` returns it (the `mode` field is unchanged,
+    so existing readers still work).
+
+  The regression tests run against a **real `agent.Registry`** with real
+  processes. That is the point, not a detail: all sixteen `New(...)` call sites
+  in the existing server suite pass a nil registry, and `transitionToIndexOnly`
+  guards with `if agents != nil`, so the suite was structurally incapable of
+  seeing this. A test was not missing — the harness could not have failed.

--- a/cmd/pogo/main.go
+++ b/cmd/pogo/main.go
@@ -175,8 +175,20 @@ Child commands include start, stop, and status.`,
 	var cmdServerStart = &cobra.Command{
 		Use:   "start",
 		Short: "Start the pogo server",
-		Long:  `Start the pogo server.`,
-		Args:  cobra.MinimumNArgs(0),
+		Long: `Start the pogo server.
+
+If the server is already running in index-only mode (after 'pogo server
+stop-orchestration'), this restarts orchestration instead: the refinery comes
+back, crash-respawn is re-armed, and the crew auto-start sweep is re-run.
+
+It then reports what actually came back, by name — which crew agents started,
+which were already running, which are parked, and which failed. Polecats are
+ephemeral and are never restored; they are re-dispatched per work item.
+
+Crew agents are not restarted when the daemon runs with [agents] autostart =
+false; the output says so rather than reporting an empty success. Exits
+non-zero if any crew agent errored while starting.`,
+		Args: cobra.MinimumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			err := client.HealthCheck()
 			if err != nil {
@@ -206,16 +218,30 @@ Child commands include start, stop, and status.`,
 				if !jsonOutput {
 					fmt.Println("Restarting orchestration...")
 				}
-				if err := client.StartOrchestration(); err != nil {
+				report, err := client.StartOrchestration()
+				if err != nil {
 					cli.ExitWithError(jsonOutput, err.Error(), cli.ExitError)
 				}
 				if jsonOutput {
 					cli.PrintJSON(map[string]interface{}{
 						"status":  "started",
-						"message": "orchestration restarted",
+						"message": orchestrationRestartSummary(report),
+						"report":  report,
 					})
 				} else {
 					fmt.Println("Orchestration restarted")
+					for _, line := range orchestrationRestartLines(report) {
+						fmt.Println("  " + line)
+					}
+				}
+				// A crew agent that ERRORED on spawn is a failure of the
+				// restart, not a detail of it, so the exit code says so —
+				// after the report has been printed, so the operator gets the
+				// names either way. Restoring zero agents because none are
+				// eligible (or because [agents] autostart = false) is not an
+				// error and stays exit 0; that case is reported in words.
+				if len(report.AgentsFailed) > 0 {
+					os.Exit(cli.ExitError)
 				}
 				return
 			}

--- a/cmd/pogo/startorchestration.go
+++ b/cmd/pogo/startorchestration.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/drellem2/pogo/internal/server"
+)
+
+// This file renders pogod's StartReport for `pogo server start` when that
+// command finds the daemon in index-only mode and restarts orchestration.
+//
+// It exists because the old output was one unconditional line — "Orchestration
+// restarted" — printed with a zero exit whether or not a single agent came
+// back. gh #108 is exactly that: the transition restored nothing, and the CLI
+// could not tell the operator, because it was never told either. A green
+// return is what the defect already produces, so naming the fleet is not
+// cosmetic; it is the part of the fix an operator can actually see.
+
+// orchestrationRestartLines renders the human-readable detail lines for a
+// restart, one per fact. Every line names something: which agents came back,
+// which were already up, which are parked, which failed, and what is
+// deliberately not restored.
+func orchestrationRestartLines(r server.StartReport) []string {
+	if r.AlreadyFull {
+		return []string{"Already in full mode — nothing was stopped, so nothing was restarted."}
+	}
+
+	var lines []string
+	if r.RefineryRestarted {
+		lines = append(lines, "Refinery: restarted.")
+	} else {
+		lines = append(lines, "Refinery: NOT restarted (the daemon has no refinery starter configured).")
+	}
+
+	if len(r.AgentsStarted) > 0 {
+		lines = append(lines, fmt.Sprintf("Crew agents started (%d): %s",
+			len(r.AgentsStarted), strings.Join(r.AgentsStarted, ", ")))
+	}
+	if len(r.AgentsAlreadyRunning) > 0 {
+		lines = append(lines, fmt.Sprintf("Crew agents already running (%d): %s",
+			len(r.AgentsAlreadyRunning), strings.Join(r.AgentsAlreadyRunning, ", ")))
+	}
+	if len(r.AgentsParked) > 0 {
+		lines = append(lines, fmt.Sprintf("Crew agents left parked (%d): %s — down on purpose; wake with 'pogo agent wake <name>'.",
+			len(r.AgentsParked), strings.Join(r.AgentsParked, ", ")))
+	}
+	for _, f := range r.AgentsFailed {
+		lines = append(lines, fmt.Sprintf("Crew agent FAILED to start: %s — %s", f.Name, f.Error))
+	}
+
+	// The "nothing came back" cases, each said out loud with its reason. This
+	// is the branch the reporter hit; silence here is the whole bug.
+	if len(r.AgentsStarted) == 0 && len(r.AgentsAlreadyRunning) == 0 && len(r.AgentsFailed) == 0 {
+		switch {
+		case r.AgentStartSkipped != "":
+			lines = append(lines, "No crew agents started: "+r.AgentStartSkipped)
+		default:
+			lines = append(lines, "No crew agents started — no crew prompt declares auto_start = true.")
+		}
+	} else if r.AgentStartSkipped != "" {
+		lines = append(lines, "Crew auto-start sweep did not run: "+r.AgentStartSkipped)
+	}
+
+	// Always stated, including when the sweep restored a full crew. Polecats
+	// are ephemeral and correctly stay gone; an operator who is not told that
+	// reads their absence as more of the same defect.
+	lines = append(lines, "Polecats are NOT restored — they are ephemeral and are re-dispatched per work item.")
+	return lines
+}
+
+// orchestrationRestartSummary is the one-line form used as the `message` field
+// in --json output, where the structured report sits beside it.
+func orchestrationRestartSummary(r server.StartReport) string {
+	if r.AlreadyFull {
+		return "already in full mode; nothing restarted"
+	}
+	parts := []string{fmt.Sprintf("orchestration restarted; %d crew agents started", len(r.AgentsStarted))}
+	if len(r.AgentsFailed) > 0 {
+		parts = append(parts, fmt.Sprintf("%d failed to start", len(r.AgentsFailed)))
+	}
+	if r.AgentStartSkipped != "" {
+		parts = append(parts, "auto-start sweep skipped: "+r.AgentStartSkipped)
+	}
+	parts = append(parts, "polecats not restored")
+	return strings.Join(parts, "; ")
+}

--- a/cmd/pogo/startorchestration_test.go
+++ b/cmd/pogo/startorchestration_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/drellem2/pogo/internal/server"
+)
+
+// The reporter's symptom was a command that returns "full mode" without saying
+// which agents actually restarted. These tests assert the output NAMES things,
+// because a message that merely stops lying — "restarted, possibly nothing" —
+// would leave the same operator trap in place.
+
+func joined(lines []string) string { return strings.Join(lines, "\n") }
+
+func TestRestartLinesNameTheAgentsThatCameBack(t *testing.T) {
+	out := joined(orchestrationRestartLines(server.StartReport{
+		Mode:              "full",
+		RefineryRestarted: true,
+		AgentsStarted:     []string{"mayor", "pm-pogo"},
+	}))
+
+	for _, want := range []string{"mayor", "pm-pogo", "Refinery: restarted"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output does not mention %q:\n%s", want, out)
+		}
+	}
+	if !strings.Contains(out, "Polecats are NOT restored") {
+		t.Errorf("output does not say polecats stay gone; their absence would read as the bug:\n%s", out)
+	}
+}
+
+func TestRestartLinesSayWhyNothingStarted(t *testing.T) {
+	cases := []struct {
+		name   string
+		report server.StartReport
+		want   string
+	}{
+		{
+			name:   "autostart disabled",
+			report: server.StartReport{Mode: "full", AgentStartSkipped: "[agents] autostart = false"},
+			want:   "[agents] autostart = false",
+		},
+		{
+			name:   "no eligible prompts",
+			report: server.StartReport{Mode: "full"},
+			want:   "no crew prompt declares auto_start = true",
+		},
+		{
+			name:   "already full",
+			report: server.StartReport{Mode: "full", AlreadyFull: true},
+			want:   "nothing was restarted",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := joined(orchestrationRestartLines(tc.report))
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("output does not explain the empty restart (%q):\n%s", tc.want, out)
+			}
+		})
+	}
+}
+
+// A partial restore is not a success. The failing agent is named, with its
+// error, on the line an operator reads.
+func TestRestartLinesNameFailedAgents(t *testing.T) {
+	out := joined(orchestrationRestartLines(server.StartReport{
+		Mode:              "full",
+		RefineryRestarted: true,
+		AgentsStarted:     []string{"mayor"},
+		AgentsFailed:      []server.AgentStartFailure{{Name: "gc", Error: "pty start: no ptys"}},
+	}))
+
+	if !strings.Contains(out, "gc") || !strings.Contains(out, "no ptys") {
+		t.Errorf("output does not name the failed agent and its error:\n%s", out)
+	}
+	if !strings.Contains(out, "FAILED") {
+		t.Errorf("a failed spawn is not marked as a failure:\n%s", out)
+	}
+}
+
+func TestRestartLinesNameParkedAndAlreadyRunning(t *testing.T) {
+	out := joined(orchestrationRestartLines(server.StartReport{
+		Mode:                 "full",
+		RefineryRestarted:    true,
+		AgentsAlreadyRunning: []string{"mayor"},
+		AgentsParked:         []string{"sleepy"},
+	}))
+
+	if !strings.Contains(out, "already running") || !strings.Contains(out, "mayor") {
+		t.Errorf("output does not name the agents that were already up:\n%s", out)
+	}
+	// A parked agent is down on purpose. Left unlabelled it reads as a
+	// casualty of the restart.
+	if !strings.Contains(out, "parked") || !strings.Contains(out, "sleepy") {
+		t.Errorf("output does not name the parked agents:\n%s", out)
+	}
+}
+
+func TestRestartSummaryCarriesTheCounts(t *testing.T) {
+	got := orchestrationRestartSummary(server.StartReport{
+		Mode:          "full",
+		AgentsStarted: []string{"mayor", "pm-pogo"},
+		AgentsFailed:  []server.AgentStartFailure{{Name: "gc", Error: "boom"}},
+	})
+	for _, want := range []string{"2 crew agents started", "1 failed", "polecats not restored"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary %q does not contain %q", got, want)
+		}
+	}
+}

--- a/cmd/pogod/agentstarter.go
+++ b/cmd/pogod/agentstarter.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"log"
+
+	"github.com/drellem2/pogo/internal/agent"
+	"github.com/drellem2/pogo/internal/server"
+)
+
+// autoStartDisabledReason is what a start-orchestration reports when the
+// daemon is configured never to spawn a crew. It is phrased as the config key
+// an operator would change, because it is printed straight through to them.
+const autoStartDisabledReason = "[agents] autostart = false"
+
+// agentStarterFor builds the server's AgentStarter: the agent-side analogue of
+// the RefineryStarter, invoked when the daemon returns to full mode.
+//
+// It re-runs the auto-start sweep — the same sweep the boot path runs, with the
+// same gate. Honouring `[agents] autostart = false` here is not defensive
+// tidiness: without it, a stop-orchestration followed by a start-orchestration
+// would spawn a fleet on a daemon whose boot path deliberately refuses to, so
+// a mode round-trip would become a side door around the config (gh #108).
+//
+// enabled is read at call time rather than captured as a bool so the gate
+// reflects the config the daemon is running under when the transition happens,
+// not the one it happened to boot with.
+func agentStarterFor(enabled func() bool, sweep func() []agent.AutoStartResult) server.AgentStarter {
+	return func() server.AgentStartOutcome {
+		if !enabled() {
+			log.Printf("pogod: orchestration restart — crew auto-start disabled (%s); not starting any agents",
+				autoStartDisabledReason)
+			return server.AgentStartOutcome{Skipped: autoStartDisabledReason}
+		}
+		return server.AgentStartOutcome{Results: sweep()}
+	}
+}

--- a/cmd/pogod/agentstarter_test.go
+++ b/cmd/pogod/agentstarter_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/drellem2/pogo/internal/agent"
+)
+
+// TestAgentStarterHonoursAutoStartDisabled: a mode round-trip must not become a
+// side door around the boot gate. A daemon running with [agents] autostart =
+// false refuses to spawn a fleet at boot; stop-orchestration followed by
+// start-orchestration must refuse the same way — and say it did.
+func TestAgentStarterHonoursAutoStartDisabled(t *testing.T) {
+	swept := false
+	start := agentStarterFor(
+		func() bool { return false },
+		func() []agent.AutoStartResult {
+			swept = true
+			return []agent.AutoStartResult{{Name: "mayor", Status: agent.AutoStartStatusStarted}}
+		},
+	)
+
+	out := start()
+	if swept {
+		t.Error("the auto-start sweep ran despite [agents] autostart = false")
+	}
+	if out.Skipped != autoStartDisabledReason {
+		t.Errorf("Skipped = %q, want %q — a silent zero is the shape of the bug being fixed",
+			out.Skipped, autoStartDisabledReason)
+	}
+	if len(out.Results) != 0 {
+		t.Errorf("Results = %+v, want none", out.Results)
+	}
+}
+
+func TestAgentStarterSweepsWhenEnabled(t *testing.T) {
+	start := agentStarterFor(
+		func() bool { return true },
+		func() []agent.AutoStartResult {
+			return []agent.AutoStartResult{{Name: "mayor", Status: agent.AutoStartStatusStarted}}
+		},
+	)
+
+	out := start()
+	if out.Skipped != "" {
+		t.Errorf("Skipped = %q, want empty", out.Skipped)
+	}
+	if len(out.Results) != 1 || out.Results[0].Name != "mayor" {
+		t.Fatalf("Results = %+v, want the sweep's own results", out.Results)
+	}
+}
+
+// The gate is read at call time, not captured at wiring time, so a transition
+// reflects the config the daemon is running under when it happens.
+func TestAgentStarterReadsTheGateAtCallTime(t *testing.T) {
+	enabled := false
+	start := agentStarterFor(
+		func() bool { return enabled },
+		func() []agent.AutoStartResult { return nil },
+	)
+
+	if out := start(); out.Skipped == "" {
+		t.Fatal("expected the disabled gate to skip the sweep")
+	}
+	enabled = true
+	if out := start(); out.Skipped != "" {
+		t.Errorf("Skipped = %q after the gate was enabled; the gate was captured, not read", out.Skipped)
+	}
+}

--- a/cmd/pogod/main.go
+++ b/cmd/pogod/main.go
@@ -1496,9 +1496,18 @@ Flags:
 			// fast crash loop doesn't peg the daemon. The agent stays in
 			// the registry and its worktree (if any) is preserved.
 			log.Printf("agent %s (%s) exited unexpectedly, scheduling restart", a.Name, a.Type)
+			// Capture the registry generation HERE, at scheduling time, not
+			// inside the goroutine. The goroutine sleeps 2s before firing
+			// while StopAll returns synchronously, so this respawn can land
+			// after a stop-orchestration has already completed — and, if a
+			// start-orchestration follows inside that window, after the
+			// shutdown latch has been cleared again. Passing the generation
+			// makes this respawn belong to the fleet it was scheduled in: any
+			// stop or start in between refuses it, however late it fires.
+			gen := agentRegistry.Generation()
 			go func() {
 				time.Sleep(2 * time.Second)
-				if _, rerr := agentRegistry.Respawn(a.Name); rerr != nil {
+				if _, rerr := agentRegistry.RespawnFromGeneration(a.Name, gen); rerr != nil {
 					log.Printf("agent %s: restart failed: %v", a.Name, rerr)
 					// A6 (mg-342d). The respawn is ONE-SHOT: nothing tries
 					// again, so a crew agent whose restart failed is simply
@@ -2362,6 +2371,18 @@ Flags:
 
 	// Initialize server coordinator
 	srv = server.New(agentRegistry, mergeQueue)
+	// The agent-side analogue of SetRefineryStarter below: a return to full
+	// mode re-runs the auto-start sweep. Before gh #108 there was no such
+	// hook, so `pogo server start` against an index-only daemon flipped the
+	// mode, brought the refinery back, and left the fleet empty.
+	//
+	// The autostart gate is the same one the boot path applies further down:
+	// a daemon configured never to spawn a fleet must not gain a side door
+	// into doing so through a mode round-trip.
+	srv.SetAgentStarter(agentStarterFor(
+		func() bool { return cfg.Agents.AutoStart },
+		agentRegistry.AutoStartAgents,
+	))
 	if mergeQueue != nil {
 		onMerged := mergeQueue.OnMergedFunc()
 		onFailed := mergeQueue.OnFailedFunc()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -389,6 +389,14 @@ type Registry struct {
 	// both edges closes it by construction rather than by timing: every
 	// goroutine scheduled at or before the clear holds a stale generation and
 	// loses forever, however late it fires.
+	//
+	// It is not the only thing standing in that window — StopAll also drops
+	// each stopped agent from the map, so a stale respawn of an agent present
+	// at drain time already hits "not found". The generation is here because
+	// that is emergent, spread across StopAll's cleanup loop and Respawn's
+	// still-running check, and it protects an invariant that is easy to
+	// re-break from either end. This makes it one local check at the point of
+	// respawn.
 	generation uint64
 
 	// stallSchedules, when set, supplies the recurring cron schedules targeting

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -370,8 +370,26 @@ type Registry struct {
 
 	// shutdown is set by StopAll to short-circuit any in-flight respawn
 	// goroutines (scheduled by the OnExit hook for restart_on_crash agents)
-	// so the registry can be torn down without an agent coming back.
+	// so the registry can be torn down without an agent coming back. Resume
+	// clears it when the daemon comes back to full mode.
 	shutdown bool
+
+	// generation is bumped every time the shutdown latch CHANGES — set by
+	// StopAll, cleared by Resume. It is the drain barrier: a deferred respawn
+	// goroutine captures the generation it was scheduled in and calls
+	// RespawnFromGeneration, which refuses once the registry has moved on.
+	//
+	// Why a counter and not just the bool: the OnExit hook schedules a respawn
+	// that sleeps 2s before firing (cmd/pogod/main.go), while StopAll returns
+	// synchronously. A goroutine scheduled during teardown therefore fires
+	// AFTER StopAll returned, and a stop->start round-trip inside that window
+	// would clear the latch in time for the stale respawn to land alongside
+	// the fresh auto-start sweep. Clearing the latch cannot close that window
+	// — the window is on the wrong side of the clear. Bumping a generation on
+	// both edges closes it by construction rather than by timing: every
+	// goroutine scheduled at or before the clear holds a stale generation and
+	// loses forever, however late it fires.
+	generation uint64
 
 	// stallSchedules, when set, supplies the recurring cron schedules targeting
 	// an agent so diagnose can suppress the stalled label during normal
@@ -1245,6 +1263,7 @@ func (r *Registry) Stop(name string, timeout time.Duration) error {
 func (r *Registry) StopAll(timeout time.Duration) {
 	r.mu.Lock()
 	r.shutdown = true
+	r.generation++
 	names := make([]string, 0, len(r.agents))
 	for name := range r.agents {
 		names = append(names, name)
@@ -1266,18 +1285,74 @@ func (r *Registry) StopAll(timeout time.Duration) {
 	}
 }
 
+// Resume clears the shutdown latch set by StopAll, so restart_on_crash agents
+// are supervised again. Without it the latch is one-way: StopAll sets it and
+// nothing in the tree ever cleared it, which made crash-respawn permanently
+// inert for the life of the process after one stop-orchestration — silently,
+// because Spawn never consulted the latch, so hand-starting an agent kept
+// working and the fleet read healthy (gh #108).
+//
+// It also bumps the generation, which is the load-bearing half. See the
+// generation field for why clearing the bool alone re-opens the window StopAll
+// closed instead of closing it.
+//
+// Its live caller is Server.transitionToFull (internal/server/server.go),
+// which calls it after transitionToIndexOnly's drain has returned and before
+// the auto-start sweep — so an agent that crashes immediately after being
+// re-spawned is already supervised. Idempotent in effect, but not free: each
+// call invalidates every respawn scheduled before it, so call it once per
+// transition, not defensively.
+func (r *Registry) Resume() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.shutdown = false
+	r.generation++
+}
+
+// Generation returns the registry's current respawn generation. A caller that
+// defers a Respawn (sleeping before it fires) reads this at SCHEDULING time and
+// passes it to RespawnFromGeneration, so a stop that happens in between wins.
+func (r *Registry) Generation() uint64 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.generation
+}
+
 // Respawn restarts a stopped agent in-place, preserving its name and config.
 // Used by crew monitoring to restart crashed agents.
 //
 // Returns an error without spawning if the registry has been shut down via
 // StopAll — this lets late-firing OnExit respawn goroutines lose cleanly to
 // teardown instead of resurrecting agents the user just stopped.
+//
+// Deferred callers should prefer RespawnFromGeneration: the latch alone cannot
+// stop a goroutine that fires after a stop->start round-trip has already
+// cleared it.
 func (r *Registry) Respawn(name string) (*Agent, error) {
+	return r.respawn(name, 0, false)
+}
+
+// RespawnFromGeneration is Respawn for a caller whose respawn was SCHEDULED
+// earlier and fires later — the 2s-backoff goroutine in pogod's OnExit hook.
+// It respawns only if the registry is still in generation gen, which the caller
+// captured with Generation() at scheduling time. A StopAll or a Resume in
+// between bumps the generation and this call refuses, so a respawn belonging to
+// the pre-stop fleet can never land in the post-restart one.
+func (r *Registry) RespawnFromGeneration(name string, gen uint64) (*Agent, error) {
+	return r.respawn(name, gen, true)
+}
+
+func (r *Registry) respawn(name string, gen uint64, checkGen bool) (*Agent, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	if r.shutdown {
 		return nil, fmt.Errorf("registry shut down")
+	}
+
+	if checkGen && gen != r.generation {
+		return nil, fmt.Errorf("respawn of %q abandoned: scheduled in registry generation %d, now %d "+
+			"(orchestration was stopped and restarted in between)", name, gen, r.generation)
 	}
 
 	// Backstop for the park race: a respawn goroutine scheduled by a crash

--- a/internal/agent/resume_test.go
+++ b/internal/agent/resume_test.go
@@ -1,0 +1,175 @@
+package agent
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestResumeClearsShutdownLatch covers the half of gh #108 that hides in plain
+// sight. StopAll's latch was one-way: nothing in the tree cleared it, and
+// Spawn never read it, so after a single stop-orchestration a daemon kept
+// accepting `pogo agent start` while restart_on_crash was inert for every
+// agent, for the life of the process. The fleet looked hand-recoverable and
+// healthy until something crashed.
+func TestResumeClearsShutdownLatch(t *testing.T) {
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	reg.StopAll(2 * time.Second)
+
+	// Spawn still works with the latch set — that asymmetry is why the defect
+	// was easy to miss, so assert it rather than assume it.
+	a, err := reg.Spawn(SpawnRequest{Name: "latch", Type: TypeCrew, Command: []string{"true"}})
+	if err != nil {
+		t.Fatalf("Spawn with the latch set: %v", err)
+	}
+	<-a.Done()
+
+	if _, err := reg.Respawn("latch"); err == nil || !strings.Contains(err.Error(), "shut down") {
+		t.Fatalf("Respawn before Resume: err = %v, want the shutdown latch to refuse it", err)
+	}
+
+	reg.Resume()
+
+	if _, err := reg.Respawn("latch"); err != nil {
+		t.Fatalf("Respawn after Resume: %v — the latch was not cleared", err)
+	}
+}
+
+// TestRespawnFromGenerationLosesToARoundTrip is the race test.
+//
+// The interval is measured, not hypothetical: pogod's OnExit hook schedules a
+// respawn that SLEEPS 2s before firing, while StopAll returns synchronously.
+// A goroutine scheduled during teardown therefore fires after the drain
+// returned — and if a start-orchestration lands inside that window, the
+// shutdown latch has already been cleared by the time it calls. Clearing the
+// latch cannot close that window; the window is on the far side of the clear.
+// The generation is what closes it: a respawn belonging to the pre-stop fleet
+// is refused however late it fires.
+func TestRespawnFromGenerationLosesToARoundTrip(t *testing.T) {
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	a, err := reg.Spawn(SpawnRequest{Name: "stale", Type: TypeCrew, Command: []string{"true"}})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	<-a.Done()
+
+	// What pogod's OnExit hook captures at SCHEDULING time.
+	gen := reg.Generation()
+
+	// The stop/start round-trip the deferred respawn sleeps through.
+	reg.StopAll(2 * time.Second)
+	reg.Resume()
+
+	// The goroutine finally fires. The latch is clear, so the latch alone
+	// would let it through.
+	if _, err := reg.RespawnFromGeneration("stale", gen); err == nil {
+		t.Fatal("a respawn scheduled before a stop/start round-trip was admitted afterwards — " +
+			"it would land in a fleet it does not belong to, alongside the auto-start sweep")
+	} else if !strings.Contains(err.Error(), "generation") {
+		t.Errorf("err = %v, want the refusal to name the generation mismatch", err)
+	}
+
+	// Sanity: the barrier is a barrier, not a wall. A respawn scheduled in the
+	// CURRENT generation still works, which is the whole point of clearing the
+	// latch before the sweep rather than after it.
+	b, err := reg.Spawn(SpawnRequest{Name: "fresh", Type: TypeCrew, Command: []string{"true"}})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	<-b.Done()
+	if _, err := reg.RespawnFromGeneration("fresh", reg.Generation()); err != nil {
+		t.Fatalf("RespawnFromGeneration in the current generation: %v", err)
+	}
+}
+
+// TestLateRespawnGoroutineDoesNotResurrectAcrossARoundTrip drives the same
+// race through the real supervisor shape — an OnExit hook that captures the
+// generation and fires on a delay, exactly as cmd/pogod/main.go does — rather
+// than calling the guarded method directly. The assertion is on the registry:
+// the agent must not be back.
+func TestLateRespawnGoroutineDoesNotResurrectAcrossARoundTrip(t *testing.T) {
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.StopAll(2 * time.Second)
+
+	var wg sync.WaitGroup
+	respawnErr := make(chan error, 4)
+	reg.SetOnExit(func(a *Agent, _ error) {
+		if !a.RestartOnCrash {
+			return
+		}
+		gen := reg.Generation() // captured at scheduling time, as pogod does
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Stands in for pogod's 2s backoff: long enough that the
+			// stop/start round-trip below completes first.
+			time.Sleep(150 * time.Millisecond)
+			_, rerr := reg.RespawnFromGeneration(a.Name, gen)
+			respawnErr <- rerr
+		}()
+	})
+
+	if _, err := reg.Spawn(SpawnRequest{
+		Name:           "ghost",
+		Type:           TypeCrew,
+		Command:        []string{"cat"},
+		RestartOnCrash: true,
+	}); err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+
+	reg.StopAll(2 * time.Second) // schedules the late respawn, then returns
+	reg.Resume()                 // the start-orchestration that clears the latch
+
+	wg.Wait()
+
+	select {
+	case rerr := <-respawnErr:
+		if rerr == nil {
+			t.Error("the late respawn succeeded after the round-trip — a pre-stop agent " +
+				"came back into the post-restart fleet")
+		}
+	default:
+		t.Fatal("the respawn goroutine never fired; the test proved nothing")
+	}
+	if a := reg.Get("ghost"); a != nil {
+		t.Errorf("agent %q is back in the registry after a stop/start round-trip: %+v", "ghost", a)
+	}
+}
+
+// TestGenerationBumpsOnBothEdges pins the invariant the barrier rests on: the
+// generation moves when the latch is SET and when it is CLEARED, so no
+// scheduled respawn can straddle either edge unnoticed.
+func TestGenerationBumpsOnBothEdges(t *testing.T) {
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	start := reg.Generation()
+	reg.StopAll(2 * time.Second)
+	afterStop := reg.Generation()
+	reg.Resume()
+	afterResume := reg.Generation()
+
+	if afterStop == start {
+		t.Errorf("generation did not move on StopAll (%d -> %d)", start, afterStop)
+	}
+	if afterResume == afterStop {
+		t.Errorf("generation did not move on Resume (%d -> %d)", afterStop, afterResume)
+	}
+}

--- a/internal/agent/resume_test.go
+++ b/internal/agent/resume_test.go
@@ -98,6 +98,16 @@ func TestRespawnFromGenerationLosesToARoundTrip(t *testing.T) {
 // generation and fires on a delay, exactly as cmd/pogod/main.go does — rather
 // than calling the guarded method directly. The assertion is on the registry:
 // the agent must not be back.
+//
+// Note what this test does and does not isolate. It asserts the end-to-end
+// property, and that property is defended twice: StopAll also drops each
+// stopped agent from the map, so a stale respawn of an agent present at drain
+// time hits "not found" even with the generation check removed (measured).
+// TestRespawnFromGenerationLosesToARoundTrip above is the test that isolates
+// the barrier itself. The barrier is kept because it makes the invariant local
+// and explicit — one check, at the point of respawn — instead of emergent from
+// StopAll's cleanup loop and Respawn's still-running check agreeing across two
+// functions.
 func TestLateRespawnGoroutineDoesNotResurrectAcrossARoundTrip(t *testing.T) {
 	reg, err := NewRegistry(shortSocketDir(t))
 	if err != nil {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/drellem2/pogo/internal/config"
 	"github.com/drellem2/pogo/internal/health"
 	"github.com/drellem2/pogo/internal/project"
+	"github.com/drellem2/pogo/internal/server"
 	pogoPlugin "github.com/drellem2/pogo/pkg/plugin"
 )
 
@@ -267,19 +268,28 @@ func GetServerMode() (string, error) {
 	return result["mode"], nil
 }
 
-// StartOrchestration tells pogod to transition to full mode,
-// restarting agents and refinery without re-indexing.
-func StartOrchestration() error {
+// StartOrchestration tells pogod to transition to full mode, restarting agents
+// and refinery without re-indexing.
+//
+// It returns the daemon's report of what actually came back. A caller that
+// prints only "restarted" is reproducing gh #108: the transition can succeed
+// while restoring no agents at all, and the report is the only thing that
+// distinguishes the two.
+func StartOrchestration() (server.StartReport, error) {
+	var report server.StartReport
 	resp, err := http.Post(serverURL+"/server/start-orchestration", "application/json", nil)
 	if err != nil {
-		return fmt.Errorf("failed to contact server: %w", err)
+		return report, fmt.Errorf("failed to contact server: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("server returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return report, fmt.Errorf("server returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
 	}
-	return nil
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
+		return report, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return report, nil
 }
 
 // StopOrchestration tells pogod to transition to index-only mode,

--- a/internal/client/startorchestration_test.go
+++ b/internal/client/startorchestration_test.go
@@ -1,0 +1,89 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/drellem2/pogo/internal/agent"
+	"github.com/drellem2/pogo/internal/config"
+	"github.com/drellem2/pogo/internal/server"
+)
+
+// TestStartOrchestrationCarriesTheReportOverTheWire closes the loop the CLI
+// actually depends on: pogod's real handler encodes the report, and the client
+// decodes it. Nothing else in the tree checks that those two agree.
+//
+// It matters because the failure mode is silent. If the encode and decode
+// drift — a renamed JSON tag, a type change — the client gets a zero-valued
+// report, the CLI prints "restarted, 0 agents", and that is indistinguishable
+// from the bug this all exists to fix (gh #108). Neither side's own tests would
+// notice.
+//
+// It uses httptest and never contacts a real daemon: a mutating call against
+// the running pogod would stop the live fleet.
+func TestStartOrchestrationCarriesTheReportOverTheWire(t *testing.T) {
+	srv := server.New(nil, nil)
+	srv.SetAgentStarter(func() server.AgentStartOutcome {
+		return server.AgentStartOutcome{Results: []agent.AutoStartResult{
+			{Name: "mayor", Status: agent.AutoStartStatusStarted},
+			{Name: "pm-pogo", Status: agent.AutoStartStatusStarted},
+			{Name: "sleepy", Status: agent.AutoStartStatusSkippedParked},
+			{Name: "gc", Status: agent.AutoStartStatusFailed, Error: "pty start: no ptys"},
+		}}
+	})
+	if err := srv.SetMode(config.ModeIndexOnly); err != nil {
+		t.Fatalf("SetMode(index-only): %v", err)
+	}
+
+	mux := http.NewServeMux()
+	srv.RegisterHandlers(mux)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	old := serverURL
+	serverURL = ts.URL
+	defer func() { serverURL = old }()
+
+	report, err := StartOrchestration()
+	if err != nil {
+		t.Fatalf("StartOrchestration: %v", err)
+	}
+
+	if report.Mode != "full" {
+		t.Errorf("Mode = %q, want \"full\"", report.Mode)
+	}
+	if len(report.AgentsStarted) != 2 ||
+		report.AgentsStarted[0] != "mayor" || report.AgentsStarted[1] != "pm-pogo" {
+		t.Errorf("AgentsStarted = %v, want [mayor pm-pogo] — the names did not survive the wire",
+			report.AgentsStarted)
+	}
+	if len(report.AgentsParked) != 1 || report.AgentsParked[0] != "sleepy" {
+		t.Errorf("AgentsParked = %v, want [sleepy]", report.AgentsParked)
+	}
+	if len(report.AgentsFailed) != 1 || report.AgentsFailed[0].Name != "gc" ||
+		report.AgentsFailed[0].Error != "pty start: no ptys" {
+		t.Errorf("AgentsFailed = %+v, want gc with its spawn error", report.AgentsFailed)
+	}
+}
+
+// A non-200 is still an error, and the report is not half-populated from a
+// body the caller should not be reading.
+func TestStartOrchestrationSurfacesServerErrors(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "restart refinery: boom", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	old := serverURL
+	serverURL = ts.URL
+	defer func() { serverURL = old }()
+
+	report, err := StartOrchestration()
+	if err == nil {
+		t.Fatal("StartOrchestration returned nil error on a 500")
+	}
+	if report.Mode != "" || len(report.AgentsStarted) != 0 {
+		t.Errorf("report = %+v on error, want the zero value", report)
+	}
+}

--- a/internal/server/orchestration_restart_test.go
+++ b/internal/server/orchestration_restart_test.go
@@ -1,0 +1,320 @@
+package server
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/drellem2/pogo/internal/agent"
+	"github.com/drellem2/pogo/internal/agenttest"
+	"github.com/drellem2/pogo/internal/config"
+	"github.com/drellem2/pogo/internal/refinery"
+	"github.com/drellem2/pogo/internal/testsandbox"
+)
+
+// Every other test in this package passes a nil registry to New(), and
+// transitionToIndexOnly guards with `if agents != nil` — so the whole existing
+// suite is structurally incapable of seeing gh #108. It is not that a test was
+// missing; the harness could not have failed. The tests below build a REAL
+// agent.Registry with real (cat) processes for exactly that reason.
+
+// catCommandConfig spawns `cat` for every agent type: a process that stays
+// alive on a PTY without doing anything, which is what a registry-level test
+// needs from a harness.
+type catCommandConfig struct{}
+
+func (catCommandConfig) AgentCommand(string) string  { return "cat" }
+func (catCommandConfig) AgentProvider(string) string { return "" }
+
+// crewFixture stands up an isolated $POGO_HOME with one auto-start crew prompt
+// and a real registry pointed at it. The returned name is the agent that
+// should be running whenever the daemon is in full mode.
+func crewFixture(t *testing.T) (*agent.Registry, string) {
+	t.Helper()
+	testsandbox.Isolate(t)
+
+	if err := agent.InitPromptDirs(); err != nil {
+		t.Fatalf("InitPromptDirs: %v", err)
+	}
+	const name = "scout"
+	path := filepath.Join(agent.CrewPromptDir(), name+".md")
+	prompt := "+++\nauto_start = true\nrestart_on_crash = true\n+++\n# scout\n"
+	if err := os.WriteFile(path, []byte(prompt), 0644); err != nil {
+		t.Fatalf("write crew prompt: %v", err)
+	}
+
+	reg, err := agent.NewRegistry(agenttest.SocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	reg.SetCommandConfig(catCommandConfig{})
+	t.Cleanup(func() { reg.StopAll(2 * time.Second) })
+	return reg, name
+}
+
+// sweepStarter is the AgentStarter pogod wires in production, minus the
+// config gate: re-run the auto-start sweep and report the results.
+func sweepStarter(reg *agent.Registry) AgentStarter {
+	return func() AgentStartOutcome {
+		return AgentStartOutcome{Results: reg.AutoStartAgents()}
+	}
+}
+
+// TestStartOrchestrationRestartsCrewAgents is the regression test for gh #108.
+//
+// The reported symptom is that a full -> index-only -> full round-trip returns
+// to full mode having restarted nothing, and reports success anyway. The
+// positive control is therefore not "SetMode returned nil" — that is what the
+// defect already produces — but the agent being observably back in the
+// registry, and named in the report the CLI prints.
+func TestStartOrchestrationRestartsCrewAgents(t *testing.T) {
+	reg, name := crewFixture(t)
+
+	// Boot: the sweep pogod runs at startup.
+	if res := reg.AutoStartAgents(); len(res) == 0 {
+		t.Fatalf("fixture did not auto-start anything: %+v", res)
+	}
+	if reg.Get(name) == nil {
+		t.Fatalf("fixture agent %q not running before the round-trip", name)
+	}
+
+	s := New(reg, nil)
+	s.SetAgentStarter(sweepStarter(reg))
+
+	if err := s.SetMode(config.ModeIndexOnly); err != nil {
+		t.Fatalf("SetMode(index-only): %v", err)
+	}
+	if a := reg.Get(name); a != nil {
+		t.Fatalf("agent %q survived the drain: %+v", name, a)
+	}
+
+	report, err := s.StartOrchestration()
+	if err != nil {
+		t.Fatalf("StartOrchestration: %v", err)
+	}
+
+	// (1) The agent is actually back. This is the assertion that fails on the
+	// unfixed transition, which flips the mode and never touches s.agents.
+	if reg.Get(name) == nil {
+		t.Errorf("agent %q was NOT restarted by the return to full mode — "+
+			"the daemon is in full mode with no crew (gh #108)", name)
+	}
+
+	// (2) The report NAMES it. A transition that restores the fleet but still
+	// reports a bare success leaves the operator trap in place: the reporter's
+	// complaint was that a green return is indistinguishable from the bug.
+	if !contains(report.AgentsStarted, name) {
+		t.Errorf("report.AgentsStarted = %v, want it to name %q", report.AgentsStarted, name)
+	}
+	if report.Mode != config.ModeFull.String() {
+		t.Errorf("report.Mode = %q, want %q", report.Mode, config.ModeFull.String())
+	}
+	if len(report.AgentsFailed) != 0 {
+		t.Errorf("report.AgentsFailed = %+v, want none", report.AgentsFailed)
+	}
+}
+
+// TestStartOrchestrationClearsShutdownLatch covers the half of gh #108 that is
+// invisible from the outside: StopAll's latch was one-way, so after ONE
+// stop-orchestration, crash-respawn was inert for the life of the process.
+//
+// It reads as healthy on every instrument, which is why it needs its own test:
+// Spawn never consulted the latch, so `pogo agent start` kept working and the
+// fleet looked hand-recoverable. Only Respawn — the path a crash takes — was
+// dead.
+func TestStartOrchestrationClearsShutdownLatch(t *testing.T) {
+	reg, _ := crewFixture(t)
+	reg.AutoStartAgents()
+
+	s := New(reg, nil)
+	s.SetAgentStarter(sweepStarter(reg))
+
+	if err := s.SetMode(config.ModeIndexOnly); err != nil {
+		t.Fatalf("SetMode(index-only): %v", err)
+	}
+	if _, err := s.StartOrchestration(); err != nil {
+		t.Fatalf("StartOrchestration: %v", err)
+	}
+
+	// Spawn an agent and let it exit, then take the path a crash would take.
+	// Spawn succeeding proves nothing about the latch — that asymmetry IS the
+	// bug — so the assertion is on Respawn.
+	const crasher = "latch-probe"
+	probe, err := reg.Spawn(agent.SpawnRequest{
+		Name:    crasher,
+		Type:    agent.TypeCrew,
+		Command: []string{"true"},
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	select {
+	case <-probe.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatalf("probe agent %q never exited", crasher)
+	}
+
+	if _, err := reg.Respawn(crasher); err != nil {
+		t.Fatalf("Respawn after a stop/start round-trip failed: %v — StopAll's shutdown "+
+			"latch was never cleared, so restart_on_crash is silently inert for the "+
+			"life of this process (gh #108)", err)
+	}
+}
+
+// TestStartOrchestrationHonoursAutoStartDisabled: a daemon configured never to
+// spawn a fleet must not acquire a side door into doing so via a mode
+// round-trip — and must SAY that nothing started on purpose, because
+// "restarted 0 agents" silently is the shape of the original bug.
+func TestStartOrchestrationHonoursAutoStartDisabled(t *testing.T) {
+	reg, name := crewFixture(t)
+	reg.AutoStartAgents()
+
+	s := New(reg, nil)
+	s.SetAgentStarter(func() AgentStartOutcome {
+		return AgentStartOutcome{Skipped: "[agents] autostart = false"}
+	})
+
+	if err := s.SetMode(config.ModeIndexOnly); err != nil {
+		t.Fatalf("SetMode(index-only): %v", err)
+	}
+	report, err := s.StartOrchestration()
+	if err != nil {
+		t.Fatalf("StartOrchestration: %v", err)
+	}
+
+	if a := reg.Get(name); a != nil {
+		t.Errorf("agent %q was started despite autostart being disabled: %+v", name, a)
+	}
+	if report.AgentStartSkipped == "" {
+		t.Error("report does not say why no agents started; a silent zero is the bug being fixed")
+	}
+	if len(report.AgentsStarted) != 0 {
+		t.Errorf("report.AgentsStarted = %v, want none", report.AgentsStarted)
+	}
+}
+
+// TestStartOrchestrationWithoutStarterSaysSo: a server with no AgentStarter
+// wired restarts no agents. That is allowed — but it is reported, not
+// swallowed, so the report can never claim a fleet it did not restore.
+func TestStartOrchestrationWithoutStarterSaysSo(t *testing.T) {
+	s := New(nil, nil)
+	if err := s.SetMode(config.ModeIndexOnly); err != nil {
+		t.Fatal(err)
+	}
+	report, err := s.StartOrchestration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.AgentStartSkipped == "" {
+		t.Error("report.AgentStartSkipped is empty; a server with no agent starter must say it started nothing")
+	}
+	if len(report.AgentsStarted) != 0 {
+		t.Errorf("report.AgentsStarted = %v, want none", report.AgentsStarted)
+	}
+}
+
+// TestStartOrchestrationAlreadyFullReportsNoRestart: the CLI only calls this
+// after reading index-only, but the read and the call are not atomic. A server
+// already in full mode restarted nothing and must not imply otherwise.
+func TestStartOrchestrationAlreadyFull(t *testing.T) {
+	s := New(nil, nil)
+	report, err := s.StartOrchestration()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.AlreadyFull {
+		t.Error("report.AlreadyFull = false for a server that was already in full mode")
+	}
+}
+
+// TestTransitionToFullReportsFailedAgents: an agent whose spawn errored is
+// named as a failure. Restoring the fleet partially is not success, and the
+// report is the only place that distinction can be made.
+func TestTransitionToFullReportsFailedAgents(t *testing.T) {
+	s := New(nil, nil)
+	s.SetAgentStarter(func() AgentStartOutcome {
+		return AgentStartOutcome{Results: []agent.AutoStartResult{
+			{Name: "ok", Status: agent.AutoStartStatusStarted},
+			{Name: "broken", Status: agent.AutoStartStatusFailed, Error: "pty start: no ptys"},
+			{Name: "sleepy", Status: agent.AutoStartStatusSkippedParked},
+			{Name: "up", Status: agent.AutoStartStatusSkippedRunning},
+			{Name: "ignored", Status: agent.AutoStartStatusSkippedNoFlag},
+		}}
+	})
+	if err := s.SetMode(config.ModeIndexOnly); err != nil {
+		t.Fatal(err)
+	}
+	report, err := s.StartOrchestration()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := report.AgentsStarted; len(got) != 1 || got[0] != "ok" {
+		t.Errorf("AgentsStarted = %v, want [ok]", got)
+	}
+	if got := report.AgentsAlreadyRunning; len(got) != 1 || got[0] != "up" {
+		t.Errorf("AgentsAlreadyRunning = %v, want [up]", got)
+	}
+	if got := report.AgentsParked; len(got) != 1 || got[0] != "sleepy" {
+		t.Errorf("AgentsParked = %v, want [sleepy]", got)
+	}
+	if len(report.AgentsFailed) != 1 || report.AgentsFailed[0].Name != "broken" {
+		t.Fatalf("AgentsFailed = %+v, want one entry for \"broken\"", report.AgentsFailed)
+	}
+	if !strings.Contains(report.AgentsFailed[0].Error, "no ptys") {
+		t.Errorf("AgentsFailed[0].Error = %q, want the underlying spawn error", report.AgentsFailed[0].Error)
+	}
+}
+
+// TestTransitionToFullAbortsWholeWhenRefineryFails: a transition that cannot
+// complete must not half-apply. If the refinery fails to restart, the mode
+// stays index-only, no agents are swept, and the shutdown latch stays SET —
+// re-arming crash-respawn for a transition that did not happen would leave the
+// daemon supervising a fleet it never restarted. This is the "clearing the
+// latch too early" failure, tested rather than asserted.
+func TestTransitionToFullAbortsWholeWhenRefineryFails(t *testing.T) {
+	reg, name := crewFixture(t)
+	reg.AutoStartAgents()
+
+	swept := false
+	s := New(reg, nil)
+	s.SetRefineryStarter(func() (*refinery.Refinery, error) {
+		return nil, errors.New("refinery would not start")
+	})
+	s.SetAgentStarter(func() AgentStartOutcome {
+		swept = true
+		return AgentStartOutcome{Results: reg.AutoStartAgents()}
+	})
+
+	if err := s.SetMode(config.ModeIndexOnly); err != nil {
+		t.Fatalf("SetMode(index-only): %v", err)
+	}
+	if _, err := s.StartOrchestration(); err == nil {
+		t.Fatal("StartOrchestration returned nil error despite a refinery that cannot start")
+	}
+
+	if s.Mode() != config.ModeIndexOnly {
+		t.Errorf("mode = %s after a failed transition, want index-only", s.Mode())
+	}
+	if swept {
+		t.Error("the auto-start sweep ran during a transition that failed before the mode flip")
+	}
+	if a := reg.Get(name); a != nil {
+		t.Errorf("agent %q was restarted by a failed transition: %+v", name, a)
+	}
+	if _, err := reg.Respawn(name); err == nil || !strings.Contains(err.Error(), "shut down") {
+		t.Errorf("Respawn error = %v, want the shutdown latch still set after a failed transition", err)
+	}
+}
+
+func contains(hay []string, needle string) bool {
+	for _, s := range hay {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,6 +26,65 @@ import (
 // the shared state file with its own (stale) view.
 type RefineryStarter func() (*refinery.Refinery, error)
 
+// AgentStarter re-runs pogod's crew auto-start sweep when transitioning back to
+// ModeFull, and reports what it did. It is the agent-side analogue of
+// RefineryStarter and exists for the same reason: the server package should not
+// own the policy (which prompts are eligible, whether autostart is configured
+// off at all) — only the sequencing.
+//
+// It RE-RUNS THE SWEEP. It does not restore the set that happened to be running
+// before the stop: the desired state is what the prompt frontmatter declares,
+// which is the same rule the boot path applies. AutoStartAgents is idempotent,
+// so an agent that survived the drain is skipped rather than double-started.
+//
+// Polecats are deliberately not covered. They are ephemeral, dispatched per
+// work item, and correctly stay gone — but the report says so out loud rather
+// than letting a bare success imply otherwise.
+type AgentStarter func() AgentStartOutcome
+
+// AgentStartOutcome is what an AgentStarter reports back.
+type AgentStartOutcome struct {
+	// Skipped, when non-empty, is the human-readable reason NO sweep ran —
+	// e.g. `[agents] autostart = false`. It is not an error: a daemon
+	// configured never to spawn a fleet must not acquire a side door into
+	// doing so via a mode round-trip. It is reported so the operator sees
+	// "started nothing, on purpose" instead of "started nothing".
+	Skipped string
+	// Results is the per-prompt outcome of the sweep, empty when Skipped is set.
+	Results []agent.AutoStartResult
+}
+
+// StartReport describes what a transition back to full mode actually brought
+// back. It exists because the CLI used to print "Orchestration restarted" and
+// exit zero whether or not a single agent came back (gh #108): a green return
+// is precisely what the defect produced, so the fix has to name the fleet, not
+// just the mode.
+type StartReport struct {
+	Mode string `json:"mode"`
+	// AlreadyFull means the server was in full mode before the call, so
+	// nothing was stopped and nothing was restarted.
+	AlreadyFull       bool `json:"already_full,omitempty"`
+	RefineryRestarted bool `json:"refinery_restarted"`
+	// AgentsStarted names the crew agents this transition spawned.
+	AgentsStarted []string `json:"agents_started"`
+	// AgentsAlreadyRunning names crew agents the sweep found already up.
+	AgentsAlreadyRunning []string `json:"agents_already_running,omitempty"`
+	// AgentsParked names crew agents left dormant by a park flag — down on
+	// purpose, and reported so they are not read as casualties.
+	AgentsParked []string `json:"agents_parked,omitempty"`
+	// AgentsFailed names crew agents whose spawn errored out. Restoring the
+	// fleet partially is not success and must not read as success.
+	AgentsFailed []AgentStartFailure `json:"agents_failed,omitempty"`
+	// AgentStartSkipped is non-empty when no sweep ran at all, and says why.
+	AgentStartSkipped string `json:"agent_start_skipped,omitempty"`
+}
+
+// AgentStartFailure is one crew agent that did not come back, and why.
+type AgentStartFailure struct {
+	Name  string `json:"name"`
+	Error string `json:"error"`
+}
+
 // Server coordinates subsystem lifecycle and mode transitions.
 type Server struct {
 	// mu guards the fields below and is held only for quick reads/writes —
@@ -40,6 +99,7 @@ type Server struct {
 	refineryCancel context.CancelFunc
 	refineryCfg    *refinery.Config
 	startRefinery  RefineryStarter
+	startAgents    AgentStarter
 
 	// transitionMu serializes mode transitions so overlapping SetMode calls
 	// can't interleave stop/start work (e.g. stopping a refinery instance
@@ -64,6 +124,16 @@ func (s *Server) SetRefineryStarter(fn RefineryStarter) {
 	s.startRefinery = fn
 }
 
+// SetAgentStarter sets the function used to re-run the crew auto-start sweep
+// when transitioning back to ModeFull. Leaving it unset means the transition
+// restarts no agents — and says so in its StartReport rather than reporting a
+// bare success.
+func (s *Server) SetAgentStarter(fn AgentStarter) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.startAgents = fn
+}
+
 // Mode returns the current run mode.
 func (s *Server) Mode() config.RunMode {
 	s.mu.RLock()
@@ -71,8 +141,15 @@ func (s *Server) Mode() config.RunMode {
 	return s.mode
 }
 
-// SetMode transitions the server to the given run mode.
+// SetMode transitions the server to the given run mode. Callers that need to
+// know what a return to full mode actually restored should use
+// StartOrchestration, which returns the report this discards.
 func (s *Server) SetMode(mode config.RunMode) error {
+	if mode == config.ModeFull {
+		_, err := s.StartOrchestration()
+		return err
+	}
+
 	s.transitionMu.Lock()
 	defer s.transitionMu.Unlock()
 
@@ -83,11 +160,21 @@ func (s *Server) SetMode(mode config.RunMode) error {
 	switch mode {
 	case config.ModeIndexOnly:
 		return s.transitionToIndexOnly()
-	case config.ModeFull:
-		return s.transitionToFull()
 	default:
 		return fmt.Errorf("unknown mode: %d", mode)
 	}
+}
+
+// StartOrchestration transitions to full mode and reports what came back —
+// the refinery, and each crew agent by name and outcome.
+func (s *Server) StartOrchestration() (StartReport, error) {
+	s.transitionMu.Lock()
+	defer s.transitionMu.Unlock()
+
+	if s.Mode() == config.ModeFull {
+		return StartReport{Mode: config.ModeFull.String(), AlreadyFull: true}, nil
+	}
+	return s.transitionToFull()
 }
 
 // transitionToIndexOnly stops agents and refinery, keeping indexing alive.
@@ -115,14 +202,19 @@ func (s *Server) transitionToIndexOnly() error {
 	return nil
 }
 
-// transitionToFull restarts agents registry and refinery.
+// transitionToFull restarts the refinery, re-arms crash-respawn, and re-runs
+// the crew auto-start sweep, reporting what came back.
 // Caller must hold s.transitionMu (not s.mu).
-func (s *Server) transitionToFull() error {
+func (s *Server) transitionToFull() (StartReport, error) {
 	log.Printf("server: transitioning to full mode")
 
 	s.mu.RLock()
 	start := s.startRefinery
+	startAgents := s.startAgents
+	agents := s.agents
 	s.mu.RUnlock()
+
+	report := StartReport{Mode: config.ModeFull.String()}
 
 	// Restart refinery if we have a starter function; run it outside the
 	// lock so Mode() checks don't block on startup work.
@@ -131,8 +223,13 @@ func (s *Server) transitionToFull() error {
 		var err error
 		newRef, err = start()
 		if err != nil {
-			return fmt.Errorf("restart refinery: %w", err)
+			// Nothing has been mutated yet — deliberately. The latch stays
+			// set and the mode stays index-only, so a failed transition
+			// leaves the daemon in the state it was already in rather than
+			// half-way between two.
+			return StartReport{Mode: s.Mode().String()}, fmt.Errorf("restart refinery: %w", err)
 		}
+		report.RefineryRestarted = true
 	}
 
 	s.mu.Lock()
@@ -143,7 +240,66 @@ func (s *Server) transitionToFull() error {
 	s.mu.Unlock()
 
 	log.Printf("server: now in full mode")
-	return nil
+
+	// Clear StopAll's shutdown latch HERE: after the drain has returned and
+	// the mode is full, and before the sweep below spawns anything.
+	//
+	// Later would be wrong. Resume bumps the registry generation, invalidating
+	// every respawn scheduled before it — so clearing after the sweep would
+	// leave exactly the agents that crashed during the sweep permanently
+	// unsupervised, in a fleet that reports itself restored.
+	//
+	// Earlier would be wrong for a different reason. The drain's own late
+	// respawn goroutines (scheduled by the OnExit hook, firing 2s after
+	// StopAll returned synchronously) would be re-admitted into a fleet that
+	// is being rebuilt, racing the sweep whose only guard is a check-then-act
+	// on r.Get(name). The generation bump is what makes that impossible rather
+	// than merely unlikely — a stale goroutine holds a stale generation and
+	// loses however late it fires — but the clear still belongs after the
+	// point of no return, not before it: a refinery failure above returns
+	// early, and re-arming crash-respawn for a transition that did not happen
+	// would leave the daemon supervising a fleet it never restarted.
+	if agents != nil {
+		agents.Resume()
+	}
+
+	// Re-run the auto-start sweep. Missing this is the defect gh #108
+	// reported: mode flipped to full, refinery came back, and s.agents was
+	// never touched, so the daemon ran on with no crew and reported success.
+	switch {
+	case startAgents == nil:
+		report.AgentStartSkipped = "no agent starter configured for this server"
+	default:
+		outcome := startAgents()
+		if outcome.Skipped != "" {
+			report.AgentStartSkipped = outcome.Skipped
+		}
+		for _, res := range outcome.Results {
+			switch res.Status {
+			case agent.AutoStartStatusStarted:
+				report.AgentsStarted = append(report.AgentsStarted, res.Name)
+			case agent.AutoStartStatusSkippedRunning:
+				report.AgentsAlreadyRunning = append(report.AgentsAlreadyRunning, res.Name)
+			case agent.AutoStartStatusSkippedParked:
+				report.AgentsParked = append(report.AgentsParked, res.Name)
+			case agent.AutoStartStatusFailed:
+				report.AgentsFailed = append(report.AgentsFailed,
+					AgentStartFailure{Name: res.Name, Error: res.Error})
+			}
+		}
+	}
+
+	log.Printf("server: full mode restored — crew started=%v already_running=%v parked=%v failed=%d%s",
+		report.AgentsStarted, report.AgentsAlreadyRunning, report.AgentsParked,
+		len(report.AgentsFailed), skippedSuffix(report.AgentStartSkipped))
+	return report, nil
+}
+
+func skippedSuffix(reason string) string {
+	if reason == "" {
+		return ""
+	}
+	return " (no auto-start sweep ran: " + reason + ")"
 }
 
 // RequireOrchestration returns middleware that rejects requests with 503
@@ -183,20 +339,22 @@ func (s *Server) handleMode(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleStartOrchestration transitions to full mode, restarting agents and refinery.
+// handleStartOrchestration transitions to full mode, restarting agents and
+// refinery. The response body carries the full StartReport — the client prints
+// it, so an operator sees which agents came back rather than a bare "mode":
+// "full" that is equally true when nothing was restarted (gh #108).
 func (s *Server) handleStartOrchestration(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "", http.StatusMethodNotAllowed)
 		return
 	}
-	if err := s.SetMode(config.ModeFull); err != nil {
+	report, err := s.StartOrchestration()
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{
-		"mode": s.Mode().String(),
-	})
+	json.NewEncoder(w).Encode(report)
 }
 
 // handleStopOrchestration transitions to index-only mode.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -226,12 +226,19 @@ func TestHandleStartOrchestration(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 
-	var resp map[string]string
+	// The body is a StartReport since gh #108 — "mode" is still there and
+	// still means the same thing, so pre-existing readers keep working, but
+	// the response now also carries what was and was not restarted.
+	var resp StartReport
 	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 		t.Fatal(err)
 	}
-	if resp["mode"] != "full" {
-		t.Fatalf("expected mode=full, got %s", resp["mode"])
+	if resp.Mode != "full" {
+		t.Fatalf("expected mode=full, got %s", resp.Mode)
+	}
+	if resp.AgentStartSkipped == "" {
+		t.Error("a server with no agent starter must report that it restarted no agents, " +
+			"not return a bare mode")
 	}
 	if s.Mode() != config.ModeFull {
 		t.Fatalf("expected ModeFull after start-orchestration")


### PR DESCRIPTION
A full → index-only → full round-trip left a running daemon with **no crew
agents and no working crash-respawn**, while the CLI printed "Orchestration
restarted" and exited zero. Three symptoms, one defect: the transition did half
its job and reported all of it.

The fix is at the choke point — `transitionToFull` — so the CLI and
`POST /server/start-orchestration` are covered by one change.

## 1. The transition now restarts the crew

`transitionToFull` resolved the refinery starter, swapped the refinery, flipped
the mode, and never touched `s.agents`. There was no agent-side analogue of
`SetRefineryStarter`, and `AutoStartAgents` had exactly one non-test caller —
the boot path in `cmd/pogod/main.go`. Two docstrings already asserted the
behaviour that was not there.

`Server.SetAgentStarter` is that analogue, wired in `cmd/pogod` beside the
refinery one. It **re-runs the auto-start sweep**: the desired state is what the
prompt frontmatter declares — the same rule boot applies — not "whatever
happened to be running before the stop". `AutoStartAgents` is already idempotent
via its `r.Get` guard, so an agent that survived the drain is skipped rather
than double-started.

`[agents] autostart = false` suppresses the sweep here exactly as it suppresses
boot. A mode round-trip must not become a side door for spawning a fleet the
boot path refuses.

## 2. StopAll's shutdown latch is cleared — and where

The latch was set in `StopAll` and cleared **nowhere in the tree**. It is read
in `Respawn` but not in `Spawn`, so after one stop-orchestration `pogo agent
start` kept working while `restart_on_crash` was silently inert for every agent,
for the life of the process. That asymmetry is why it was easy to miss: the
fleet looked hand-recoverable and healthy right up until something crashed.

**Where the clear happens.** `Registry.Resume()` is called from
`transitionToFull`, **after the refinery has successfully restarted and the mode
has flipped, and before the auto-start sweep**.

**What I considered on the later side.** `Resume` invalidates every respawn
scheduled before it (see below). Clearing *after* the sweep would therefore
leave exactly the agents that crashed during the sweep permanently unsupervised
— their respawn goroutine, scheduled a moment earlier, would be killed by the
clear itself — in a fleet that reports itself fully restored. That is the same
class of bug as the one being fixed, narrowed to the most fragile agents.

**What I considered on the earlier side.** Clearing at the top of
`transitionToFull` — or at the end of `transitionToIndexOnly` — re-admits the
drain's own late respawn goroutines into a fleet that is being rebuilt. The
interval is measured, not hypothetical: the `OnExit` respawn goroutine sleeps
**2 seconds** before calling `Respawn`, while `StopAll` returns synchronously,
so a goroutine scheduled during teardown fires ~2s *after* the drain returns.
It also matters that a refinery failure returns early: re-arming crash-respawn
for a transition that did not happen would leave the daemon supervising a fleet
it never restarted. `TestTransitionToFullAbortsWholeWhenRefineryFails` pins
that — mode stays index-only, no sweep runs, latch stays set.

**The barrier.** Clearing the latch cannot close that 2s window, because the
window is on the far side of the clear. So the latch is not a bool any more:
`Registry.generation` bumps on **both edges** — set by `StopAll`, cleared by
`Resume` — and a deferred caller captures `Generation()` at *scheduling* time
and calls `RespawnFromGeneration(name, gen)`. Any stop or start in between
refuses it, however late it fires. `cmd/pogod`'s `OnExit` hook now captures the
generation outside the goroutine, before the sleep. That closes the window by
construction rather than by timing.

### Honest note on how load-bearing that barrier is

I measured it rather than asserting it. With the generation check disabled,
`TestRespawnFromGenerationLosesToARoundTrip` fails as expected — but the
end-to-end goroutine test **still passes**, because `StopAll` also drops each
stopped agent from the map, so a stale respawn of an agent present at drain time
hits `agent "stale" not found` anyway. In every sequence I could construct, that
removal plus `Respawn`'s still-running check already defeat the stale respawn.

I kept the generation because that defence is *emergent* — spread across
`StopAll`'s cleanup loop and `Respawn`'s status check, in two functions, neither
of which documents that a third function depends on it — and because it is what
makes `Resume` safe to call at a chosen point in the sequence rather than only
at a point where the other two guards happen to hold. It is one local check at
the point of respawn. The test comments say exactly this, so nobody later reads
the end-to-end test as proof the barrier is doing the work.

If a reviewer would rather not carry the mechanism, the place to cut it is
`respawn(name, gen, checkGen)` plus the `Generation()`/`RespawnFromGeneration`
pair; `Resume()` and the sequencing stand on their own.

## 3. The CLI names what came back

The reporter's symptom is a command that returns "full mode" without saying
which agents actually restarted, and a green return is precisely what the bug
already produces. So the output is now:

```
Orchestration restarted
  Refinery: restarted.
  Crew agents started (2): mayor, pm-pogo
  Crew agents left parked (1): sleepy — down on purpose; wake with 'pogo agent wake <name>'.
  Crew agent FAILED to start: gc — pty start: no ptys
  Polecats are NOT restored — they are ephemeral and are re-dispatched per work item.
```

Every branch names something. When nothing started it says **why** — `[agents]
autostart = false`, or no prompt declaring `auto_start = true` — because a
silent zero is the shape of the original bug. Polecats get their own line even
on a fully successful restart: their absence would otherwise read as more of the
same defect.

`POST /server/start-orchestration` returns the whole report; the `mode` field is
unchanged and still means what it did, so existing readers keep working. `--json`
carries it under `report`.

**One judgement call worth flagging:** a crew agent that *errored* on spawn now
makes `pogo server start` exit non-zero, after printing the report. Restoring
zero agents because none are eligible (or because autostart is off) stays exit 0
— that is a configuration fact, not a failure. I took "a partial restore is not
a success" as the intent behind "reports success anyway"; if the preference is
to keep the command exit-0 for scriptability and rely on the printed names plus
`agents_failed` in JSON, that is a two-line revert.

## Verification

**Positive control, as required — the tests fail against the unfixed
behaviour.** I neutered the fix in place (kept the API, removed the `Resume()`
call and the sweep) and ran the regression tests:

```
--- FAIL: TestStartOrchestrationRestartsCrewAgents (0.01s)
    orchestration_restart_test.go:102: agent "scout" was NOT restarted by the return to full mode — the daemon is in full mode with no crew (gh #108)
    orchestration_restart_test.go:110: report.AgentsStarted = [], want it to name "scout"
--- FAIL: TestStartOrchestrationClearsShutdownLatch (0.01s)
    orchestration_restart_test.go:161: Respawn after a stop/start round-trip failed: registry shut down — StopAll's shutdown latch was never cleared, so restart_on_crash is silently inert for the life of this process (gh #108)
```

The tests run against a **real `agent.Registry`** with real processes, under
`testsandbox.Isolate`. That is the point, not a detail: all sixteen `New(...)`
call sites in the existing server suite pass a nil registry and
`transitionToIndexOnly` guards with `if agents != nil`, so the suite was
structurally incapable of seeing this. A test was not missing — the harness
could not have failed. A new test inheriting the nil-registry pattern would have
reproduced that blindness exactly.

**The observable the reporter asked for.** The log from the round-trip in
`TestStartOrchestrationRestartsCrewAgents` now reads:

```
server: transitioning to full mode
server: now in full mode
agent scout: spawned pid=69252 type=crew proc=pogo-crew-scout
autostart: started scout (pid=69252)
server: full mode restored — crew started=[scout] already_running=[] parked=[] failed=0
```

The issue's diagnostic signature is `server: now in full mode` with **no**
`autostart:` line following it. The `autostart:` line is now there, and the
agent is named in the report the CLI prints — observed from the output, not
inferred from an exit code.

**Wire-level, because the failure mode is silent.** The handler encodes the
report and the client decodes it, and nothing else in the tree checked that
those two agree. If they drift — a renamed tag, a type change — the client gets
a zero-valued report and the CLI prints "restarted, 0 agents", which is
*indistinguishable from the bug*. `TestStartOrchestrationCarriesTheReportOverTheWire`
runs the real handler against `httptest` and asserts the names survive.

### CLI-level, against a real daemon — the reporter's own observation

The issue is a CLI-level complaint, so the last check is a real `pogod` in an
isolated sandbox, driven by the real `pogo` binary, with **the same script run
against `main` and against this branch**. Two auto-start crew prompts plus the
mayor; `[agents] command = "sleep 600"`.

**`main` — the reported symptom, reproduced verbatim:**

```
=============== pogo server start ===============
Restarting orchestration...
Orchestration restarted
exit=0

=============== agents after ===============
No running agents.

=============== daemon log ===============
server: now in full mode
server: now in full mode
```

Green return, `No running agents`, and `server: now in full mode` with **no
`autostart:` line following it** — the diagnostic signature named in the issue.

**This branch, same script:**

```
=============== pogo server start ===============
Restarting orchestration...
Orchestration restarted
  Refinery: restarted.
  Crew agents started (3): mayor, scout, tinker
  Polecats are NOT restored — they are ephemeral and are re-dispatched per work item.
exit=0

=============== agents after ===============
mayor                 pid=98372   type=crew      status=running     uptime=2s
scout                 pid=98374   type=crew      status=running     uptime=2s
tinker                pid=98376   type=crew      status=running     uptime=2s

=============== daemon log ===============
server: now in full mode
autostart: started mayor (pid=98372)
autostart: started scout (pid=98374)
autostart: started tinker (pid=98376)
server: full mode restored — crew started=[mayor scout tinker] already_running=[] parked=[] failed=0
```

The agents are named **by the CLI's own output**, and observed back in `agent
list` with fresh pids — not inferred from the exit code, which is `0` in both
runs and is exactly why the exit code proves nothing here. `--json` carries
`"agents_started": ["mayor","scout","tinker"]`.

**How the sandbox was made safe, because my first attempt was not.** Attempt one
redirected `HOME`, `XDG_CONFIG_HOME` and `POGO_HOME` and still resolved to the
**live** daemon — `pogo agent list` returned this machine's real fleet. Nothing
was stopped only because I had guessed a subcommand that does not exist. The
working version pins the client with `POGO_PORT` and gates on an exact check
before any mutating command: the process listening on the port the CLI resolves
to must be the pid this script started (`listener on :18917 = 94372   my pogod =
94372`), with no polecats and no multi-hour uptimes in the probe. A
fleet-shape guess is what nearly went wrong — "a mayor exists" is true of the
sandbox too. Stray listeners are reaped and the port confirmed free on exit.

`./build.sh` green (exit 0, zero failures). `internal/agent` also green under
`-race`.

## Noted, not fixed (out of scope)

`pogo agent list` against a daemon in index-only mode prints:

```
json: cannot unmarshal object into Go value of type []agent.AgentInfo
```

`RequireOrchestration` returns a 503 JSON *object* (`{"error":...,"mode":...}`)
and the client decodes into a slice. Reproduces identically on `main` and on
this branch, so it is pre-existing and untouched by this change — but it is
adjacent enough that a reviewer will see it in the transcripts above, and it is
a bad message in exactly the state this PR is about. Flagging rather than
fixing.

## Relationship to the "drain counts polecats" finding

A separate open ticket observes that the drain's predicate counts polecats while
compute can outlive the polecat, so "0 polecats active" does not mean "no work
in flight". I considered whether that undermines this change and concluded it
does not, in either direction: `StopAll` waits on registry entries, and detached
grandchild processes were never covered by it and are not covered by the
generation barrier either — that barrier is pogod-internal and makes no claim
about host quiescence. The crew agents restarted here do not require a quiet
host for correctness; a loaded host costs them contention, not consistency.

One directional note, stated because it is a real consequence: by making
crash-respawn work again after a round-trip, this change means an agent that
crashes post-restart will now actually come back — so a post-drain host can get
busier than it did before the fix. That is the intended behaviour being
restored, not a regression, but it is a change in what happens after a drain. I
have deliberately not answered that ticket's open question here.

## Refs

Refs drellem2/pogo#108 — **deliberately not a closing reference.** The triage
packet records that #108 is open on purpose: the drafted public reply is
human-gated and has not been posted. Auto-closing it on merge would shut the
issue on the reporter before anyone had answered them. Close it by hand once the
reply goes out.

Approved triage recommendation: mg-c23c (verdict: implement at
`transitionToFull`; re-run the auto_start sweep rather than restore the prior
set; `autostart = false` must suppress the transition path; regression test
against a real `Registry`). Signed off by pm-pogo 2026-08-05.

Work item: mg-4b01
