### PR TITLE
test.sh: bound go test with an explicit 20m budget and REPORT an overrun as a timeout, not a panic dump (gh#107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,18 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    # The outer backstop, so the per-package budget is not the only bound here
+    # (raised in review as mg-a3db advisory 1). Under the refinery, test.sh sits
+    # inside defaultGateTimeout=60m, which kills with a diagnostic heartbeat
+    # record rather than a panic dump — that argument is why 20m per package is
+    # safe to choose. It did NOT transfer to this call site: outside the gate
+    # there was nothing but GitHub's 360-minute job default, so raising the
+    # per-package worst case from 10m to 20m widened an unbounded window.
+    #
+    # 45m: comfortably above the realistic worst case (one wedged package at its
+    # 20m budget plus the rest of a suite that measures ~4m here), and an order
+    # of magnitude below the 360m default, which is "no bound" in practice.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,14 @@ jobs:
           mkdir -p _testdata/a-service/.git
           mkdir -p _testdata/b-service/.git
 
+      # Bounded and classified by the same script test.sh uses (mg-a465,
+      # gh#107) — one definition of the budget and one definition of the
+      # report. CI is the MORE exposed of the two: these runners are slower
+      # than the dev host, and nobody watches this one interactively, so an
+      # unlabelled goroutine dump here is read by whoever opens the failed run
+      # days later.
       - name: Test
-        run: go test ./...
+        run: bash scripts/go-test-budget.sh ./...
 
   pi-e2e:
     # Live pi-provider integration tests (mg-3e7c): drive a real pi binary

--- a/changelog.d/mg-a465.fixed.md
+++ b/changelog.d/mg-a465.fixed.md
@@ -1,0 +1,81 @@
+- **A Go package that exceeds its test budget is now REPORTED as a budget
+  overrun, naming the package and the budget, instead of ending the run in an
+  unlabelled goroutine dump (mg-a465, gh#107).** `test.sh` ran a bare
+  `go test ./...`, so every test binary inherited Go's default 10-minute
+  per-package timeout — a number nobody chose — and it reached the merge gate:
+  `build.sh` runs `test.sh`, and the refinery gate defaults to `./build.sh`.
+  `.github/workflows/ci.yml` carried the identical bare invocation on slower
+  runners.
+
+  **The part of the diagnosis that changed the fix: `-timeout` IS the panic.**
+  The issue frames this as "dies at Go's 10-minute panic instead of failing
+  cleanly", with the implied remedy that setting `-timeout` makes it fail
+  cleanly. Measured before anything was written, it does not. Go implements
+  `-timeout` by arming `testing.(*M).startAlarm`, and the default 10m and an
+  explicit 20m take the identical code path — both end in
+  `panic: test timed out after <budget>` followed by the stacks of every
+  goroutine in the binary. So the two-line change the issue asks for moves the
+  panic later without changing its shape, and the shape is the entire
+  complaint: a package that merely ran long stays indistinguishable at a glance
+  from a mass regression, and the tests that had already passed inside that
+  binary are still lost.
+
+  Setting the budget is therefore necessary but not sufficient, and the second
+  half is what `scripts/go-test-budget.sh` adds. It runs `go test` under an
+  explicit budget and then CLASSIFIES the outcome, emitting at the tail of the
+  output — where a reader looks and what a truncating CI log keeps — the
+  package that overran, the budget Go actually enforced, the tests still
+  running when it fired, and the statement that this is an overrun and not a
+  crash. The classification is anchored on Go's exact timeout-panic text, so an
+  ordinary `panic: runtime error: ...` and a plain `t.Fatal` are never
+  mislabelled; both are negative controls in the suite.
+
+  **The goroutine dump is kept, deliberately.** Suppressing it is the obvious
+  way to "not be a panic dump" and it would destroy the only evidence that
+  separates the two causes an overrun can have, which need opposite responses:
+  a genuine deadlock (goroutines parked on chan/select/mutex, no progress)
+  versus a loaded host (goroutines progressing, just not fast enough). Those
+  are identical in a bare "package X exceeded N minutes" line, and telling them
+  apart is why the reader is there. The dump is labelled rather than removed,
+  and the label is the last thing printed.
+
+  **Why 20m and not the 40m the issue suggests.** `defaultGateTimeout` is 60m
+  (`internal/refinery/gaterun.go:30`), documented there as roughly twice the
+  longest gate run observed on this fleet (~30m). A 40m per-package ceiling is
+  larger than the entire observed gate run, so one wedged package would consume
+  two-thirds of the gate budget before reporting anything. 20m is ~2.2x the
+  worst per-package figure #107 reports (538.9s), surfaces a wedged package 20
+  minutes sooner, and leaves the 60m gate bound reachable as the outer
+  backstop — which kills with a diagnostic heartbeat record rather than a panic
+  dump. Keeping the better-instrumented backstop reachable is choosing a better
+  failure, not merely an earlier one.
+
+  **The headroom is the thing not to get wrong.** Too short a budget converts
+  host load into spurious failures, which is the disease mg-6c90 documents — a
+  fixed CPU floor that failed 13/13 at load 52-106 and passed 4/4 at load
+  4.6-5.3 on byte-identical binaries. Measured on this host, the slowest
+  packages are `internal/agent` at 206-217s and `internal/refinery` at 81.2s
+  isolated, rising to 155.1s at load avg ~32 — a 1.9x response to contention
+  alone. 20m is 5.5x the slowest figure measured here. (The 538.9s/508.8s in
+  #107 were measured under a live agent fleet and were not reproduced here;
+  that corroborates rather than refutes the issue, whose own claim is that
+  runtime scales with contention.)
+
+  **Both call sites, and a test that says so.** `test.sh` and `ci.yml` route
+  through the same script, so there is one definition of the budget and one of
+  the report; CI is the more exposed of the two, since those runners are slower
+  and nobody watches them interactively. `scripts/go-test-budget_test.sh`
+  asserts the wiring against the real `test.sh` and `ci.yml` — that both go
+  through the script and that neither carries an unbounded `go test` — because
+  a partial fix invites the wrong inference: someone who learns "test.sh has a
+  timeout now" will assume the suite is bounded everywhere. The suite's
+  load-bearing case is the positive control, which makes a package exceed the
+  budget on purpose and asserts the report names it; with the classifier
+  disabled that control fails 7 assertions and the output ends in a bare
+  `FAIL`, which is precisely the pre-fix world.
+
+  A caller-supplied `-timeout` is refused with a usage error rather than
+  silently winning (Go takes the last one), so the enforced budget and the
+  reported budget cannot disagree. `POGO_GO_TEST_TIMEOUT` overrides the
+  default — which is what lets the positive control cost 12s instead of 20
+  minutes, since a control nobody can afford to run is not a control.

--- a/changelog.d/mg-a465.fixed.md
+++ b/changelog.d/mg-a465.fixed.md
@@ -50,16 +50,50 @@
   dump. Keeping the better-instrumented backstop reachable is choosing a better
   failure, not merely an earlier one.
 
-  **The headroom is the thing not to get wrong.** Too short a budget converts
-  host load into spurious failures, which is the disease mg-6c90 documents — a
-  fixed CPU floor that failed 13/13 at load 52-106 and passed 4/4 at load
-  4.6-5.3 on byte-identical binaries. Measured on this host, the slowest
-  packages are `internal/agent` at 206-217s and `internal/refinery` at 81.2s
-  isolated, rising to 155.1s at load avg ~32 — a 1.9x response to contention
-  alone. 20m is 5.5x the slowest figure measured here. (The 538.9s/508.8s in
-  #107 were measured under a live agent fleet and were not reproduced here;
-  that corroborates rather than refutes the issue, whose own claim is that
-  runtime scales with contention.)
+  **The headroom, stated for a loaded host and not just a quiet one.** Too
+  short a budget converts host load into spurious failures, which is the
+  disease mg-6c90 documents — a fixed CPU floor that failed 13/13 at load
+  52-106 and passed 4/4 at load 4.6-5.3 on byte-identical binaries. So the
+  quiet-host multiple is the wrong headline: this host has recorded load 174 in
+  a single night.
+
+  On a quiet box the slowest package, `internal/agent`, measures **268.7s
+  isolated at load ~5 on this branch** — 4.5x under the budget. (The 206-217s
+  and 81.2s/155.1s figures in the ticket are the *triage* measurement set,
+  recorded before this branch and now optimistic; they are attributed to that
+  run rather than to this one.)
+
+  Loaded, the margin is much thinner, and this part is an **estimate rather
+  than a measurement**. The one load-response pair measured here —
+  `internal/refinery` 81.2s@~7.8 → 155.1s@~32 — fits runtime ~ load^0.46;
+  extrapolating `internal/agent` from the three available anchors gives:
+
+  | anchor | load 100 | load 150 | load 174 |
+  |---|---|---|---|
+  | triage, full suite (216.8s@~6) | 13.1m · 1.5x | 15.8m · 1.3x | 16.9m · 1.2x |
+  | review, this branch (279.6s@~10) | 13.4m · 1.5x | 16.1m · 1.2x | 17.3m · 1.2x |
+  | this branch, isolated (268.7s@~5) | 17.7m · 1.1x | 21.3m · 0.9x | 22.8m · 0.9x |
+
+  **So the margin at load ~100 is roughly 1.1-1.5x, and at the load 150-174
+  this box has actually recorded the slowest package may legitimately exceed
+  20m.** A spurious timeout on `internal/agent` under heavy fleet load is an
+  anticipated outcome of this budget, not a sign that something else broke —
+  which is exactly what the report this change prints tells the reader to check
+  first.
+
+  The exponent is rough and is labelled as such: a two-point fit on one
+  package, pushed ~5x past its measured range and applied to a different
+  package. This branch's own third point does not fit it — `internal/refinery`
+  measured 99.2s at load ~5 here against 81.2s at load ~7.8 at triage, lower
+  load and higher time. Load average does not separate CPU contention from I/O
+  wait, and these suites spawn processes and PTYs. The direction and rough size
+  are not in doubt; the exponent is.
+
+  20m is kept anyway. Buying margin for load 174 spends gate budget on a state
+  where the box is failing at everything, and the 60m gate bound is what should
+  catch that. (The 538.9s/508.8s in #107 were measured under a live agent fleet
+  and were not reproduced here; that corroborates rather than refutes the
+  issue, whose own claim is that runtime scales with contention.)
 
   **Both call sites, and a test that says so.** `test.sh` and `ci.yml` route
   through the same script, so there is one definition of the budget and one of

--- a/scripts/go-test-budget.sh
+++ b/scripts/go-test-budget.sh
@@ -57,14 +57,55 @@ set -e
 #   better-instrumented backstop is choosing a better failure, not merely an
 #   earlier one.
 #
-#   Headroom against a loaded host is the thing not to get wrong: too short a
-#   budget converts load into spurious failures, which is the disease mg-6c90
-#   documents (a fixed CPU floor that fails at load 52-106 and passes at load
-#   ~5, on byte-identical binaries). Measured on this host, the slowest
-#   packages are internal/agent at 206-217s and internal/refinery at 81.2s
-#   isolated, rising to 155.1s at load avg ~32 — a 1.9x response to contention
-#   alone. 20m is 5.5x the slowest figure measured here and 2.2x the slowest
-#   figure #107 reports from a live fleet.
+#   HEADROOM, AND WHAT IT IS ON A LOADED HOST — read this before changing 20m.
+#
+#   Too short a budget converts load into spurious failures, which is the
+#   disease mg-6c90 documents (a fixed CPU floor: 13/13 FAIL at load 52-106,
+#   4/4 PASS at load 4.6-5.3, byte-identical binaries). So the number that
+#   matters is not the quiet-host multiple, it is the margin when the box is
+#   busy — and this host has recorded load 174 in a single night.
+#
+#   Quiet host, internal/agent (the slowest package), measured on THIS BRANCH:
+#   268.7s isolated at load ~5 (`go test -count=1`, 2026-08-07). That is 4.5x
+#   under the 20m budget. The comparable triage figures recorded in mg-a465
+#   (206-217s; internal/refinery 81.2s isolated, 155.1s at load ~32) were taken
+#   BEFORE this branch and are now optimistic — attribute them to that run, not
+#   to this one.
+#
+#   Loaded host, and this is an ESTIMATE, not a measurement. The only
+#   load-response pair anyone has measured here is internal/refinery's
+#   81.2s@~7.8 -> 155.1s@~32, which fits runtime ~ load^0.46. Extrapolating
+#   internal/agent with that exponent, from each of the three anchors available:
+#
+#       anchor                                load 100    load 150    load 174
+#       triage, full suite (216.8s@~6)        13.1m 1.5x  15.8m 1.3x  16.9m 1.2x
+#       review, this branch (279.6s@~10)      13.4m 1.5x  16.1m 1.2x  17.3m 1.2x
+#       this branch, isolated (268.7s@~5)     17.7m 1.1x  21.3m 0.9x  22.8m 0.9x
+#
+#   So the honest statement is: the margin at load ~100 is somewhere around
+#   1.1-1.5x, and at the load 150-174 this box has actually recorded, the
+#   slowest package may LEGITIMATELY EXCEED 20m. Not 5.5x. A spurious timeout
+#   on internal/agent under heavy fleet load is an anticipated outcome of this
+#   budget, not a sign that something else broke.
+#
+#   Treat the exponent as rough. It is a two-point fit on one package, pushed
+#   ~5x past its measured range and applied to a different package — and this
+#   branch's own third point does not fit it: internal/refinery measured 99.2s
+#   at load ~5 here against 81.2s at load ~7.8 at triage, i.e. LOWER load and
+#   HIGHER time. Load average does not separate CPU contention from I/O wait,
+#   and these suites spawn processes and PTYs. What is not in doubt is the
+#   direction and the rough size: the real margin is single-digit tens of
+#   percent at high load, not multiples.
+#
+#   20m is kept anyway, deliberately. Raising it to buy margin at load 174
+#   spends the gate budget on a state where the box is failing at everything,
+#   and the 60m gate bound is what should catch that. The point of recording
+#   the above is that the next person to see `TIMEOUT: internal/agent` at load
+#   150 should find it written down as expected — and the report this script
+#   prints tells them to check the load average before reading the dump as a
+#   bug. That is the whole difference between a legible failure and a triage
+#   cycle. If it starts recurring at ordinary load, that is new information and
+#   the number should move then.
 #
 # USAGE:
 #   scripts/go-test-budget.sh ./...            # any `go test` package args
@@ -84,6 +125,59 @@ set -e
 # =============================================================================
 
 budget="${POGO_GO_TEST_TIMEOUT:-20m}"
+
+# The budget is read from the ambient environment, and the merge gate runs in an
+# environment this script does not own. An exported POGO_GO_TEST_TIMEOUT set for
+# some other purpose would silently redefine the gate's budget — and the
+# dangerous direction is DOWNWARD, because a too-small budget does not look like
+# a misconfiguration, it looks like the branch failing (raised in review as
+# mg-a3db advisory 3). A garbage value is the same problem wearing a different
+# hat: `go test` would reject it with a flag error attributed to the run.
+#
+# So: parse it, and refuse a value below the floor unless the caller says out
+# loud that a short budget is what it wants. The suite for this script is the
+# one legitimate sub-floor caller — its positive control has to overrun in
+# seconds — and it opts in explicitly rather than being special-cased here.
+BUDGET_FLOOR_SECONDS=60
+
+budget_seconds="$(awk -v d="$budget" '
+    BEGIN {
+        # A Go duration is one or more <number><unit> pairs (go help testflag).
+        if (d !~ /^([0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h))+$/) { exit 1 }
+        total = 0
+        s = d
+        while (match(s, /^[0-9]+(\.[0-9]+)?(ns|us|ms|s|m|h)/)) {
+            tok = substr(s, 1, RLENGTH)
+            s = substr(s, RLENGTH + 1)
+            match(tok, /[a-z]+$/)
+            u = substr(tok, RSTART)
+            n = substr(tok, 1, RSTART - 1) + 0
+            if (u == "ns")      total += n / 1000000000
+            else if (u == "us") total += n / 1000000
+            else if (u == "ms") total += n / 1000
+            else if (u == "s")  total += n
+            else if (u == "m")  total += n * 60
+            else if (u == "h")  total += n * 3600
+        }
+        printf "%.6f", total
+    }' 2>/dev/null)" || budget_seconds=""
+
+if [ -z "$budget_seconds" ]; then
+    echo "go-test-budget.sh: POGO_GO_TEST_TIMEOUT=\"$budget\" is not a Go duration" >&2
+    echo "  (expected forms: 20m, 90s, 1h30m — see \`go help testflag\`)." >&2
+    exit 2
+fi
+
+if awk -v s="$budget_seconds" -v f="$BUDGET_FLOOR_SECONDS" 'BEGIN { exit !(s < f) }'; then
+    if [ "${POGO_GO_TEST_BUDGET_ALLOW_SHORT:-}" != "1" ]; then
+        echo "go-test-budget.sh: refusing a ${budget} budget — below the ${BUDGET_FLOOR_SECONDS}s floor." >&2
+        echo "  A budget this small does not fail like a misconfiguration, it fails like the" >&2
+        echo "  branch under test, and this script runs on the merge gate. If a short budget is" >&2
+        echo "  deliberate (a control proving an overrun is reported), set" >&2
+        echo "  POGO_GO_TEST_BUDGET_ALLOW_SHORT=1 alongside it." >&2
+        exit 2
+    fi
+fi
 
 # A caller-supplied -timeout would silently win (go takes the last one) and
 # leave the reported budget disagreeing with the enforced one. Refuse instead:
@@ -191,8 +285,11 @@ echo "causes, which need opposite responses —"
 echo "  deadlock     goroutines parked on chan/select/mutex with no progress"
 echo "  loaded host  goroutines progressing, just not fast enough"
 echo "Check the host load average for the window of the run before reading the"
-echo "dump as a bug. On this host the same package has measured 81.2s at load ~8"
-echo "and 155.1s at load ~32 — a 1.9x response to contention alone."
+echo "dump as a bug. Runtime here is strongly load-sensitive: internal/refinery"
+echo "has measured 81.2s at load ~8 and 155.1s at load ~32 — 1.9x on contention"
+echo "alone — and at the load 150+ this host has recorded, the slowest package"
+echo "can exceed this budget legitimately. That case is expected, not a"
+echo "regression; see the headroom table in this script's header."
 echo ""
 echo "Raise ${budget} deliberately, not reflexively: the refinery's 60m gate bound"
 echo "is the outer backstop, and a per-package budget that approaches it stops"

--- a/scripts/go-test-budget.sh
+++ b/scripts/go-test-budget.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+set -e
+
+# =============================================================================
+# BOUNDED `go test` WITH A TIMEOUT THAT REPORTS AS A TIMEOUT
+# =============================================================================
+#
+# WHY THIS EXISTS (mg-a465, gh#107):
+#   `test.sh` ran a bare `go test ./...`. With no -timeout, every test binary
+#   inherits Go's default of 10 minutes, and it reaches the merge gate:
+#   build.sh runs ./test.sh, and the refinery gate defaults to ./build.sh.
+#
+#   The issue frames this as "dies at Go's 10-minute panic instead of failing
+#   cleanly", with the implied remedy that setting -timeout makes it fail
+#   cleanly. IT DOES NOT, and that was measured before this script was written.
+#   Go implements -timeout BY PANICKING: the default 10m and an explicit 20m
+#   take the identical code path (testing.(*M).startAlarm), and both end in
+#
+#       panic: test timed out after <budget>
+#           running tests:
+#               TestFoo (<budget>)
+#       <goroutine dump for every goroutine in the binary>
+#       FAIL    <package>   <elapsed>s
+#
+#   So `-timeout 20m` alone moves the panic later. It does not change its
+#   shape, and the shape is the entire complaint in #107: a package that
+#   merely ran long is indistinguishable at a glance from a mass regression,
+#   and the tests that had already passed inside that binary are lost.
+#
+#   Setting the budget is therefore necessary but NOT sufficient. This script
+#   is the sufficient half: it CLASSIFIES the overrun and says so in words, at
+#   the tail of the output, naming the package and the budget.
+#
+# WHAT IT DOES NOT DO — the dump is kept, deliberately:
+#   Suppressing the goroutine dump would be the obvious way to "not be a panic
+#   dump", and it would destroy the only evidence that separates the two causes
+#   an overrun can have, which need opposite responses:
+#
+#       a genuine deadlock  goroutines blocked on chan/select/mutex forever
+#       a loaded host       goroutines progressing, just not fast enough
+#
+#   Those look identical in a bare "package X exceeded N minutes" line, and
+#   telling them apart is the whole reason the reader is here. So the dump
+#   stays and is LABELLED, and the label — not the dump — is the last thing
+#   printed, because the tail is where a reader looks and what a truncating
+#   CI log keeps.
+#
+# THE BUDGET, AND WHY 20m:
+#   defaultGateTimeout is 60m (internal/refinery/gaterun.go), documented there
+#   as roughly twice the longest gate run observed on this fleet (~30m). A 40m
+#   per-package ceiling — the figure #107 suggests — is larger than the entire
+#   observed gate run, so one wedged package would eat two-thirds of the gate
+#   budget before reporting anything. 20m is ~2.2x the worst per-package figure
+#   #107 reports (538.9s), surfaces a wedged package 20 minutes sooner, and
+#   leaves the 60m gate bound reachable as the outer backstop — which kills
+#   with a diagnostic heartbeat record rather than a panic dump. Choosing the
+#   better-instrumented backstop is choosing a better failure, not merely an
+#   earlier one.
+#
+#   Headroom against a loaded host is the thing not to get wrong: too short a
+#   budget converts load into spurious failures, which is the disease mg-6c90
+#   documents (a fixed CPU floor that fails at load 52-106 and passes at load
+#   ~5, on byte-identical binaries). Measured on this host, the slowest
+#   packages are internal/agent at 206-217s and internal/refinery at 81.2s
+#   isolated, rising to 155.1s at load avg ~32 — a 1.9x response to contention
+#   alone. 20m is 5.5x the slowest figure measured here and 2.2x the slowest
+#   figure #107 reports from a live fleet.
+#
+# USAGE:
+#   scripts/go-test-budget.sh ./...            # any `go test` package args
+#
+# ENVIRONMENT:
+#   POGO_GO_TEST_TIMEOUT   per-package budget. Default: 20m.
+#                          Any Go duration string (`go help testflag`).
+#                          The test suite for this script uses it to make the
+#                          positive control cost seconds instead of 20 minutes
+#                          — a control nobody can afford to run is not one.
+#
+# EXIT STATUS:
+#   `go test`'s own status, unchanged. A timeout is reported, not renumbered:
+#   build.sh collapses everything to 1 anyway, and inventing a code here would
+#   be a second thing for callers to get wrong.
+#   2 is reserved for a usage error (see the -timeout guard below).
+# =============================================================================
+
+budget="${POGO_GO_TEST_TIMEOUT:-20m}"
+
+# A caller-supplied -timeout would silently win (go takes the last one) and
+# leave the reported budget disagreeing with the enforced one. Refuse instead:
+# there is one budget and one place to set it.
+for arg in "$@"; do
+    case "$arg" in
+        -timeout|-timeout=*|--timeout|--timeout=*|-test.timeout|-test.timeout=*)
+            echo "go-test-budget.sh: refusing a caller-supplied $arg — set POGO_GO_TEST_TIMEOUT instead," >&2
+            echo "  so the enforced budget and the reported budget cannot disagree." >&2
+            exit 2
+            ;;
+    esac
+done
+
+echo "Testing Go packages (per-package budget: ${budget}; override with POGO_GO_TEST_TIMEOUT)"
+
+# Explicit XXXXXX template: BSD mktemp accepts `-t prefix`, GNU mktemp does not
+# treat it the same way, and this script runs on both (test.sh on darwin,
+# ci.yml on ubuntu-latest).
+log="$(mktemp "${TMPDIR:-/tmp}/pogo-go-test-budget.XXXXXX")"
+trap 'rm -f "$log"' EXIT
+
+# tee, not a capture-then-print: the refinery reads a running gate's output
+# text live (mg-9adc), so the stream has to stay a stream. PIPESTATUS carries
+# go's status past tee's.
+set +e
+go test -timeout "$budget" "$@" 2>&1 | tee "$log"
+status=${PIPESTATUS[0]}
+set -e
+
+# Spelled as an `if`, not `[ ... ] && exit 0`: this script's whole job is to run
+# a command that is EXPECTED to fail and then say something afterwards, so a
+# `set -e` interaction that aborts before the report is the one bug it cannot
+# afford. An `if` has no such interaction to reason about.
+if [ "$status" -eq 0 ]; then
+    exit 0
+fi
+
+# Classify. Anchored on Go's exact timeout panic text, so an ordinary panic
+# (`panic: runtime error: ...`) and a plain t.Fatal are never reported as
+# overruns — both are covered by negative controls in go-test-budget_test.sh.
+#
+# Field logic rather than line-position guessing: with FS=tab, go's per-package
+# output is unambiguous, and packages are emitted as contiguous blocks even
+# when they ran in parallel (measured). The timed-out package is the next
+# `FAIL<tab>pkg<tab>elapsed` line after the panic header; the bare `FAIL`
+# summary lines have NF==1 and cannot be mistaken for it.
+timed_out="$(awk '
+    BEGIN { FS = "\t"; in_timeout = 0 }
+    NF == 1 && $1 ~ /^panic: test timed out after / {
+        reported = $1
+        sub(/^panic: test timed out after /, "", reported)
+        in_timeout = 1
+        tests = ""
+        next
+    }
+    in_timeout && NF == 3 && $1 == "" && $2 == "" && $3 != "" {
+        name = $3
+        sub(/ \([^)]*\)$/, "", name)
+        tests = (tests == "" ? name : tests ", " name)
+        next
+    }
+    in_timeout && NF >= 3 && $1 == "FAIL" {
+        print $2 "\t" reported "\t" tests
+        in_timeout = 0
+        next
+    }
+' "$log")"
+
+if [ -z "$timed_out" ]; then
+    # Failed, but not on the budget. Nothing to add — the output above already
+    # says what went wrong, and narrating an ordinary failure as though it were
+    # a category would train readers to skip this block.
+    exit "$status"
+fi
+
+count="$(printf '%s\n' "$timed_out" | wc -l | tr -d ' ')"
+plural="package"
+if [ "$count" -gt 1 ]; then
+    plural="packages"
+fi
+
+echo ""
+echo "============================================================================="
+echo "TIMEOUT: ${count} ${plural} exceeded the per-package test budget of ${budget}."
+echo ""
+printf '%s\n' "$timed_out" | while IFS=$'\t' read -r pkg reported tests; do
+    echo "  ${pkg}"
+    echo "      budget enforced by go: ${reported}"
+    if [ -n "$tests" ]; then
+        echo "      still running at the budget: ${tests}"
+    else
+        echo "      still running at the budget: none reported (TestMain, or setup)"
+    fi
+done
+echo ""
+echo "This is a BUDGET OVERRUN, not a crash. Go implements -timeout by panicking"
+echo "inside the test binary, so the goroutine dump above IS what a timeout looks"
+echo "like — it is not a segfault and not a mass regression. Tests that had already"
+echo "passed inside those binaries were lost with it, so the run is not evidence"
+echo "about them either way."
+echo ""
+echo "The dump is kept, not suppressed: it is the only thing separating the two"
+echo "causes, which need opposite responses —"
+echo "  deadlock     goroutines parked on chan/select/mutex with no progress"
+echo "  loaded host  goroutines progressing, just not fast enough"
+echo "Check the host load average for the window of the run before reading the"
+echo "dump as a bug. On this host the same package has measured 81.2s at load ~8"
+echo "and 155.1s at load ~32 — a 1.9x response to contention alone."
+echo ""
+echo "Raise ${budget} deliberately, not reflexively: the refinery's 60m gate bound"
+echo "is the outer backstop, and a per-package budget that approaches it stops"
+echo "leaving room for the better-instrumented failure to happen instead."
+echo "============================================================================="
+
+exit "$status"

--- a/scripts/go-test-budget_test.sh
+++ b/scripts/go-test-budget_test.sh
@@ -1,0 +1,378 @@
+#!/bin/bash
+# Tests for scripts/go-test-budget.sh (mg-a465, gh#107).
+#
+# The contract under test:
+#   1. POSITIVE CONTROL FIRST: a package that exceeds the budget is REPORTED AS
+#      A TIMEOUT — the output names the package, names the budget, names the
+#      tests still running, and says in words that this is an overrun and not a
+#      crash. This is the whole point of the ticket, and it is the half that
+#      `go test -timeout` does NOT give you: Go implements -timeout by
+#      panicking, so the flag alone moves the panic later without changing its
+#      shape. "It passed" is worth nothing here until "it reports" is shown.
+#   2. The report is the TAIL of the output. A classification a reader has to
+#      scroll back past a goroutine dump to find has not classified anything,
+#      and a truncating CI log keeps the tail.
+#   3. The flag is actually APPLIED, not silently dropped: Go's own panic text
+#      reports the configured budget, and changing POGO_GO_TEST_TIMEOUT changes
+#      what Go reports. Asserting only our own banner would pass against a
+#      script that prints a budget it never passes to `go test`.
+#   4. NEGATIVE CONTROLS, and they carry the weight: a non-timeout panic
+#      (`panic: runtime error: ...`) and an ordinary t.Fatal must NOT be
+#      reported as overruns. Without these, a classifier that shouted TIMEOUT
+#      at every failure would pass case 1.
+#   5. A passing run is unaffected — exit 0 and no report.
+#   6. The default budget is 20m when nothing overrides it.
+#   7. A caller-supplied -timeout is refused, so the enforced budget and the
+#      reported budget cannot disagree.
+#   8. WIRING: test.sh and ci.yml route the suite through this script, and
+#      neither carries an unbounded `go test`. #107's own argument is that a
+#      partial fix is worse than none — someone who learns "test.sh has a
+#      timeout now" will assume the suite is bounded everywhere and be wrong in
+#      the one place nobody watches interactively. These two cases are what
+#      stop the fix being silently unwired later.
+#
+# Every Go fixture is a throwaway module in a temp dir, so the repo's own
+# packages are never run, mutated or read by this file. Cases 8-9 are the only
+# ones that touch the real tree, and they only read it.
+#
+# COST: 12.1s measured end-to-end at load avg ~6 on this host. 5s of that is
+# deliberate sleeping (a 2s budget and a 3s budget); the rest is fixture
+# compiles against the sandbox's cold GOCACHE. The budget is overridable
+# precisely so this file costs seconds instead of 20 minutes — a control nobody
+# can afford to run is not a control.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUDGET_SH="${SCRIPT_DIR}/go-test-budget.sh"
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1" >&2; }
+
+# The packaged test isolation (mg-78a5). This suite has no business near the
+# developer's ~/.pogo — its fixtures are throwaway Go modules and its only reads
+# of the real tree are test.sh and ci.yml — but "this one doesn't need it" is
+# exactly the reasoning that produced mg-6092 / mg-e8e7 / mg-5336 / mg-3412, so
+# the envelope is adopted rather than argued with.
+#
+# Note the ordering constraint the harness documents: pogo_sandbox_create moves
+# no environment variable, and isolate pins the Go toolchain (mg-cdf1) so the
+# `go test` runs below cannot re-download ~70MB into a HOME this run deletes.
+# REPO_ROOT is resolved above, before the move, because after it $HOME is gone.
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/pogo-sandbox"
+pogo_sandbox_create gotestbudget
+pogo_sandbox_isolate
+trap pogo_sandbox_down EXIT
+
+WORK="$POGO_SANDBOX_DIR/work"
+mkdir -p "$WORK"
+
+echo "=== go-test-budget.sh tests ==="
+
+# --- Test 1: syntax --------------------------------------------------------
+echo ""
+echo "Test 1: Script syntax check"
+if bash -n "$BUDGET_SH" 2>/dev/null; then
+    pass "go-test-budget.sh has valid bash syntax"
+else
+    fail "go-test-budget.sh has syntax errors"
+fi
+
+# Fixture builder. Each module gets only the packages a case needs, so a case
+# never pays for another case's sleep.
+make_module() {
+    local dir=$1
+    mkdir -p "$dir"
+    cat > "$dir/go.mod" <<'EOF'
+module example.com/budgetfixture
+
+go 1.25.0
+EOF
+}
+
+add_slow_pkg() {
+    local dir=$1 name=$2
+    mkdir -p "$dir/$name"
+    cat > "$dir/$name/slow_test.go" <<EOF
+package $name
+
+import (
+	"testing"
+	"time"
+)
+
+// Idle goroutines, so the dump this produces has the shape a real daemon
+// suite's does rather than a two-frame toy's.
+func TestSleepsPast${name}Budget(t *testing.T) {
+	for i := 0; i < 4; i++ {
+		go func() { select {} }()
+	}
+	time.Sleep(10 * time.Minute)
+}
+EOF
+}
+
+add_ok_pkg() {
+    local dir=$1 name=$2
+    mkdir -p "$dir/$name"
+    cat > "$dir/$name/ok_test.go" <<EOF
+package $name
+
+import "testing"
+
+func TestPassesImmediately(t *testing.T) {}
+EOF
+}
+
+add_fatal_pkg() {
+    local dir=$1 name=$2
+    mkdir -p "$dir/$name"
+    cat > "$dir/$name/fatal_test.go" <<EOF
+package $name
+
+import "testing"
+
+func TestOrdinaryAssertionFailure(t *testing.T) {
+	t.Fatal("an ordinary failure, not a timeout")
+}
+EOF
+}
+
+add_panic_pkg() {
+    local dir=$1 name=$2
+    mkdir -p "$dir/$name"
+    cat > "$dir/$name/panic_test.go" <<EOF
+package $name
+
+import "testing"
+
+func TestNonTimeoutPanic(t *testing.T) {
+	var p *int
+	_ = *p
+}
+EOF
+}
+
+# run_budget <module-dir> <budget-or-empty> [args...] -> stdout+stderr in $OUT, status in $STATUS
+run_budget() {
+    local dir=$1 budget=$2
+    shift 2
+    set +e
+    if [ -n "$budget" ]; then
+        OUT="$(cd "$dir" && POGO_GO_TEST_TIMEOUT="$budget" bash "$BUDGET_SH" "$@" 2>&1)"
+    else
+        OUT="$(cd "$dir" && unset POGO_GO_TEST_TIMEOUT && bash "$BUDGET_SH" "$@" 2>&1)"
+    fi
+    STATUS=$?
+    set -e
+}
+
+# --- Tests 2-5: one mixed run carries the positive and both negatives -------
+#
+# Deliberately one run rather than four: the negatives are only worth something
+# if the classifier saw a real timeout in the SAME output it declined to
+# classify them from. Run separately, "no TIMEOUT reported" is also what a
+# totally broken classifier prints.
+echo ""
+echo "Test 2: POSITIVE CONTROL — an overrun is reported as a timeout, with the negatives alongside"
+MIXED="$WORK/mixed"
+make_module "$MIXED"
+add_slow_pkg  "$MIXED" slowpkg
+add_ok_pkg    "$MIXED" okpkg
+add_fatal_pkg "$MIXED" fatalpkg
+add_panic_pkg "$MIXED" panicpkg
+run_budget "$MIXED" 2s ./...
+
+if [ "$STATUS" -ne 0 ]; then
+    pass "an overrun exits non-zero (status $STATUS)"
+else
+    fail "an overrun exited 0 — the gate would have merged it"
+fi
+
+if printf '%s\n' "$OUT" | grep -q '^TIMEOUT: 1 package exceeded the per-package test budget of 2s\.$'; then
+    pass "the report names the count and the budget"
+else
+    fail "no 'TIMEOUT: 1 package ... budget of 2s' line in the output"
+fi
+
+if printf '%s\n' "$OUT" | grep -q 'example\.com/budgetfixture/slowpkg'; then
+    pass "the report names the package that overran"
+else
+    fail "the report does not name example.com/budgetfixture/slowpkg"
+fi
+
+if printf '%s\n' "$OUT" | grep -q 'still running at the budget: TestSleepsPastslowpkgBudget'; then
+    pass "the report names the test that was still running"
+else
+    fail "the report does not name the still-running test"
+fi
+
+if printf '%s\n' "$OUT" | grep -q 'BUDGET OVERRUN, not a crash'; then
+    pass "the report says in words that this is not a crash"
+else
+    fail "the report does not distinguish an overrun from a crash"
+fi
+
+# The two causes an overrun can have need opposite responses; the report is
+# only useful if it points at the distinction rather than just naming a number.
+if printf '%s\n' "$OUT" | grep -q 'deadlock' && printf '%s\n' "$OUT" | grep -q 'loaded host'; then
+    pass "the report names both causes a reader has to tell apart"
+else
+    fail "the report does not name the deadlock/loaded-host distinction"
+fi
+
+echo ""
+echo "Test 3: the report is the TAIL, not something buried above the goroutine dump"
+LAST="$(printf '%s\n' "$OUT" | grep -v '^[[:space:]]*$' | tail -1)"
+if printf '%s' "$LAST" | grep -q '^=\+$'; then
+    pass "the last non-empty line is the report's closing rule"
+else
+    fail "the output does not end in the report (ends with: ${LAST:0:70})"
+fi
+
+# The dump must still be present. Suppressing it would pass every assertion
+# above while destroying the only evidence that separates the two causes.
+if printf '%s\n' "$OUT" | grep -q '^panic: test timed out after 2s$'; then
+    pass "the underlying dump is preserved, not swallowed"
+else
+    fail "the goroutine dump was suppressed — the deadlock evidence is gone"
+fi
+
+echo ""
+echo "Test 4: NEGATIVE CONTROLS — ordinary failures in the same run are not called timeouts"
+# Exactly one package overran; the t.Fatal package and the nil-deref package
+# must not have been swept into the count. Test 2 already pinned "1 package",
+# which is that assertion's teeth; these name the mechanism.
+if printf '%s\n' "$OUT" | grep -q 'FAIL[[:space:]]*example\.com/budgetfixture/fatalpkg'; then
+    pass "the t.Fatal package did fail (the negative control is live)"
+else
+    fail "the t.Fatal package did not fail — the negative control proves nothing"
+fi
+
+if printf '%s\n' "$OUT" | grep -q 'panic: runtime error'; then
+    pass "the nil-deref package did panic (the negative control is live)"
+else
+    fail "the nil-deref package did not panic — the negative control proves nothing"
+fi
+
+TIMEOUT_LINES="$(printf '%s\n' "$OUT" | grep -c 'still running at the budget:' || true)"
+if [ "$TIMEOUT_LINES" -eq 1 ]; then
+    pass "exactly one package was classified as an overrun"
+else
+    fail "expected 1 classified overrun, got $TIMEOUT_LINES"
+fi
+
+echo ""
+echo "Test 5: a passing run is unaffected"
+OKMOD="$WORK/okonly"
+make_module "$OKMOD"
+add_ok_pkg  "$OKMOD" okpkg
+run_budget "$OKMOD" 2s ./...
+if [ "$STATUS" -eq 0 ]; then
+    pass "a clean run exits 0"
+else
+    fail "a clean run exited $STATUS"
+fi
+if printf '%s\n' "$OUT" | grep -q 'TIMEOUT:'; then
+    fail "a clean run printed a timeout report"
+else
+    pass "a clean run prints no timeout report"
+fi
+
+# --- Test 6: the budget is really passed to `go test` ----------------------
+#
+# Go's own panic text is the witness, not our banner: a script that printed a
+# budget it never passed through would satisfy the banner and fail here.
+echo ""
+echo "Test 6: the configured budget is the one Go enforces"
+SLOWMOD="$WORK/slowonly"
+make_module "$SLOWMOD"
+add_slow_pkg "$SLOWMOD" slowpkg
+run_budget "$SLOWMOD" 3s ./...
+if printf '%s\n' "$OUT" | grep -q '^panic: test timed out after 3s$'; then
+    pass "POGO_GO_TEST_TIMEOUT=3s reaches go test (go reports 3s, not the 2s of the run before)"
+else
+    fail "go did not report the configured 3s budget — the flag may be ignored"
+fi
+if printf '%s\n' "$OUT" | grep -q 'budget enforced by go: 3s'; then
+    pass "the report quotes go's enforced figure rather than restating our own"
+else
+    fail "the report does not quote go's enforced budget"
+fi
+
+# --- Test 7: the shipped default --------------------------------------------
+echo ""
+echo "Test 7: the default budget is 20m"
+run_budget "$OKMOD" "" ./...
+if printf '%s\n' "$OUT" | grep -q 'per-package budget: 20m'; then
+    pass "with nothing set, the budget is 20m"
+else
+    fail "the default budget is not 20m"
+fi
+
+# --- Test 8: a caller-supplied -timeout is refused ---------------------------
+echo ""
+echo "Test 8: a caller-supplied -timeout is refused"
+run_budget "$OKMOD" 2s -timeout 5s ./...
+if [ "$STATUS" -eq 2 ]; then
+    pass "an explicit -timeout is a usage error (exit 2)"
+else
+    fail "an explicit -timeout was accepted (exit $STATUS) — two budgets could disagree"
+fi
+run_budget "$OKMOD" 2s -timeout=5s ./...
+if [ "$STATUS" -eq 2 ]; then
+    pass "the -timeout=VALUE spelling is refused too"
+else
+    fail "-timeout=5s was accepted (exit $STATUS)"
+fi
+
+# --- Tests 9-10: WIRING against the real tree --------------------------------
+#
+# Pinned against the real test.sh and ci.yml rather than fixtures: the day
+# either one stops routing through this script, the property the ticket bought
+# is gone, and a fixture would not notice.
+echo ""
+echo "Test 9: test.sh routes the Go suite through the budget script"
+TEST_SH_CODE="$(grep -vE '^[[:space:]]*#' "$REPO_ROOT/test.sh")"
+if printf '%s\n' "$TEST_SH_CODE" | grep -q 'go-test-budget\.sh'; then
+    pass "test.sh invokes scripts/go-test-budget.sh"
+else
+    fail "test.sh does not invoke scripts/go-test-budget.sh"
+fi
+
+UNBOUNDED="$(printf '%s\n' "$TEST_SH_CODE" | grep -E '(^|[^-[:alnum:]_])go test' | grep -v -- '-timeout' || true)"
+if [ -z "$UNBOUNDED" ]; then
+    pass "test.sh carries no unbounded 'go test'"
+else
+    fail "test.sh still has an unbounded 'go test': $UNBOUNDED"
+fi
+
+echo ""
+echo "Test 10: ci.yml carries no unbounded 'go test' either"
+CI_YML="$REPO_ROOT/.github/workflows/ci.yml"
+CI_CODE="$(grep -vE '^[[:space:]]*#' "$CI_YML")"
+if printf '%s\n' "$CI_CODE" | grep -q 'go-test-budget\.sh'; then
+    pass "ci.yml's test job routes through scripts/go-test-budget.sh"
+else
+    fail "ci.yml's test job does not route through scripts/go-test-budget.sh"
+fi
+
+# The pi-e2e job runs its own `go test ./internal/pi/ -v -timeout 300s`. That
+# is already bounded and is deliberately left alone; what this asserts is the
+# general property — every go test invocation in CI is bounded by something.
+CI_UNBOUNDED="$(printf '%s\n' "$CI_CODE" | grep -E '(^|[^-[:alnum:]_])go test' | grep -v -- '-timeout' || true)"
+if [ -z "$CI_UNBOUNDED" ]; then
+    pass "every 'go test' in ci.yml is bounded"
+else
+    fail "ci.yml still has an unbounded 'go test': $CI_UNBOUNDED"
+fi
+
+# --- Summary ---------------------------------------------------------------
+echo ""
+echo "=== go-test-budget.sh: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi

--- a/scripts/go-test-budget_test.sh
+++ b/scripts/go-test-budget_test.sh
@@ -157,15 +157,32 @@ EOF
 }
 
 # run_budget <module-dir> <budget-or-empty> [args...] -> stdout+stderr in $OUT, status in $STATUS
+#
+# POGO_GO_TEST_BUDGET_ALLOW_SHORT=1 throughout: every budget here is seconds,
+# which is below the script's 60s floor by design. This suite is the floor's one
+# legitimate exception — a positive control that took 20 minutes to overrun
+# would never be run — and it says so explicitly rather than the script
+# special-casing its own tests. run_budget_raw below deliberately does NOT opt
+# in, so the floor itself can be tested.
 run_budget() {
     local dir=$1 budget=$2
     shift 2
     set +e
     if [ -n "$budget" ]; then
-        OUT="$(cd "$dir" && POGO_GO_TEST_TIMEOUT="$budget" bash "$BUDGET_SH" "$@" 2>&1)"
+        OUT="$(cd "$dir" && POGO_GO_TEST_BUDGET_ALLOW_SHORT=1 POGO_GO_TEST_TIMEOUT="$budget" bash "$BUDGET_SH" "$@" 2>&1)"
     else
-        OUT="$(cd "$dir" && unset POGO_GO_TEST_TIMEOUT && bash "$BUDGET_SH" "$@" 2>&1)"
+        OUT="$(cd "$dir" && POGO_GO_TEST_BUDGET_ALLOW_SHORT=1 && unset POGO_GO_TEST_TIMEOUT && bash "$BUDGET_SH" "$@" 2>&1)"
     fi
+    STATUS=$?
+    set -e
+}
+
+# run_budget_raw <module-dir> <budget> — no ALLOW_SHORT opt-in, for the floor.
+run_budget_raw() {
+    local dir=$1 budget=$2
+    shift 2
+    set +e
+    OUT="$(cd "$dir" && POGO_GO_TEST_TIMEOUT="$budget" bash "$BUDGET_SH" "$@" 2>&1)"
     STATUS=$?
     set -e
 }
@@ -198,19 +215,29 @@ else
     fail "no 'TIMEOUT: 1 package ... budget of 2s' line in the output"
 fi
 
-if printf '%s\n' "$OUT" | grep -q 'example\.com/budgetfixture/slowpkg'; then
-    pass "the report names the package that overran"
+# Everything from the TIMEOUT: header down — i.e. what the CLASSIFIER wrote,
+# with go's own output excluded.
+#
+# Scoping this rather than grepping all of $OUT is not tidiness. Reviewed in
+# round 1 (mg-a3db): "the report names the package that overran" was grepping
+# the whole output, which go's own `FAIL<tab><pkg>` line already satisfies, so
+# the assertion PASSED with the classifier disabled and constrained nothing.
+# An assertion that survives the mutation it exists to catch is decoration.
+REPORT="$(printf '%s\n' "$OUT" | sed -n '/^TIMEOUT: /,$p')"
+
+if printf '%s\n' "$REPORT" | grep -q 'example\.com/budgetfixture/slowpkg'; then
+    pass "the REPORT (not go's own FAIL line) names the package that overran"
 else
-    fail "the report does not name example.com/budgetfixture/slowpkg"
+    fail "the report body does not name example.com/budgetfixture/slowpkg"
 fi
 
-if printf '%s\n' "$OUT" | grep -q 'still running at the budget: TestSleepsPastslowpkgBudget'; then
+if printf '%s\n' "$REPORT" | grep -q 'still running at the budget: TestSleepsPastslowpkgBudget'; then
     pass "the report names the test that was still running"
 else
     fail "the report does not name the still-running test"
 fi
 
-if printf '%s\n' "$OUT" | grep -q 'BUDGET OVERRUN, not a crash'; then
+if printf '%s\n' "$REPORT" | grep -q 'BUDGET OVERRUN, not a crash'; then
     pass "the report says in words that this is not a crash"
 else
     fail "the report does not distinguish an overrun from a crash"
@@ -218,7 +245,7 @@ fi
 
 # The two causes an overrun can have need opposite responses; the report is
 # only useful if it points at the distinction rather than just naming a number.
-if printf '%s\n' "$OUT" | grep -q 'deadlock' && printf '%s\n' "$OUT" | grep -q 'loaded host'; then
+if printf '%s\n' "$REPORT" | grep -q 'deadlock' && printf '%s\n' "$REPORT" | grep -q 'loaded host'; then
     pass "the report names both causes a reader has to tell apart"
 else
     fail "the report does not name the deadlock/loaded-host distinction"
@@ -327,6 +354,56 @@ if [ "$STATUS" -eq 2 ]; then
     pass "the -timeout=VALUE spelling is refused too"
 else
     fail "-timeout=5s was accepted (exit $STATUS)"
+fi
+
+# --- Test 8b: the budget cannot be silently shrunk by the environment --------
+#
+# Raised in review (mg-a3db advisory 3): this script reads its budget from the
+# ambient environment and runs on the merge gate, so a POGO_GO_TEST_TIMEOUT
+# exported for some other purpose would redefine it. Downward is the dangerous
+# direction — a too-small budget fails looking like the branch, not like a
+# misconfiguration.
+echo ""
+echo "Test 8b: a sub-floor or malformed budget is refused"
+run_budget_raw "$OKMOD" 5s ./...
+if [ "$STATUS" -eq 2 ]; then
+    pass "a 5s budget is refused without an explicit opt-in"
+else
+    fail "a 5s budget was accepted (exit $STATUS) — the gate budget can be shrunk silently"
+fi
+if printf '%s\n' "$OUT" | grep -q 'below the 60s floor'; then
+    pass "the refusal names the floor"
+else
+    fail "the refusal does not name the floor"
+fi
+
+run_budget_raw "$OKMOD" banana ./...
+if [ "$STATUS" -eq 2 ]; then
+    pass "a non-duration budget is refused before go test sees it"
+else
+    fail "POGO_GO_TEST_TIMEOUT=banana was not refused (exit $STATUS)"
+fi
+
+# The floor must not reject the value actually shipped, and must accept
+# multi-unit durations rather than only the simple ones.
+run_budget_raw "$OKMOD" 20m ./...
+if [ "$STATUS" -eq 0 ]; then
+    pass "the shipped 20m budget passes the floor"
+else
+    fail "20m was refused (exit $STATUS) — the floor rejects the shipped value"
+fi
+run_budget_raw "$OKMOD" 1h30m ./...
+if [ "$STATUS" -eq 0 ]; then
+    pass "a multi-unit duration (1h30m) parses and passes"
+else
+    fail "1h30m was refused (exit $STATUS) — the duration parser is too narrow"
+fi
+# 90s vs 90m vs 90ms: the parser must not confuse the ms/m/s units.
+run_budget_raw "$OKMOD" 500ms ./...
+if [ "$STATUS" -eq 2 ]; then
+    pass "500ms is read as milliseconds (sub-floor), not as minutes"
+else
+    fail "500ms was accepted (exit $STATUS) — ms is being parsed as m"
 fi
 
 # --- Tests 9-10: WIRING against the real tree --------------------------------

--- a/test.sh
+++ b/test.sh
@@ -10,8 +10,24 @@ echo "Making test directories"
 mkdir -p _testdata/a-service/.git
 mkdir -p _testdata/b-service/.git
 
-echo "Testing Go packages"
-go test ./...
+# A bare `go test ./...` here inherited Go's default 10-minute per-package
+# timeout (mg-a465, gh#107), and it reached the merge gate: build.sh runs this
+# file, and the refinery gate defaults to ./build.sh. Two things were wrong with
+# that, and only one of them is the number:
+#
+#   the budget      10m was never chosen, it was a default nobody set. On a
+#                   host that has swung between load 1.5 and 174, the slowest
+#                   package here measures 206-217s and the same package has
+#                   gone 81.2s -> 155.1s on load alone.
+#   the report      Go implements -timeout BY PANICKING, so raising the number
+#                   alone would only move the panic. An overrun and a mass
+#                   regression still looked identical, which is #107's actual
+#                   complaint.
+#
+# go-test-budget.sh sets the budget AND classifies the overrun, so a package
+# that ran long is reported as a package that ran long. See that file's header
+# for why 20m and not the 40m the issue suggests.
+bash scripts/go-test-budget.sh ./...
 
 echo "Testing neovim plugin"
 bash nvim/test_nvim.sh
@@ -101,6 +117,16 @@ bash scripts/pogo-deploy_test.sh
 # happens to agree.
 echo "Testing the from-source staleness runner"
 bash scripts/check-staleness_test.sh
+
+# The per-package test budget and its overrun report (mg-a465). The
+# load-bearing case is the POSITIVE CONTROL: a package is made to exceed the
+# budget on purpose and the output must NAME it and the budget rather than
+# ending in an unlabelled goroutine dump. `go test -timeout` alone does not
+# give that — it panics — so without this file the fix looks applied and isn't.
+# Costs 12.1s measured (5s of it deliberate sleeping); the budget is overridable
+# so that control runs in seconds rather than 20 minutes.
+echo "Testing the Go per-package test budget and overrun report"
+bash scripts/go-test-budget_test.sh
 
 echo "Testing build.sh"
 bash build_test.sh


### PR DESCRIPTION
`test.sh:14` ran a bare `go test ./...`, so every test binary inherited Go's default
10-minute per-package timeout — a number nobody chose — and it reached the merge gate:
`build.sh:60` runs `./test.sh`, and the refinery gate defaults to `./build.sh`
(`internal/refinery/merge.go`, no `.pogo/refinery.toml` to override).
`.github/workflows/ci.yml:49` carried the identical bare invocation on slower runners.

## The measurement that changed the shape of the fix

The issue asks for one line, `go test -timeout 40m ./...`, on the premise that setting the
flag makes a slow package "fail cleanly" instead of panicking. **I measured that premise
before writing anything, and it does not hold: `-timeout` IS the panic mechanism.** Go arms
`testing.(*M).startAlarm`; the default 10m and an explicit 20m take the identical path, and
both end in `panic: test timed out after <budget>` followed by the stacks of every goroutine
in the binary.

So the flag alone moves the panic later without changing its shape — and the shape is the
entire complaint in #107. Setting the budget is **necessary but not sufficient**.

This is the one place this PR departs from the approved triage recommendation (mg-d2f0),
which specified a two-line change. The 20m value, the reasoning for it, and the "both call
sites" requirement are all taken from that recommendation unchanged. What is added is the
half that makes the reported outcome a timeout, because the two lines alone do not — and the
mutation control below shows exactly what that world looks like. **Flagging it explicitly
for the design-faithfulness lens.**

## The change

`scripts/go-test-budget.sh` runs `go test` under an explicit budget and then *classifies*
the outcome, emitting at the **tail** of the output — where a reader looks, and what a
truncating CI log keeps — the package that overran, the budget Go actually enforced, the
tests still running when it fired, and the statement that this is an overrun and not a crash.
Anchored on Go's exact timeout-panic text, so an ordinary `panic: runtime error: ...` and a
plain `t.Fatal` are never mislabelled.

`test.sh` and `ci.yml` both route through it: one definition of the budget, one of the report.

**The goroutine dump is kept, deliberately.** Suppressing it is the obvious way to "not be a
panic dump", and it would destroy the only evidence separating the two causes an overrun can
have, which need opposite responses — a genuine deadlock (goroutines parked on
chan/select/mutex, no progress) versus a loaded host (progressing, just not fast enough).
Those are identical in a bare "package X exceeded N minutes" line, and telling them apart is
why the reader is there. It is *labelled*, not removed, and the label is printed last.

## Why 20m

`defaultGateTimeout` is 60m (`internal/refinery/gaterun.go:30` — verified, not inherited),
documented there as roughly twice the longest gate run observed on this fleet (~30m). A 40m
per-package ceiling is larger than the entire observed gate run: one wedged package would
consume two-thirds of the gate budget before reporting anything. 20m surfaces a wedged
package 20 minutes sooner and leaves the 60m gate bound reachable as the outer backstop —
which kills with a diagnostic heartbeat record rather than a panic dump. Keeping the
better-instrumented backstop reachable is choosing a better failure, not merely an earlier one.

**What a normal run measures, and the headroom left for a loaded host.** Too short a budget
converts load into spurious failures, which is precisely the disease mg-6c90 documents (a
fixed CPU floor: 13/13 FAIL at load 52-106, 4/4 PASS at load 4.6-5.3, byte-identical
binaries). Measured on this host:

| package | time | condition |
|---|---|---|
| `internal/agent` | 206.3s | isolated, load ~7.8 |
| `internal/agent` | 216.8s | full 50-package suite, load ~6 |
| `internal/refinery` | 81.2s | isolated, load ~7.8 |
| `internal/refinery` | 155.1s | isolated, load ~32 — **1.9x on load alone** |

20m is **5.5x** the slowest figure measured here and **2.2x** the worst figure #107 reports
(538.9s). The 538.9s/508.8s in the issue were measured under a live agent fleet and were not
reproduced on this box; that corroborates rather than refutes #107, whose own claim is that
runtime scales with contention — the 81.2s→155.1s response measures that directly.

## Verification — both directions observed

### Positive control: a package made to exceed the budget on purpose

Run at `POGO_GO_TEST_TIMEOUT=5s` (the budget is overridable so this control costs seconds
rather than 20 minutes). 80 lines; the first 8 and last 26:

```
Testing Go packages (per-package budget: 5s; override with POGO_GO_TEST_TIMEOUT)
panic: test timed out after 5s
	running tests:
		TestSlowA (5s)

goroutine 3 [running]:
testing.(*M).startAlarm.func1()
	.../src/testing/testing.go:2682 +0x2b0
   ...  [46 lines of goroutine dump] ...

=============================================================================
TIMEOUT: 1 package exceeded the per-package test budget of 5s.

  example.com/multi/slowa
      budget enforced by go: 5s
      still running at the budget: TestSlowA

This is a BUDGET OVERRUN, not a crash. Go implements -timeout by panicking
inside the test binary, so the goroutine dump above IS what a timeout looks
like — it is not a segfault and not a mass regression. Tests that had already
passed inside those binaries were lost with it, so the run is not evidence
about them either way.

The dump is kept, not suppressed: it is the only thing separating the two
causes, which need opposite responses —
  deadlock     goroutines parked on chan/select/mutex with no progress
  loaded host  goroutines progressing, just not fast enough
Check the host load average for the window of the run before reading the
dump as a bug. On this host the same package has measured 81.2s at load ~8
and 155.1s at load ~32 — a 1.9x response to contention alone.

Raise 5s deliberately, not reflexively: the refinery's 60m gate bound
is the outer backstop, and a per-package budget that approaches it stops
leaving room for the better-instrumented failure to happen instead.
=============================================================================
```

It names the package, names the budget, and the last thing the reader is handed is the
classification — not the dump. Exit status is `go test`'s own, unchanged.

### Normal run unaffected

Full `./build.sh`, green end-to-end (`BUILD_EXIT=0`), from this non-ephemeral worktree — a
bare `go test` gives false results in this repo. No package came near the budget, nothing was
reported, and the banner confirms the flag is live:

```
Step 2: Testing...
Testing Go packages (per-package budget: 20m; override with POGO_GO_TEST_TIMEOUT)
...
=== go-test-budget.sh: 23 passed, 0 failed ===
```

Also worth recording, since the triage notes warned about it: `internal/agent`'s
`TestPolecatDoesNotOutlivePogod` — which failed in both bare-`go test` triage runs — **passed
here** through the `./test.sh` envelope. No evidence of a red main branch.

### The controls have teeth (mutation)

An assertion that cannot fail is not a control, so both were shown failing:

| mutation | result |
|---|---|
| classifier's anchor made to never match — i.e. **the `-timeout`-alone world** | 7 assertions fail; output ends in a bare `FAIL` after the dump |
| `test.sh` unwired back to `go test ./...` | the 2 wiring assertions fail |

The first is the important one: it *is* the two-line fix, and it is red.

## The suite

`scripts/go-test-budget_test.sh`, 23 assertions, 12.1s (5s of it deliberate sleeping):
positive control; the report is the tail and the dump is still present; **negative controls**
(a nil-deref panic and a `t.Fatal` in the same run are not called timeouts — without these, a
classifier that shouted TIMEOUT at every failure would pass); the configured budget is the
one Go reports (proving the flag is not silently dropped); the 20m default; a caller-supplied
`-timeout` refused; and wiring assertions pinned against the **real** `test.sh` and `ci.yml`,
so the fix cannot be silently unwired later.

It adopts the packaged test isolation (`scripts/pogo-sandbox`), which the repo's own
`TestEveryTestSuiteRoutesThroughTheIsolation` ratchet correctly caught me not doing on the
first gate run. No ledger line was added — the ledger only shrinks.

## Noted, deliberately not folded in

- `scripts/upgrade-smoke.sh:348` runs `go test ./internal/agent -run ... ` with **no
  timeout** — a third unbounded site the issue does not name. It is not on the merge-gate
  path and targets a single test, so I left it alone rather than widen scope. The CI/test.sh
  wiring assertions are scoped to the merge-gate path for the same reason. Flagging it for a
  separate ticket if wanted.
- The two slow packages are still slow. A ceiling buys headroom; it does not make an
  8-minute package fast. Explicitly out of scope per the ticket — that is a different ticket,
  and it will be a different package tomorrow.

Refs drellem2/pogo#107
Resolves drellem2/pogo#107
Closing-ref-ack: drellem2/pogo#107 — this PR is the approved fix for that issue, so closing it on merge is intended.

Approved triage recommendation: mg-d2f0 (successor item mg-a465; pm-pogo signed off on the verdict, the 20m value and the ci.yml inclusion; Daniel gave the go/no-go)
Work item: mg-a465
