### PR TITLE
check-mailloops must disclose who was not judged on ALL THREE render branches, with the unjudged set in the JSON

### DIFF
--- a/changelog.d/mg-0db1.fixed.md
+++ b/changelog.d/mg-0db1.fixed.md
@@ -1,0 +1,53 @@
+- **`pogo check-mailloops` names WHO it did not judge on every render branch,
+  and the JSON carries the same set with a reason (mg-0db1,
+  Refs drellem2/pogo#127).** On the reporting host the command judged 2 of 6
+  agents and printed `All 2 judged agent(s) have a mail-check schedule. (6 in
+  the registry.)` at exit 0. Four of six were not judged; the output named
+  neither which four nor why, and `--json` carried only `scanned` and `judged`.
+  Reproduced live during triage at 5 of 12.
+
+  **This was an inconsistency inside one command, not a missing feature.**
+  `MailLoopReport.Render` had three branches and only the GREEN one omitted the
+  who-was-not-judged disclosure: the `Judged == 0` branch states it in full, and
+  the RED branch carried half of it (`Judged N of S`, a count with no way to
+  turn it into names). Three in-tree precedents already do this correctly —
+  `ackwatch.Report.renderCoverage`, `deafwatch.renderBody`, and the shipped
+  `unjudged` JSON field in `internal/staleness/prompts.go` — so the fix applies
+  an established convention rather than inventing one.
+
+  All three branches now end in a single `renderCoverage`, which is the point:
+  the smaller diff would have been to patch the green branch, and that leaves
+  three branches free to diverge again. The RED branch's bare count is fixed as
+  a side effect.
+
+  **The unjudged set rides on the report, so the JSON says what the text says.**
+  Each entry carries name, type, and a machine-stable reason from the coarse set
+  `polecat` / `not_running` / `not_configured`. That set is deliberately coarser
+  than the three categories `--help` lists: `IsConfiguredAgent` returns false
+  BOTH for an unreadable prompt tree and for a genuinely unconfigured agent, so
+  the finer taxonomy is not computable today, and emitting a reason the code
+  cannot back would be this issue's own failure mode one level in. The `--help`
+  text now says so. The collapse itself is a separate defect, filed separately.
+  The reason and the judgeability predicate are one function
+  (`mailLoopExclusionFor`, which `mailLoopJudgeable` is now defined in terms of),
+  so the roster cannot name a reason the predicate would not give.
+
+  **Absent and empty are distinguishable on the wire, and absent renders
+  UNKNOWN — never zero.** `internal/client` plain-decodes this struct with no
+  version negotiation, so a pogod older than the client simply does not send the
+  new field. A plain slice would have flattened that into a confident "0 not
+  judged" — this issue's exact defect, green, inside its own fix, on the fleet
+  that filed it. Not hypothetical: the running pogod was ~93 commits behind main
+  when this was written, so the skew case was the CURRENT state. `Unjudged` is
+  therefore a pointer with no `omitempty`: a report that judged everything puts
+  `"unjudged": []` on the wire, and an absent field renders the count (derivable
+  from `scanned - judged`, which every version sends) with WHO and WHY stated as
+  unknown. `TestMailLoopReport_AbsentUnjudgedSetRendersUnknownNotZero` decodes a
+  payload with the field absent and asserts the render does not claim full
+  coverage.
+
+  **Exit status does not move.** `Actionable() = len(Missing) > 0` is unchanged.
+  Everything in the unjudged set is excluded on purpose — mg-738f drew that
+  boundary and the cry-wolf guarantee rests on it — so firing on it would make
+  the exit status useless. This changed what the command DISCLOSES, not what it
+  judges; recorded here and at the predicate rather than left as a silence.

--- a/cmd/pogo/main.go
+++ b/cmd/pogo/main.go
@@ -1455,9 +1455,21 @@ WHO IS NOT JUDGED, deliberately:
   unreadable prompts  if the prompt tree cannot be read the agent cannot be
                       classified, and a false RED costs more than silence.
 
-Those exclusions mean a small "judged" count is normal. A report that judged
+Those exclusions mean a small "judged" count is normal. Every report NAMES the
+agents it did not judge, whatever the verdict — a clean bill of health over 2 of
+6 agents is a statement about 2 agents, and it says so. A report that judged
 NOTHING says so in as many words rather than printing an all-clear, and a pogod
 with no basis to judge at all is an ERROR here, not an empty list.
+
+The machine-readable reason in --json is coarser than the three categories
+above: it is one of "polecat", "not_running", "not_configured", and the last of
+those covers an unreadable prompt tree as well, because agent.IsConfiguredAgent
+cannot currently tell the two apart. That collapse is tracked separately. The
+reason set is deliberately not more precise than the code can back.
+
+Against a pogod older than this client the unjudged set is absent from the wire
+entirely. That is reported as UNKNOWN — never as zero — because "the daemon did
+not say" and "nobody was excluded" are opposite statements.
 
 REPORTS ONLY — it never registers a schedule, nudges, or restarts. Re-registering
 the loop on the agent's behalf would hide WHY it vanished, and that is the part

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -843,17 +843,43 @@ func mailLoopFor(a *Agent, p MailCheckProvider) mailLoopState {
 //   - ANYTHING DIAGNOSE IS NEVER RUN AGAINST. This check is only as loud as its
 //     caller: a diagnose field helps someone already running diagnose. It is
 //     detection, not an alarm.
-func mailLoopJudgeable(a *Agent) bool {
+func mailLoopJudgeable(a *Agent) bool { return mailLoopExclusionFor(a) == "" }
+
+// mailLoopExclusionFor is mailLoopJudgeable's answer with its REASON attached:
+// it returns the reason a is not judged, or "" when a is judged.
+//
+// The predicate and the reason are one function on purpose. A report that names
+// who was excluded has to say why, and a second function computing "why" would
+// be free to disagree with the one computing "whether" — the same drift
+// mailLoopFor exists to prevent one level down (mg-0db1).
+//
+// The reason set is deliberately COARSER than the three categories the doc
+// comment above and `pogo check-mailloops --help` name. IsConfiguredAgent
+// (autostart.go:198-217) returns false BOTH for an unreadable prompt tree and
+// for a genuinely unconfigured agent, so "unreadable prompt tree" is not
+// computable here today; emitting it anyway would be this reader's own failure
+// mode — a disclosure the code cannot back — one level in. That collapse is a
+// real defect and is filed separately; it is not fixed here.
+func mailLoopExclusionFor(a *Agent) MailLoopExclusionReason {
+	if a == nil {
+		return ExclusionNotConfigured
+	}
 	if IsExpectedAgent(a.Name) {
-		return true
+		return ""
 	}
 	// A polecat can never reach the configured branch (it has no prompt), but
 	// say so explicitly rather than resting on that: the exclusion is a decision,
 	// not an accident of naming.
 	if a.Type == TypePolecat {
-		return false
+		return ExclusionPolecat
 	}
-	return a.Alive() && IsConfiguredAgent(a.Name)
+	if !a.Alive() {
+		return ExclusionNotRunning
+	}
+	if !IsConfiguredAgent(a.Name) {
+		return ExclusionNotConfigured
+	}
+	return ""
 }
 
 // NudgeAPIResponse is returned for wait-idle nudges to report delivery status.

--- a/internal/agent/mailloop_report.go
+++ b/internal/agent/mailloop_report.go
@@ -38,22 +38,87 @@ type MailLoopFinding struct {
 	Alive bool `json:"alive"`
 }
 
+// MailLoopExclusionReason names WHY an agent was not judged.
+//
+// The set is deliberately COARSER than the three categories
+// `pogo check-mailloops --help` lists, because IsConfiguredAgent cannot today
+// separate an unreadable prompt tree from a genuinely unconfigured agent — see
+// mailLoopExclusionFor, which is the one place the reason is computed. Emitting
+// a reason the code cannot back would be this command's own defect one level
+// in: a disclosure that sounds precise and is not.
+type MailLoopExclusionReason string
+
+const (
+	// ExclusionPolecat: polecats register their own loop at spawn (mg-e633)
+	// with their own escalation path on failure (mg-6fe0).
+	ExclusionPolecat MailLoopExclusionReason = "polecat"
+	// ExclusionNotRunning: a configured agent that is not running is owed
+	// nothing — "not there" is not a fault.
+	ExclusionNotRunning MailLoopExclusionReason = "not_running"
+	// ExclusionNotConfigured: no readable prompt-tree configuration. This
+	// COLLAPSES "unreadable prompt tree" with "not configured"; the collapse is
+	// a separate defect in IsConfiguredAgent, filed on its own.
+	ExclusionNotConfigured MailLoopExclusionReason = "not_configured"
+)
+
+// Describe renders the reason as the phrase an operator reads. An unrecognised
+// reason renders verbatim rather than as a blank: a newer pogod naming a
+// category this binary does not know must not read as no reason at all.
+func (r MailLoopExclusionReason) Describe() string {
+	switch r {
+	case ExclusionPolecat:
+		return "registers its own mail loop at spawn"
+	case ExclusionNotRunning:
+		return "not running"
+	case ExclusionNotConfigured:
+		return "not configured, or its prompt tree could not be read"
+	case "":
+		return "reason not reported"
+	}
+	return string(r)
+}
+
+// MailLoopExclusion names one agent the report did NOT judge, and why. It is
+// not a finding: nothing here is wrong, and nothing here is an all-clear
+// either. It is the census line that turns "judged 2 of 6" from a number into
+// a statement (mg-0db1).
+type MailLoopExclusion struct {
+	Name   string                  `json:"name"`
+	Type   AgentType               `json:"type"`
+	Reason MailLoopExclusionReason `json:"reason"`
+}
+
 // MailLoopReport is one reading of the fleet's mail-delivery paths: every agent
 // diagnose has standing to judge, and which of them have no way to be woken.
 //
 // Scanned counts every agent in the registry; Judged counts the subset
 // mailLoopJudgeable admits (see its doc comment for who is deliberately NOT
 // judged — polecats, configured-but-not-running agents, and anything with an
-// unreadable prompt tree). Missing is the RED set, sorted by name.
+// unreadable prompt tree). Missing is the RED set, sorted by name; Unjudged is
+// the complement of Judged, also sorted by name.
 //
 // Judged is load-bearing for any consumer that wants to alert: an empty Missing
 // with Judged == 0 means nothing was judged, which is not the same statement as
 // a clean fleet.
+//
+// # Why Unjudged is a POINTER
+//
+// ABSENT and EMPTY must be distinguishable on the wire, and they mean opposite
+// things: an empty list is "every agent was judged", an absent one is "this
+// daemon does not report the set at all". internal/client plain-decodes this
+// struct with no version negotiation, so a plain slice would flatten a pogod
+// too old to send the field into a confident "0 not judged" — this issue's
+// exact defect, reproduced inside its own fix, green, on the fleet that filed
+// it. That is not hypothetical: when this shipped the running pogod was ~93
+// commits behind main. The pointer makes "unknown" unsayable as zero, and the
+// tag carries no `omitempty` so a report that judged everything still puts
+// `"unjudged": []` on the wire (the shape internal/staleness already ships).
 type MailLoopReport struct {
-	Now     time.Time         `json:"now"`
-	Scanned int               `json:"scanned"`
-	Judged  int               `json:"judged"`
-	Missing []MailLoopFinding `json:"missing,omitempty"`
+	Now      time.Time            `json:"now"`
+	Scanned  int                  `json:"scanned"`
+	Judged   int                  `json:"judged"`
+	Missing  []MailLoopFinding    `json:"missing,omitempty"`
+	Unjudged *[]MailLoopExclusion `json:"unjudged"`
 }
 
 // MailLoopReport enumerates the registry and applies diagnose's OWN mail-loop
@@ -87,6 +152,10 @@ func (r *Registry) MailLoopReport() (MailLoopReport, error) {
 	}
 
 	rep := MailLoopReport{Now: time.Now()}
+	// Non-nil from the first line, so a report that judged everything still
+	// serialises `"unjudged": []` — the wire signal that this daemon DOES
+	// report the set and found it empty. See the struct's doc comment.
+	unjudged := []MailLoopExclusion{}
 	for _, a := range r.List() {
 		rep.Scanned++
 		switch mailLoopFor(a, provider) {
@@ -101,9 +170,20 @@ func (r *Registry) MailLoopReport() (MailLoopReport, error) {
 				Status:   a.Status,
 				Alive:    a.Alive(),
 			})
+		default:
+			// mailLoopUnknown. The reason comes from mailLoopExclusionFor —
+			// the same function mailLoopJudgeable is defined in terms of — so
+			// the roster cannot name a reason the predicate would not give.
+			unjudged = append(unjudged, MailLoopExclusion{
+				Name:   a.Name,
+				Type:   a.Type,
+				Reason: mailLoopExclusionFor(a),
+			})
 		}
 	}
 	sort.Slice(rep.Missing, func(i, j int) bool { return rep.Missing[i].Name < rep.Missing[j].Name })
+	sort.Slice(unjudged, func(i, j int) bool { return unjudged[i].Name < unjudged[j].Name })
+	rep.Unjudged = &unjudged
 	return rep, nil
 }
 
@@ -113,6 +193,11 @@ func (r *Registry) MailLoopReport() (MailLoopReport, error) {
 //
 // A report that judged nothing says so in as many words rather than printing
 // the same reassuring line a clean fleet prints.
+//
+// ALL THREE branches end in renderCoverage. The green branch used to be the
+// only one that omitted who-was-not-judged, which is the defect
+// drellem2/pogo#127 reported; routing every branch through one renderer is what
+// makes them structurally incapable of diverging again (mg-0db1).
 func (rep MailLoopReport) Render() string {
 	var b strings.Builder
 	if len(rep.Missing) == 0 {
@@ -120,10 +205,12 @@ func (rep MailLoopReport) Render() string {
 			fmt.Fprintf(&b, "NOTHING JUDGED: %d agent(s) in the registry, none of them judgeable.\n", rep.Scanned)
 			b.WriteString("This is not an all-clear. Polecats, configured-but-stopped agents, and\n")
 			b.WriteString("agents whose prompt tree could not be read are deliberately not judged.\n")
+			rep.renderCoverage(&b)
 			return b.String()
 		}
 		fmt.Fprintf(&b, "All %d judged agent(s) have a mail-check schedule. (%d in the registry.)\n",
 			rep.Judged, rep.Scanned)
+		rep.renderCoverage(&b)
 		return b.String()
 	}
 	fmt.Fprintf(&b, "%d agent(s) have NO mail-check schedule — they can be mailed, and nothing\n"+
@@ -136,6 +223,7 @@ func (rep MailLoopReport) Render() string {
 		fmt.Fprintf(&b, "  %-20s %-8s %s\n", m.Name, m.Type, live)
 	}
 	fmt.Fprintf(&b, "\nJudged %d of %d agents in the registry.\n", rep.Judged, rep.Scanned)
+	rep.renderCoverage(&b)
 	b.WriteString("\nConfirm one:\n")
 	for _, m := range rep.Missing {
 		fmt.Fprintf(&b, "  pogo agent diagnose %s\n", m.Name)
@@ -149,8 +237,54 @@ func (rep MailLoopReport) Render() string {
 	return b.String()
 }
 
+// renderCoverage states WHO was not judged and WHY. Every Render branch calls
+// it, including the green one — a verdict delivered over a subset of the fleet
+// has to name the subset, or "judged 2 of 6, all fine" reads as "the fleet is
+// fine" (drellem2/pogo#127).
+//
+// It has two modes, and the difference between them is the whole point:
+//
+//   - Unjudged SUPPLIED — name every excluded agent and its reason. An empty
+//     supplied list means genuinely nobody was excluded, so there is nothing to
+//     print.
+//   - Unjudged ABSENT — the daemon is older than this binary and does not
+//     report the set. The COUNT is still honest, because Scanned and Judged are
+//     fields every version sends and the count falls out of arithmetic; WHO and
+//     WHY are UNKNOWN and are printed as unknown. This branch must never print
+//     zero: "the daemon did not tell me" and "nobody was excluded" are opposite
+//     statements, and collapsing them is the defect this command was filed for.
+func (rep MailLoopReport) renderCoverage(b *strings.Builder) {
+	if rep.Unjudged == nil {
+		n := rep.Scanned - rep.Judged
+		if n <= 0 {
+			// Every scanned agent was judged — derivable without the field, so
+			// this is a real all-clear on coverage rather than an assumed one.
+			return
+		}
+		fmt.Fprintf(b, "\nNot judged: %d of %d — WHO and WHY are UNKNOWN. This pogod is older than the\n"+
+			"client and does not report the unjudged set, so the verdict above covers %d of\n"+
+			"%d agents and cannot say which. Upgrade pogod, or ask one at a time with\n"+
+			"`pogo agent diagnose <name>`.\n", n, rep.Scanned, rep.Judged, rep.Scanned)
+		return
+	}
+	if len(*rep.Unjudged) == 0 {
+		return
+	}
+	fmt.Fprintf(b, "\nNot judged: %d of %d. This is not a verdict on them — it is who the verdict\n"+
+		"above does NOT cover:\n", len(*rep.Unjudged), rep.Scanned)
+	for _, u := range *rep.Unjudged {
+		fmt.Fprintf(b, "  %-20s %-8s %s\n", u.Name, u.Type, u.Reason.Describe())
+	}
+}
+
 // Actionable reports whether the report found anything worth acting on. It is
 // the CLI's exit-status predicate.
+//
+// The unjudged set deliberately does NOT move it. Everything in that set is
+// excluded on purpose (mg-738f drew the boundary and the cry-wolf guarantee
+// rests on it), so exiting non-zero because a polecat exists would make the
+// command's exit status useless. mg-0db1 changed what the command DISCLOSES,
+// not what it judges — recorded here rather than left as a silence.
 func (rep MailLoopReport) Actionable() bool { return len(rep.Missing) > 0 }
 
 // handleMailLoops serves GET /agents/mail-loops: the FLEET-WIDE read of the

--- a/internal/agent/mailloop_report_test.go
+++ b/internal/agent/mailloop_report_test.go
@@ -180,6 +180,211 @@ func TestMailLoopReport_RenderNamesTheAgent(t *testing.T) {
 	}
 }
 
+// TestMailLoopReport_GreenPathNamesWhoItDidNotJudge is drellem2/pogo#127's
+// acceptance: the all-clear branch was the ONLY one that omitted the
+// who-was-not-judged disclosure the other two carry, so a verdict over 2 of 6
+// agents read as a verdict over the fleet.
+//
+// It also pins the reason taxonomy end to end. All three reasons are staged in
+// one registry deliberately: the reasons come from mailLoopExclusionFor, which
+// is the same function mailLoopJudgeable is defined in terms of, and a roster
+// naming a reason the predicate would not give is this issue one level in.
+func TestMailLoopReport_GreenPathNamesWhoItDidNotJudge(t *testing.T) {
+	sandboxDesiredState(t, "pm-pogo", true)
+	now := time.Now()
+
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	// Judged and fine — the one agent the all-clear is actually about.
+	reg.agents["pm-pogo"] = mailLoopCrewAgent("pm-pogo", now)
+	// A running polecat: owns its own registration path (mg-e633).
+	cat := mailLoopCrewAgent("cat-032b", now)
+	cat.Type = TypePolecat
+	cat.PID = liveProcess(t)
+	reg.agents["cat-032b"] = cat
+	// A configured agent that is not running.
+	off := mailLoopCrewAgent("doctor", now)
+	off.PID = deadProcess(t)
+	reg.agents["doctor"] = off
+	// Alive, but this machine has no prompt for it.
+	ghost := mailLoopCrewAgent("ghost", now)
+	ghost.PID = liveProcess(t)
+	reg.agents["ghost"] = ghost
+
+	reg.SetMailCheckProvider(fakeMailChecks{have: map[string]bool{"crew-pm-pogo": true}})
+
+	rep, err := reg.MailLoopReport()
+	if err != nil {
+		t.Fatalf("MailLoopReport: %v", err)
+	}
+	if len(rep.Missing) != 0 || rep.Judged != 1 || rep.Scanned != 4 {
+		t.Fatalf("want the GREEN branch over 1 of 4; got Missing=%+v Judged=%d Scanned=%d",
+			rep.Missing, rep.Judged, rep.Scanned)
+	}
+	if rep.Unjudged == nil {
+		t.Fatal("Unjudged = nil from a registry that computed the set; absent means 'this daemon does not report it'")
+	}
+	want := []MailLoopExclusion{
+		{Name: "cat-032b", Type: TypePolecat, Reason: ExclusionPolecat},
+		{Name: "doctor", Type: TypeCrew, Reason: ExclusionNotRunning},
+		{Name: "ghost", Type: TypeCrew, Reason: ExclusionNotConfigured},
+	}
+	if len(*rep.Unjudged) != len(want) {
+		t.Fatalf("Unjudged = %+v, want %+v", *rep.Unjudged, want)
+	}
+	for i, w := range want {
+		if got := (*rep.Unjudged)[i]; got != w {
+			t.Errorf("Unjudged[%d] = %+v, want %+v", i, got, w)
+		}
+	}
+
+	// The TEXT is the half the issue was filed about.
+	out := rep.Render()
+	if !strings.Contains(out, "All 1 judged agent(s)") {
+		t.Errorf("the all-clear line is gone:\n%s", out)
+	}
+	for _, w := range []string{"Not judged: 3 of 4", "cat-032b", "doctor", "ghost",
+		"registers its own mail loop at spawn", "not running", "not configured"} {
+		if !strings.Contains(out, w) {
+			t.Errorf("Render() missing %q — an all-clear over 1 of 4 must name the other 3:\n%s", w, out)
+		}
+	}
+
+	// And the JSON must say what the text says; a machine reader that gets
+	// strictly less than the operator is the same defect wearing a different hat.
+	blob, err := json.Marshal(rep)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, w := range []string{`"unjudged"`, `"cat-032b"`, `"not_running"`, `"not_configured"`, `"polecat"`} {
+		if !strings.Contains(string(blob), w) {
+			t.Errorf("JSON missing %s:\n%s", w, blob)
+		}
+	}
+
+	// Exit status does NOT move on the unjudged set. Everything in it is
+	// excluded on purpose; firing on it would be the cry-wolf mg-738f's
+	// boundary exists to prevent (mg-0db1, recorded so it is not reopened).
+	if rep.Actionable() {
+		t.Error("Actionable() = true with an empty Missing — the unjudged set must not move exit status")
+	}
+}
+
+// TestMailLoopReport_RedPathNamesWhoItDidNotJudge covers the second branch the
+// shared renderer fixed. The RED path printed "Judged N of S" and stopped: a
+// count, with no way to turn it into names. The issue named the green branch;
+// routing all three through one renderer fixed this one too.
+func TestMailLoopReport_RedPathNamesWhoItDidNotJudge(t *testing.T) {
+	sandboxDesiredState(t, "pm-pogo", true)
+	now := time.Now()
+
+	reg, err := NewRegistry(shortSocketDir(t))
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	reg.agents["pm-pogo"] = mailLoopCrewAgent("pm-pogo", now)
+	cat := mailLoopCrewAgent("cat-032b", now)
+	cat.Type = TypePolecat
+	cat.PID = liveProcess(t)
+	reg.agents["cat-032b"] = cat
+
+	// pm-pogo's loop was reaped: the RED branch.
+	reg.SetMailCheckProvider(fakeMailChecks{have: map[string]bool{}})
+
+	rep, err := reg.MailLoopReport()
+	if err != nil {
+		t.Fatalf("MailLoopReport: %v", err)
+	}
+	if len(rep.Missing) != 1 {
+		t.Fatalf("want the RED branch; Missing = %+v", rep.Missing)
+	}
+	out := rep.Render()
+	for _, w := range []string{"NO mail-check schedule", "Not judged: 1 of 2", "cat-032b",
+		"registers its own mail loop at spawn"} {
+		if !strings.Contains(out, w) {
+			t.Errorf("Render() missing %q on the RED branch:\n%s", w, out)
+		}
+	}
+}
+
+// TestMailLoopReport_AbsentUnjudgedSetRendersUnknownNotZero is the version-skew
+// guard, and it is the whole reason Unjudged is a pointer.
+//
+// internal/client plain-decodes this struct off the wire with no version
+// negotiation, so a pogod older than the client simply does not send the field.
+// If absent flattened to empty, the fix would print a confident "0 not judged"
+// over a fleet it judged 2 of 6 of — this issue's exact defect, green, inside
+// its own fix. That is not a hypothetical: when this shipped, the running pogod
+// was ~93 commits behind main, so the skew case WAS the current state.
+func TestMailLoopReport_AbsentUnjudgedSetRendersUnknownNotZero(t *testing.T) {
+	// Exactly what an older pogod puts on the wire: no `unjudged` key at all.
+	const oldDaemon = `{"now":"2026-08-07T20:00:00Z","scanned":6,"judged":2}`
+
+	var rep MailLoopReport
+	if err := json.Unmarshal([]byte(oldDaemon), &rep); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if rep.Unjudged != nil {
+		t.Fatalf("Unjudged = %+v after decoding a payload that never mentioned it; absent must stay absent", *rep.Unjudged)
+	}
+
+	out := rep.Render()
+	if !strings.Contains(out, "UNKNOWN") {
+		t.Errorf("Render() over an absent unjudged set must say UNKNOWN:\n%s", out)
+	}
+	if !strings.Contains(out, "4 of 6") {
+		t.Errorf("Render() must still state the COUNT — it is derivable from scanned/judged, which every version sends:\n%s", out)
+	}
+	for _, forbidden := range []string{"Not judged: 0", "0 of 6"} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("Render() claimed %q over a daemon that reported nothing — 'not told' is not 'nobody':\n%s", forbidden, out)
+		}
+	}
+
+	// The positive control: the SAME counts, with the field present and empty,
+	// is a genuine full-coverage report and must not print the unknown notice.
+	var full MailLoopReport
+	if err := json.Unmarshal([]byte(`{"scanned":2,"judged":2,"unjudged":[]}`), &full); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if full.Unjudged == nil {
+		t.Fatal("`\"unjudged\": []` decoded to absent — absent and empty must be distinguishable on the wire")
+	}
+	if got := full.Render(); strings.Contains(got, "Not judged") || strings.Contains(got, "UNKNOWN") {
+		t.Errorf("a report that judged everything must not print a coverage caveat:\n%s", got)
+	}
+
+	// And the wire itself must carry the distinction, or no decoder can.
+	empty, err := json.Marshal(MailLoopReport{Scanned: 2, Judged: 2, Unjudged: &[]MailLoopExclusion{}})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(empty), `"unjudged":[]`) {
+		t.Errorf("an empty unjudged set must serialise as [] rather than being omitted:\n%s", empty)
+	}
+	absent, err := json.Marshal(MailLoopReport{Scanned: 2, Judged: 2})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(absent), `"unjudged":[]`) {
+		t.Errorf("an unreported unjudged set must not serialise as an empty one:\n%s", absent)
+	}
+}
+
+// TestMailLoopExclusionReason_DescribeKeepsAnUnknownReasonLegible guards the
+// other direction of skew: a NEWER pogod naming a category this binary does not
+// know must render as that category, not as a blank where a reason should be.
+func TestMailLoopExclusionReason_DescribeKeepsAnUnknownReasonLegible(t *testing.T) {
+	if got := MailLoopExclusionReason("prompt_unreadable").Describe(); !strings.Contains(got, "prompt_unreadable") {
+		t.Errorf("Describe() of an unknown reason = %q; it must render the reason verbatim", got)
+	}
+	if got := MailLoopExclusionReason("").Describe(); got == "" {
+		t.Error("Describe() of an empty reason = \"\"; a missing reason must read as missing, not as absent text")
+	}
+}
+
 // TestHandleMailLoops_ServesTheFleetRead covers the HTTP surface `pogo
 // check-mailloops` reads, including the 503: pogod answering "I cannot judge"
 // must not be decodable as an empty finding list.
@@ -210,5 +415,11 @@ func TestHandleMailLoops_ServesTheFleetRead(t *testing.T) {
 	}
 	if len(got.Missing) != 1 || got.Missing[0].Name != "pm-pogo" {
 		t.Errorf("Missing = %+v, want [pm-pogo]", got.Missing)
+	}
+	// The endpoint must SAY it reports the unjudged set, even when the set is
+	// empty — that is the signal a client uses to tell this daemon apart from
+	// one too old to have the field at all.
+	if got.Unjudged == nil {
+		t.Error("decoded Unjudged = nil; the endpoint must put `\"unjudged\": []` on the wire rather than omitting it")
 	}
 }


### PR DESCRIPTION
`pogo check-mailloops` printed an all-clear over a SUBSET of the fleet without naming the subset or the reason. Reproduced live during triage: it judged 5 of 12 agents and printed `All 5 judged agent(s) have a mail-check schedule. (12 in the registry.)` at exit 0, with the 7 unjudged agents named nowhere, and `--json` carrying only `scanned` and `judged`.

Refs drellem2/pogo#127

## What changed

**All three render branches now end in one shared `renderCoverage`.** `MailLoopReport.Render` had three branches and only the GREEN one omitted the who-was-not-judged disclosure — the `Judged == 0` branch states it in full, and the RED branch carried half of it (`Judged N of S`, a count with no way to turn it into names). Patching only the green branch was the smaller diff and would have left three branches free to diverge again; the RED branch's bare count is fixed as a side effect. This mirrors `internal/ackwatch/ackwatch.go` `renderCoverage`, which already does exactly this on its non-actionable path.

**The unjudged set rides on `MailLoopReport`, so the JSON says what the text says.** Each entry carries name, type, and a machine-stable reason. The field name and no-`omitempty` shape follow the precedent already shipped at `internal/staleness/prompts.go:346`.

```
All 1 judged agent(s) have a mail-check schedule. (4 in the registry.)

Not judged: 3 of 4. This is not a verdict on them — it is who the verdict
above does NOT cover:
  cat-032b             polecat  registers its own mail loop at spawn
  doctor               crew     not running
  ghost                crew     not configured, or its prompt tree could not be read
```

**The reason taxonomy is the coarse-but-true set** `polecat` / `not_running` / `not_configured`. It is deliberately coarser than the three categories `--help` lists: `IsConfiguredAgent` returns false BOTH for an unreadable prompt tree and for a genuinely unconfigured agent, so the finer taxonomy is not computable today, and emitting a reason the code cannot back would be this issue's own failure mode one level in. `--help` now says so out loud. That collapse is a real defect and is filed separately — it is not fixed here.

The reason and the judgeability predicate are **one function**: `mailLoopJudgeable` is now defined as `mailLoopExclusionFor(a) == ""`. A second function computing "why" would be free to disagree with the one computing "whether" — the same drift `mailLoopFor` exists to prevent one level down.

## The version-skew guard (hard requirement)

**Absent and empty are distinguishable on the wire, and an absent field renders UNKNOWN — never 0.**

`internal/client/agent.go` plain-decodes this struct with no version negotiation, so a pogod older than the client simply does not send the new field. A plain slice would have flattened that into a confident "0 not judged" — this issue's exact defect, green, inside its own fix, on the fleet that filed it. That is the CURRENT state, not an edge case: the running pogod is ~93 commits behind main as of this PR.

Mechanism chosen: `Unjudged *[]MailLoopExclusion` with tag `json:"unjudged"` and **no** `omitempty`.

| wire | meaning | render |
|---|---|---|
| `"unjudged": [...]` | daemon reports the set | names every excluded agent and its reason |
| `"unjudged": []` | daemon reports the set, and it is empty | no caveat — genuine full coverage |
| field absent / `null` | daemon does not report the set | count from `scanned - judged` (fields every version sends), WHO and WHY stated as **UNKNOWN** |

```
All 2 judged agent(s) have a mail-check schedule. (6 in the registry.)

Not judged: 4 of 6 — WHO and WHY are UNKNOWN. This pogod is older than the
client and does not report the unjudged set, so the verdict above covers 2 of
6 agents and cannot say which. Upgrade pogod, or ask one at a time with
`pogo agent diagnose <name>`.
```

`TestMailLoopReport_AbsentUnjudgedSetRendersUnknownNotZero` is the guard: it decodes `{"now":...,"scanned":6,"judged":2}` — a payload that never mentions the field — and asserts the render says UNKNOWN, states the count `4 of 6`, and contains neither `Not judged: 0` nor `0 of 6`. It carries a positive control (same shape with `"unjudged": []` prints no caveat) and asserts the wire distinction in both directions.

## Explicit decision: exit status does NOT move

`Actionable() = len(Missing) > 0` is **unchanged**. Everything in the unjudged set is excluded on purpose — mg-738f drew that boundary and the cry-wolf guarantee rests on it — so firing on it would make the exit status useless. This changed what the command DISCLOSES, not what it judges. Recorded here and in a doc comment at the predicate rather than left as a silence, so it is not reopened. A test asserts it directly.

## Out of scope, deliberately

- **Issue item 3** (informational coverage for the excluded set) — changes what is COMPUTED rather than what is DISCLOSED; filed separately.
- **The `IsConfiguredAgent` collapsed-error defect** — filed separately; this PR discloses the collapse rather than papering over it.
- **`internal/deafwatch`'s announcement body** — a different surface with its own snapshot type; untouched.

## Tests

- `TestMailLoopReport_GreenPathNamesWhoItDidNotJudge` — the filed defect, plus all three reasons end to end, plus the JSON, plus the exit-status non-change.
- `TestMailLoopReport_RedPathNamesWhoItDidNotJudge` — the second branch the shared renderer fixed.
- `TestMailLoopReport_AbsentUnjudgedSetRendersUnknownNotZero` — the mandatory skew guard.
- `TestMailLoopExclusionReason_DescribeKeepsAnUnknownReasonLegible` — the other skew direction: a newer pogod's unknown reason renders verbatim, not blank.
- `TestHandleMailLoops_ServesTheFleetRead` gains an assertion that the endpoint puts `"unjudged": []` on the wire rather than omitting it.
- `TestMailLoopReport_InheritsDiagnoseExclusions` still passes on the literal `NOTHING JUDGED` — the shared renderer did not displace it.

Verified with a **cold** cache (`go clean -testcache && ./build.sh`) — exit 0, on `main` at 3fbf303 (mg-6a0b merged, `internal/agent` green).

Approved triage recommendation: mg-e605 (`json triage-packet` block + the "2026-08-07 pm-pogo RULINGS" section)
Work item: mg-0db1
